### PR TITLE
Add user account management features to the JSON API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    better_together (0.1.0)
+    better_together (0.2.1)
       devise
       devise-jwt
       friendly_id (>= 5.2, < 5.5)

--- a/app/concerns/better_together/devise_user.rb
+++ b/app/concerns/better_together/devise_user.rb
@@ -14,6 +14,8 @@ module BetterTogether
         opts[:confirmation_url] ||= BetterTogether.default_user_confirmation_url
         opts[:confirmation_url] += "?confirmation_token=#{@raw_confirmation_token}"
 
+        opts[:person_name] = person&.name || unconfirmed_email
+
         send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
       end
 

--- a/app/concerns/better_together/devise_user.rb
+++ b/app/concerns/better_together/devise_user.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  # Represents a devise-powered user model 
+  module DeviseUser
+    extend ActiveSupport::Concern
+
+    included do
+      # override devise method to include additional info as opts hash
+      def send_confirmation_instructions(opts = {})
+        generate_confirmation_token! unless @raw_confirmation_token
+
+        # fall back to "default" config name
+        opts[:client_config] ||= 'default'
+        opts[:to] = unconfirmed_email if pending_reconfirmation?
+        opts[:redirect_url] ||= BetterTogether.default_user_confirm_success_url
+
+        send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
+      end
+
+      # override devise method to include additional info as opts hash
+      def send_reset_password_instructions(opts = {})
+        token = set_reset_password_token
+
+        # fall back to "default" config name
+        opts[:client_config] ||= 'default'
+
+        send_devise_notification(:reset_password_instructions, token, opts)
+        token
+      end
+    end
+  end
+end

--- a/app/concerns/better_together/devise_user.rb
+++ b/app/concerns/better_together/devise_user.rb
@@ -11,7 +11,8 @@ module BetterTogether
         generate_confirmation_token! unless @raw_confirmation_token
 
         opts[:to] = unconfirmed_email if pending_reconfirmation?
-        opts[:redirect_url] ||= BetterTogether.default_user_confirm_success_url
+        opts[:confirmation_url] ||= BetterTogether.default_user_confirmation_url
+        opts[:confirmation_url] += "?confirmation_token=#{@raw_confirmation_token}"
 
         send_devise_notification(:confirmation_instructions, @raw_confirmation_token, opts)
       end

--- a/app/concerns/better_together/devise_user.rb
+++ b/app/concerns/better_together/devise_user.rb
@@ -20,9 +20,6 @@ module BetterTogether
       def send_reset_password_instructions(opts = {})
         token = set_reset_password_token
 
-        # fall back to "default" config name
-        opts[:client_config] ||= 'default'
-
         send_devise_notification(:reset_password_instructions, token, opts)
         token
       end

--- a/app/concerns/better_together/devise_user.rb
+++ b/app/concerns/better_together/devise_user.rb
@@ -10,8 +10,6 @@ module BetterTogether
       def send_confirmation_instructions(opts = {})
         generate_confirmation_token! unless @raw_confirmation_token
 
-        # fall back to "default" config name
-        opts[:client_config] ||= 'default'
         opts[:to] = unconfirmed_email if pending_reconfirmation?
         opts[:redirect_url] ||= BetterTogether.default_user_confirm_success_url
 

--- a/app/concerns/better_together/devise_user.rb
+++ b/app/concerns/better_together/devise_user.rb
@@ -20,6 +20,10 @@ module BetterTogether
       def send_reset_password_instructions(opts = {})
         token = set_reset_password_token
 
+        opts[:new_password_url] ||= BetterTogether.default_user_new_password_url
+
+        opts[:new_password_url] += "?reset_password_token=#{token}"
+
         send_devise_notification(:reset_password_instructions, token, opts)
         token
       end

--- a/app/controllers/better_together/api_controller.rb
+++ b/app/controllers/better_together/api_controller.rb
@@ -2,6 +2,7 @@ require_dependency 'jsonapi/resource_controller'
 
 module BetterTogether
   class ApiController < ::JSONAPI::ResourceController
+    include Pundit
     include Pundit::ResourceController
     protect_from_forgery with: :null_session
   end

--- a/app/controllers/better_together/bt/api/v1/people_controller.rb
+++ b/app/controllers/better_together/bt/api/v1/people_controller.rb
@@ -6,6 +6,12 @@ module BetterTogether
       module V1   
         class PeopleController < ApiController
           before_action :authenticate_user!
+
+          def me
+            @policy_used = person = authorize current_user.person
+
+            render json: person.to_json
+          end
         end
       end
     end

--- a/app/controllers/better_together/confirmations_controller.rb
+++ b/app/controllers/better_together/confirmations_controller.rb
@@ -9,11 +9,7 @@ module BetterTogether
     end
 
     def after_confirmation_path_for(resource_name, resource)
-      if signed_in?(resource_name)
-        signed_in_root_path(resource)
-      else
-        better_together.new_session_path(resource_name)
-      end
+      
     end
   end
 end

--- a/app/controllers/better_together/confirmations_controller.rb
+++ b/app/controllers/better_together/confirmations_controller.rb
@@ -2,14 +2,33 @@ module BetterTogether
   class ConfirmationsController < Devise::ConfirmationsController
     respond_to :json
 
+    # GET /resource/confirmation?confirmation_token=abcdef
+    def show
+      self.resource = resource_class.confirm_by_token(params[:confirmation_token])
+
+      if resource.errors.empty?
+        yield resource if block_given?
+        
+        redirect_to redirect_url
+      else
+        respond_with_navigational(resource.errors, status: :unprocessable_entity){ render :new }
+      end
+    end
+
     protected
 
     def resource_name
       :user
     end
 
-    def after_confirmation_path_for(resource_name, resource)
-      
+     # give redirect value from params priority or fall back to default value if provided
+    def redirect_url
+      params.fetch(
+        :redirect_url,
+        BetterTogether.default_user_confirm_success_url
+      )
     end
+
+    def after_confirmation_path_for(resource_name, resource); end
   end
 end

--- a/app/controllers/better_together/passwords_controller.rb
+++ b/app/controllers/better_together/passwords_controller.rb
@@ -2,10 +2,37 @@ module BetterTogether
   class PasswordsController < Devise::PasswordsController
     respond_to :json
 
+    # POST /resource/password
+    def create
+      @email = params[:email]
+
+      @resource = resource_class.find_by(email: @email)
+      self.resource = @resource
+
+      resource.send_reset_password_instructions(
+        email: @email,
+        new_password_url: new_password_url
+      )
+      yield resource if block_given?
+
+      if successfully_sent?(resource)
+        respond_with({}, location: after_sending_reset_password_instructions_path_for(resource_name))
+      else
+        respond_with(resource)
+      end
+    end
+
     protected
 
     def resource_name
       :user
+    end
+
+    def new_password_url
+      params.fetch(
+        :new_password_url,
+        BetterTogether.default_user_new_password_url
+      )
     end
   end
 end

--- a/app/controllers/better_together/passwords_controller.rb
+++ b/app/controllers/better_together/passwords_controller.rb
@@ -28,6 +28,8 @@ module BetterTogether
       :user
     end
 
+    def after_resetting_password_path_for(resource); end
+
     def new_password_url
       params.fetch(
         :new_password_url,

--- a/app/controllers/better_together/registrations_controller.rb
+++ b/app/controllers/better_together/registrations_controller.rb
@@ -1,6 +1,7 @@
 module BetterTogether
   class RegistrationsController < Devise::RegistrationsController
     respond_to :json
+    before_action :configure_permitted_parameters
 
     def create
       build_resource(sign_up_params)
@@ -51,6 +52,11 @@ module BetterTogether
     end
 
     protected
+
+    def configure_permitted_parameters
+      # for user account creation i.e sign up
+      devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :password, :password_confirmation, { person_attributes: [ :name, :description] }])
+    end
 
     def confirmable_enabled?
       resource_class.devise_modules.include?(:confirmable)

--- a/app/controllers/better_together/registrations_controller.rb
+++ b/app/controllers/better_together/registrations_controller.rb
@@ -5,14 +5,14 @@ module BetterTogether
     def create
       build_resource(sign_up_params)
 
-      # give redirect value from params priority
-      @redirect_url = params.fetch(
-        :confirm_success_url,
-        BetterTogether.default_user_confirm_success_url
+      # give confirmation value from params priority
+      @confirmation_url = params.fetch(
+        :confirmation_url,
+        BetterTogether.default_user_confirmation_url
       )
 
-      # success redirect url is required
-      if confirmable_enabled? && !@redirect_url
+      # success confirmation url is required
+      if confirmable_enabled? && !@confirmation_url
         return render json: { error: 'You must configure a default user confirmation success url' }.to_json
       end
 
@@ -32,7 +32,7 @@ module BetterTogether
         unless resource.confirmed?
           # user will require email authentication
           resource.send_confirmation_instructions({
-            redirect_url: @redirect_url
+            confirmation_url: @confirmation_url
           })
         end
 

--- a/app/controllers/better_together/registrations_controller.rb
+++ b/app/controllers/better_together/registrations_controller.rb
@@ -1,5 +1,9 @@
 module BetterTogether
   class RegistrationsController < Devise::RegistrationsController
     respond_to :json
+
+    protected
+
+    def after_inactive_sign_up_path_for(resource); end
   end
 end

--- a/app/controllers/better_together/registrations_controller.rb
+++ b/app/controllers/better_together/registrations_controller.rb
@@ -40,7 +40,6 @@ module BetterTogether
           sign_up(resource_name, resource)
           respond_with resource, location: after_sign_up_path_for(resource)
         else
-          set_flash_message! :
           expire_data_after_sign_in!
           respond_with resource, location: after_inactive_sign_up_path_for(resource)
         end
@@ -52,6 +51,10 @@ module BetterTogether
     end
 
     protected
+
+    def confirmable_enabled?
+      resource_class.devise_modules.include?(:confirmable)
+    end
 
     def after_inactive_sign_up_path_for(resource); end
   end

--- a/app/controllers/better_together/registrations_controller.rb
+++ b/app/controllers/better_together/registrations_controller.rb
@@ -2,6 +2,55 @@ module BetterTogether
   class RegistrationsController < Devise::RegistrationsController
     respond_to :json
 
+    def create
+      build_resource(sign_up_params)
+
+      # give redirect value from params priority
+      @redirect_url = params.fetch(
+        :confirm_success_url,
+        BetterTogether.default_user_confirm_success_url
+      )
+
+      # success redirect url is required
+      if confirmable_enabled? && !@redirect_url
+        return render json: { error: 'You must configure a default user confirmation success url' }.to_json
+      end
+
+      # override email confirmation, must be sent manually from ctrl
+      callback_name = defined?(ActiveRecord) && resource_class < ActiveRecord::Base ? :commit : :create
+      resource_class.set_callback(callback_name, :after, :send_on_create_confirmation_instructions)
+      resource_class.skip_callback(callback_name, :after, :send_on_create_confirmation_instructions)
+
+      if resource.respond_to? :skip_confirmation_notification!
+        # Fix duplicate e-mails by disabling Devise confirmation e-mail
+        resource.skip_confirmation_notification!
+      end
+
+      resource.save
+      yield resource if block_given?
+      if resource.persisted?
+        unless resource.confirmed?
+          # user will require email authentication
+          resource.send_confirmation_instructions({
+            redirect_url: @redirect_url
+          })
+        end
+
+        if resource.active_for_authentication?
+          sign_up(resource_name, resource)
+          respond_with resource, location: after_sign_up_path_for(resource)
+        else
+          set_flash_message! :
+          expire_data_after_sign_in!
+          respond_with resource, location: after_inactive_sign_up_path_for(resource)
+        end
+      else
+        clean_up_passwords resource
+        set_minimum_password_length
+        respond_with resource
+      end
+    end
+
     protected
 
     def after_inactive_sign_up_path_for(resource); end

--- a/app/controllers/better_together/sessions_controller.rb
+++ b/app/controllers/better_together/sessions_controller.rb
@@ -11,5 +11,7 @@ module BetterTogether
     def respond_to_on_destroy
       head :ok
     end
+
+    def after_sign_in_path_for(resource); end
   end
 end

--- a/app/models/better_together/identification.rb
+++ b/app/models/better_together/identification.rb
@@ -2,9 +2,11 @@
 module BetterTogether
   class Identification < ApplicationRecord
     belongs_to :identity,
-               polymorphic: true
+               polymorphic: true,
+               autosave: true
     belongs_to :agent,
-               polymorphic: true
+               polymorphic: true,
+               autosave: true
 
     validates :identity,
               presence: true

--- a/app/models/better_together/user.rb
+++ b/app/models/better_together/user.rb
@@ -1,5 +1,6 @@
 module BetterTogether
   class User < ApplicationRecord
+    include ::BetterTogether::DeviseUser
     # Include default devise modules. Others available are:
     # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
     devise :database_authenticatable, :registerable,

--- a/app/models/better_together/user.rb
+++ b/app/models/better_together/user.rb
@@ -6,5 +6,29 @@ module BetterTogether
     devise :database_authenticatable, :registerable,
            :recoverable, :rememberable, :validatable, :confirmable,
            :jwt_authenticatable, jwt_revocation_strategy: JwtDenylist
+    
+    has_one :person_identification,
+            -> {
+              where(
+                identity_type: 'BetterTogether::Person',
+                active: true
+              )
+            },
+            as: :agent,
+            class_name: 'BetterTogether::Identification',
+            autosave: true
+    has_one :person,
+          through: :person_identification,
+          source: :identity,
+          source_type: 'BetterTogether::Person'
+
+    accepts_nested_attributes_for :person
+
+    def build_person(attributes)
+      self.build_person_identification(
+        agent: self,
+        identity: BetterTogether::Person.new(attributes)
+      )
+    end
   end
 end

--- a/app/policies/better_together/person_policy.rb
+++ b/app/policies/better_together/person_policy.rb
@@ -5,6 +5,10 @@ module BetterTogether
       false
     end
 
+    def me?
+      record === user.person
+    end
+
     class Scope < Scope
       def resolve
         scope.all

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p>Welcome <%= @email %>!</p>
+<p>Welcome <%= message['person-name'].to_s %>!</p>
 
 <p>You can confirm your account email through the link below:</p>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to t('Confirm my account'), better_together.user_confirmation_url(@resource, confirmation_token: @token, redirect_url: message['redirect-url']).html_safe %></p>
+<p><%= link_to t('Confirm my account'), message['confirmation-url'].to_s %></p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -2,4 +2,4 @@
 
 <p>You can confirm your account email through the link below:</p>
 
-<p><%= link_to 'Confirm my account', better_together.user_confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t('Confirm my account'), better_together.user_confirmation_url(@resource, confirmation_token: @token, redirect_url: message['redirect-url']).html_safe %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -2,7 +2,7 @@
 
 <p>Someone has requested a link to change your password. You can do this through the link below.</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'Change my password', message['new-password-url'].to_s %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
 <p>Your password won't change until you access the link above and create a new one.</p>

--- a/config/initializers/better_together.rb
+++ b/config/initializers/better_together.rb
@@ -1,10 +1,10 @@
 require 'better_together'
 
 BetterTogether.user_class = 'BetterTogether::User'
-BetterTogether.default_user_confirm_success_url = ENV.fetch(
+BetterTogether.default_user_confirmation_url = ENV.fetch(
   'APP_HOST',
   'http://localhost:3000'
-)
+) + '/bt/api/auth/confirmation'
 BetterTogether.default_user_new_password_url = ENV.fetch(
   'APP_HOST',
   'http://localhost:3000'

--- a/config/initializers/better_together.rb
+++ b/config/initializers/better_together.rb
@@ -5,3 +5,7 @@ BetterTogether.default_user_confirm_success_url = ENV.fetch(
   'APP_HOST',
   'http://localhost:3000'
 )
+BetterTogether.default_user_new_password_url = ENV.fetch(
+  'APP_HOST',
+  'http://localhost:3000'
+) + '/bt/api/auth/password/new'

--- a/config/initializers/better_together.rb
+++ b/config/initializers/better_together.rb
@@ -1,4 +1,7 @@
 require 'better_together'
 
 BetterTogether.user_class = 'BetterTogether::User'
-BetterTogether.default_user_confirm_success_url = 'http://localhost:3000'
+BetterTogether.default_user_confirm_success_url = ENV.fetch(
+  'APP_HOST',
+  'http://localhost:3000'
+)

--- a/config/initializers/better_together.rb
+++ b/config/initializers/better_together.rb
@@ -1,3 +1,4 @@
 require 'better_together'
 
 BetterTogether.user_class = 'BetterTogether::User'
+BetterTogether.default_user_confirm_success_url = 'http://localhost:3000'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -325,10 +325,10 @@ Devise.setup do |config|
       'fe066f312d07ecef37a5ae4db05e94b0659ef63f600df6e602380e244647b198eaa4d1d5d566f614b77552ad84104983d49f25b45122f7d0ff85717285d38bd2'
     )
     jwt.dispatch_requests = [
-      ['POST', %r{^/bt/api/auth/login$}]
+      ['POST', %r{^/bt/api/auth/sign-in$}]
     ]
     jwt.revocation_requests = [
-      ['DELETE', %r{^/bt/api/auth/logout$}]
+      ['DELETE', %r{^/bt/api/auth/sign-out$}]
     ]
     jwt.expiration_time = 1.hour.to_i
     jwt.request_formats = {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -186,7 +186,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 12..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ BetterTogether::Engine.routes.draw do
           # jsonapi_relationships
         end
 
+        get 'people/me', to: 'people#me'
+
         jsonapi_resources :people do
           # jsonapi_relationships
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,9 @@ BetterTogether::Engine.routes.draw do
     skip: [:unlocks, :omniauth_callbacks],
     path: 'bt/api/auth',
     path_names: {
-      sign_in: 'login',
-      sign_out: 'logout',
-      registration: 'signup'
+      sign_in: 'sign-in',
+      sign_out: 'sign-out',
+      registration: 'sign-up'
     },
     defaults: { format: :json }
 

--- a/lib/better_together.rb
+++ b/lib/better_together.rb
@@ -1,7 +1,9 @@
 require "better_together/engine"
 
 module BetterTogether
-  mattr_accessor :user_class, :default_user_confirm_success_url
+  mattr_accessor :user_class,
+                 :default_user_confirm_success_url,
+                 :default_user_new_password_url
 
   class << self
     def user_class

--- a/lib/better_together.rb
+++ b/lib/better_together.rb
@@ -1,7 +1,7 @@
 require "better_together/engine"
 
 module BetterTogether
-  mattr_accessor :user_class
+  mattr_accessor :user_class, :default_user_confirm_success_url
 
   class << self
     def user_class

--- a/lib/better_together.rb
+++ b/lib/better_together.rb
@@ -2,7 +2,7 @@ require "better_together/engine"
 
 module BetterTogether
   mattr_accessor :user_class,
-                 :default_user_confirm_success_url,
+                 :default_user_confirmation_url,
                  :default_user_new_password_url
 
   class << self

--- a/lib/better_together/configuration.rb
+++ b/lib/better_together/configuration.rb
@@ -1,9 +1,13 @@
 module BetterTogether
   class Configuration
-    attr_reader :user_class
+    attr_reader :user_class, :default_user_confirm_success_url
 
     def user_class=(class_as_string)
       BetterTogether.user_class = class_as_string
+    end
+
+    def default_user_confirm_success_url=(url)
+      BetterTogether.default_user_confirm_success_url = url
     end
   end
 end

--- a/lib/generators/better_together/install/install_generator.rb
+++ b/lib/generators/better_together/install/install_generator.rb
@@ -15,8 +15,14 @@ module BetterTogether
       <<-CONTENT
 require 'better_together'
 
-BetterTogether.user_class = "BetterTogether::User"
-BetterTogether.default_user_confirm_success_url = 'http://localhost:3000'
+BetterTogether.user_class = 'BetterTogether::User'
+BetterTogether.default_user_confirm_success_url = ENV.fetch(
+  'APP_HOST',
+  'http://localhost:3000'
+BetterTogether.default_user_new_password_url = ENV.fetch(
+  'APP_HOST',
+  'http://localhost:3000'
+) + '/bt/api/auth/password/new'
       CONTENT
     end
   end

--- a/lib/generators/better_together/install/install_generator.rb
+++ b/lib/generators/better_together/install/install_generator.rb
@@ -16,6 +16,7 @@ module BetterTogether
 require 'better_together'
 
 BetterTogether.user_class = "BetterTogether::User"
+BetterTogether.default_user_confirm_success_url = 'http://localhost:3000'
       CONTENT
     end
   end

--- a/spec/factories/better_together/users.rb
+++ b/spec/factories/better_together/users.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     class: ::BetterTogether::User,
     aliases: %i[user] do
     email { Faker::Internet.unique.email }
-    password { Faker::Internet.password(min_length: 10, max_length: 20) }
+    password { Faker::Internet.password(min_length: 12, max_length: 20) }
 
     trait :confirmed do
       confirmed_at { Time.zone.now }

--- a/spec/models/better_together/user_spec.rb
+++ b/spec/models/better_together/user_spec.rb
@@ -10,6 +10,9 @@ module BetterTogether
     end
 
     describe 'ActiveRecord associations' do
+      it { is_expected.to have_one(:person_identification) }
+      it { is_expected.to have_one(:person) }
+      it { is_expected.to accept_nested_attributes_for(:person) }
     end
 
     describe 'ActiveModel validations' do

--- a/spec/requests/better_together/api/auth/confirmations_spec.rb
+++ b/spec/requests/better_together/api/auth/confirmations_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe BetterTogether::ConfirmationsController, type: :request do
+  let (:user) { create(:user) }
+  let (:confirmation_token) { user.send(:generate_confirmation_token!) }
+  context 'When confirming an account' do
+
+    before do
+      get confirmation_url
+    end
+
+    # context 'when the token is valid' do
+    #   let (:confirmation_url) { better_together.user_confirmation_path(confirmation_token: confirmation_token) }
+
+    #   it 'returns 201' do
+    #     expect(response.status).to eq(201)
+    #   end
+    # end
+
+    # context 'when the token is invalid' do
+    #   let (:confirmation_url) { better_together.user_confirmation_path(confirmation_token: 'hgduagduhagsdhak') }
+
+    #   it 'returns 422' do
+    #     expect(response.status).to eq(422)
+    #   end
+    # end
+  end
+
+  context 'When requesting a new confirmation email' do
+    let (:resend_confirmation_url) { better_together.user_confirmation_path }
+
+    before do
+      post resend_confirmation_url, params: params
+    end
+
+    context 'when the email exists' do
+      let (:params) {
+        {
+          user: {
+            email: user.email
+          }
+        }
+      }
+
+
+      it 'returns 201' do
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context 'when the email does not exist' do
+      let (:params) {
+        {
+          user: {
+            email: 'nothingexistingwiththis@here.com'
+          }
+        }
+      }
+
+
+      it 'returns 422' do
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end

--- a/spec/requests/better_together/api/auth/passwords_spec.rb
+++ b/spec/requests/better_together/api/auth/passwords_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+describe BetterTogether::SessionsController, type: :request do
+
+  let (:user) { create(:user, :confirmed) }
+  let (:login_url) { better_together.user_session_path }
+  let (:logout_url) { better_together.destroy_user_session_path }
+
+  context 'When logging in' do
+    before do
+      login(user)
+    end
+
+    it 'returns a token' do
+      expect(response.headers['Authorization']).to be_present
+    end
+
+    it 'returns 200' do
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context 'When password is missing' do
+    before do
+      post login_url, params: {
+        user: {
+          email: user.email,
+          password: nil
+        }
+      }
+    end
+
+    it 'returns 401' do
+      expect(response.status).to eq(401)
+    end
+
+  end
+
+  context 'When logging out' do
+    it 'returns 200' do
+      delete logout_url
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
+end


### PR DESCRIPTION
User should be able to create a new account, confirm it, and then log in. They should be able to request a password reset, and resend their confirmation token.