### PR TITLE
Fix/trix attachment uploads

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 PATH
   remote: .
   specs:
-    better_together (0.4.0)
+    better_together (0.4.1)
       activerecord-import
       activerecord-postgis-adapter
       bootstrap (~> 5.3.2)

--- a/app/controllers/better_together/application_controller.rb
+++ b/app/controllers/better_together/application_controller.rb
@@ -3,6 +3,7 @@
 module BetterTogether
   # Base application controller for engine
   class ApplicationController < ActionController::Base
+    include ActiveStorage::SetCurrent
     include Pundit::Authorization
 
     protect_from_forgery with: :exception

--- a/app/javascript/better_together/controllers/trix_controller.js
+++ b/app/javascript/better_together/controllers/trix_controller.js
@@ -1,0 +1,19 @@
+// app/javascripts/better_together/controllers/trix_controller.js
+
+import { Controller } from "@hotwired/stimulus";
+
+export default class TrixController extends Controller {
+
+  connect() {
+
+    // wait for the trix editor is attached to the DOM to do stuff
+    addEventListener("trix-initialize", function (event) {
+      console.log("im inititalized!");
+      // ...
+      // add underline code
+      // remove buttons code
+      // add custom icons code here
+      // ...
+    }, true);
+  }
+}

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag main_app.url_for(blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ])) %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]).processed.url %>
   <% end %>
 
   <% if caption = blob.try(:caption) %>

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,6 +1,6 @@
 <figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
   <% if blob.representable? %>
-    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]).processed.url %>
+    <%= image_tag main_app.url_for(blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ])) %>
   <% end %>
 
   <% if caption = blob.try(:caption) %>

--- a/app/views/better_together/pages/_form.html.erb
+++ b/app/views/better_together/pages/_form.html.erb
@@ -39,7 +39,11 @@
 
     <div class="row mb-3">
       <%= form.label :content %>
-      <%= form.rich_text_area :content, class: "form-control#{' is-invalid' if page.errors[:content].any?}" %>
+      <%=
+        form.rich_text_area :content,
+                            class: "form-control#{' is-invalid' if page.errors[:content].any?}",
+                            data: { controller: 'trix' }
+      %>
       <% if page.errors[:content].any? %>
         <div class="invalid-feedback">
           <%= page.errors[:content].join(", ") %>

--- a/lib/better_together/engine.rb
+++ b/lib/better_together/engine.rb
@@ -40,10 +40,18 @@ module BetterTogether
       require_dependency 'rack/cors'
     end
 
-    config.action_mailer.default_url_options = {
+    default_url_options = {
       host: ENV.fetch('APP_HOST', 'localhost:3000'),
-      locale: I18n.locale
+      protocol: ENV.fetch('APP_PROTOCOL', 'http'),
+      locale: ENV.fetch('APP_LOCALE', I18n.locale)
     }
+
+    routes.default_url_options =
+      config.action_mailer.default_url_options =
+      config.default_url_options = 
+      default_url_options
+
+    config.time_zone = ENV.fetch('APP_TIME_ZONE', 'Newfoundland')
 
     initializer 'better_together.importmap', before: 'importmap' do |app|
       app.config.importmap.paths << Engine.root.join('config/importmap.rb')

--- a/lib/better_together/engine.rb
+++ b/lib/better_together/engine.rb
@@ -48,8 +48,8 @@ module BetterTogether
 
     routes.default_url_options =
       config.action_mailer.default_url_options =
-      config.default_url_options = 
-      default_url_options
+        config.default_url_options =
+          default_url_options
 
     config.time_zone = ENV.fetch('APP_TIME_ZONE', 'Newfoundland')
 

--- a/lib/better_together/version.rb
+++ b/lib/better_together/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module BetterTogether
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end


### PR DESCRIPTION
The direct upload of active storage attachments to S3 was not working. This fixes it so that image uploads from the trix editor for pages now works as expected, allowing use of the rudimentary page builder/CMS