### PR TITLE
Attempt to exclude spatial tables from db dump

### DIFF
--- a/lib/better_together/engine.rb
+++ b/lib/better_together/engine.rb
@@ -77,6 +77,11 @@ module BetterTogether
       app.config.log_tags = %i[request_id remote_ip]
     end
 
+    # Exclude postgis tables from database dumper
+    initializer 'better_together.spatial_tables' do
+      ::ActiveRecord::SchemaDumper.ignore_tables = %w[spatial_ref_sys] + ::ActiveRecord::SchemaDumper.ignore_tables
+    end
+
     rake_tasks do
       load 'tasks/better_together_tasks.rake'
 

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_05_22_204901) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_12_113954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
the better-together-rails project is erroring running rspec in the database cleanup step