### PR TITLE
Fix dev setup typo

### DIFF
--- a/docs/development/dev-setup.md
+++ b/docs/development/dev-setup.md
@@ -1,7 +1,7 @@
 
 # Development Setup
 
-The Commuity Engine is a Ruby on Rails Engine that provides turnkey community features for your application so you can focus on building your business logic.
+The Community Engine is a Ruby on Rails Engine that provides turnkey community features for your application so you can focus on building your business logic.
 
 It uses Docker and Docker Compose to build and provision the dependency containers.
 


### PR DESCRIPTION
## Summary
- fix the line describing Community Engine in dev setup guide

## Testing
- `bundle -v` *(fails: ruby not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886d1b175488321a1f6088f4dc5e475