### PR TITLE
Spec/succeeding messaging

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   rspec:
     runs-on: ubuntu-latest
+    environment: test
     services:
       postgres:
         image: postgis/postgis:latest
@@ -50,6 +51,8 @@ jobs:
         run: rm -f spec/dummy/tmp/pids/server.pid && cd ./spec/dummy && bundle exec rails db:schema:load
       # Add or replace test runners here
       - name: Run tests
+        env:
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         run: rm -f spec/dummy/tmp/pids/server.pid && bundle exec rspec
 
   rubocop:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -321,6 +321,8 @@ GEM
       multipart-post (~> 2.0)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-arm64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     fog-aws (3.32.0)
       base64 (~> 0.2.0)
@@ -354,6 +356,12 @@ GEM
       csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    google-protobuf (4.30.2-aarch64-linux)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.30.2-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
     google-protobuf (4.30.2-x86_64-linux)
       bigdecimal
       rake (>= 13)
@@ -473,6 +481,10 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.4)
+    nokogiri (1.18.9-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-gnu)
       racc (~> 1.4)
     noticed (2.8.0)
@@ -685,6 +697,10 @@ GEM
       ffi (~> 1.12)
       logger
     rubyzip (2.4.1)
+    sass-embedded (1.86.3-aarch64-linux-gnu)
+      google-protobuf (~> 4.30)
+    sass-embedded (1.86.3-arm64-darwin)
+      google-protobuf (~> 4.30)
     sass-embedded (1.86.3-x86_64-linux-gnu)
       google-protobuf (~> 4.30)
     sassc (2.4.0)
@@ -792,6 +808,8 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/app/helpers/better_together/application_helper.rb
+++ b/app/helpers/better_together/application_helper.rb
@@ -34,6 +34,7 @@ module BetterTogether
     # Retrieves the current person associated with the signed-in user.
     # Returns nil if no user is signed in or the user has no associated person.
     def current_person
+      byebug
       return unless user_signed_in? && current_user.person
 
       @current_person ||= current_user.person

--- a/app/helpers/better_together/application_helper.rb
+++ b/app/helpers/better_together/application_helper.rb
@@ -34,7 +34,6 @@ module BetterTogether
     # Retrieves the current person associated with the signed-in user.
     # Returns nil if no user is signed in or the user has no associated person.
     def current_person
-      byebug
       return unless user_signed_in? && current_user.person
 
       @current_person ||= current_user.person

--- a/app/models/better_together/user.rb
+++ b/app/models/better_together/user.rb
@@ -18,8 +18,7 @@ module BetterTogether
               )
             },
             as: :agent,
-            class_name: 'BetterTogether::Identification',
-            autosave: true
+            class_name: 'BetterTogether::Identification'
 
     has_one :person,
             through: :person_identification,
@@ -43,6 +42,13 @@ module BetterTogether
       # Check if a Person object exists and return its attributes
       super.present? ? super : build_person
     end
+
+    # def person= arg
+    #     build_person_identification(
+    #     agent: self,
+    #     identity: arg
+    #   )&.identity
+    # end
 
     # Define person_attributes= method
     def person_attributes=(attributes)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
   db:
     <<: *env-info
     container_name: community-engine-db
-    image: postgis/postgis:latest
+    image: imresamu/postgis:17-recent
     volumes:
       - community-engine-db-data:/var/lib/postgresql/data
     ports:

--- a/spec/factories/better_together/people.rb
+++ b/spec/factories/better_together/people.rb
@@ -9,6 +9,8 @@ module BetterTogether
       name { Faker::Name.name }
       description { Faker::Lorem.paragraphs(number: 3) }
       identifier { Faker::Internet.unique.username(specifier: 5..10) }
+
+      community
     end
   end
 end

--- a/spec/factories/better_together/users.rb
+++ b/spec/factories/better_together/users.rb
@@ -10,9 +10,7 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     password { Faker::Internet.password(min_length: 12, max_length: 20) }
 
-    after(:build) do |user|
-      user.person = build(:better_together_person)
-    end
+    person
 
     trait :confirmed do
       confirmed_at { Time.zone.now }

--- a/spec/factories/better_together/users.rb
+++ b/spec/factories/better_together/users.rb
@@ -10,10 +10,25 @@ FactoryBot.define do
     email { Faker::Internet.unique.email }
     password { Faker::Internet.password(min_length: 12, max_length: 20) }
 
+    after(:build) do |user|
+      user.person = create(:better_together_person)
+    end
+
     trait :confirmed do
       confirmed_at { Time.zone.now }
       confirmation_sent_at { Time.zone.now }
       confirmation_token { '12345' }
+    end
+
+    trait :platform_manager do
+      after(:create) do
+        host_platform = BetterTogether::Platform.find_or_create_by(host: true)
+        platform_manager_role = BetterTogether::Role.find_by(identifier: 'platform_manager')
+        host_platform.person_platform_memberships.create!(
+          member: user.person,
+          role: platform_manager_role
+        )
+      end
     end
   end
 end

--- a/spec/factories/better_together/users.rb
+++ b/spec/factories/better_together/users.rb
@@ -11,7 +11,7 @@ FactoryBot.define do
     password { Faker::Internet.password(min_length: 12, max_length: 20) }
 
     after(:build) do |user|
-      user.person = create(:better_together_person)
+      user.person = build(:better_together_person)
     end
 
     trait :confirmed do
@@ -21,7 +21,7 @@ FactoryBot.define do
     end
 
     trait :platform_manager do
-      after(:create) do
+      after(:create) do |user|
         host_platform = BetterTogether::Platform.find_or_create_by(host: true)
         platform_manager_role = BetterTogether::Role.find_by(identifier: 'platform_manager')
         host_platform.person_platform_memberships.create!(

--- a/spec/factories/better_together/users.rb
+++ b/spec/factories/better_together/users.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
     trait :confirmed do
       confirmed_at { Time.zone.now }
       confirmation_sent_at { Time.zone.now }
-      confirmation_token { '12345' }
+      confirmation_token { Faker::Alphanumeric.alphanumeric(number: 20) }
     end
 
     trait :platform_manager do

--- a/spec/features/conversations/create_spec.rb
+++ b/spec/features/conversations/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'creating a new conversation', type: :feature do
     login_as_platform_manager
   end
 
-  let!(:user) { create(:better_together_user) }
+  let!(:user) { create(:better_together_user, :confirmed) }
 
   scenario 'between a platform manager and normal user' do
     visit new_conversation_path(locale: I18n.default_locale)
@@ -18,5 +18,20 @@ RSpec.describe 'creating a new conversation', type: :feature do
     fill_in 'conversation[title]', with: Faker::Lorem.sentence(word_count: 3)
     click_button 'Create Conversation'
     expect(BetterTogether::Conversation.count).to eq(1)
+  end
+
+  context 'as a normal user' do
+    before do
+      sign_out_current_user
+      sign_in_user(user.email, user.password)
+    end
+    let(:user2) do
+      create(:better_together_user)
+    end
+
+    it 'cannot create conversations with private users' do
+      visit new_conversation_path(locale: I18n.default_locale)
+      expect('conversation[participant_ids][]').not_to have_content(user2.person.name)
+    end
   end
 end

--- a/spec/features/conversations/create_spec.rb
+++ b/spec/features/conversations/create_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe 'creating a new conversation', type: :feature do
       sign_out_current_user
       sign_in_user(user.email, user.password)
     end
-    let(:user2) do
-      create(:better_together_user)
-    end
+    let(:user2) { create(:better_together_user) }
 
     it 'cannot create conversations with private users' do
       visit new_conversation_path(locale: I18n.default_locale)

--- a/spec/features/conversations/create_spec.rb
+++ b/spec/features/conversations/create_spec.rb
@@ -10,10 +10,11 @@ RSpec.describe 'creating a new conversation', type: :feature do
     login_as_platform_manager
   end
 
-  let!(:user) { build(:better_together_user) }
+  let!(:user) { create(:better_together_user) }
 
   scenario 'with two members' do
     visit new_conversation_path(locale: I18n.default_locale)
+    # byebug
     select "#{user.person.name} - @#{user.person.identifier}", from: 'conversation[participant_ids][]'
     click_button 'Create Conversation'
     expect(BetterTogether::Conversation.count).to eq(1)

--- a/spec/features/conversations/create_spec.rb
+++ b/spec/features/conversations/create_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'creating a new conversation', type: :feature do
+  include BetterTogether::DeviseSessionHelpers
+
+  before do
+    configure_host_platform
+    login_as_platform_manager
+  end
+
+  let!(:user) { build(:better_together_user) }
+
+  scenario 'with two members' do
+    visit new_conversation_path(locale: I18n.default_locale)
+    select "#{user.person.name} - @#{user.person.identifier}", from: 'conversation[participant_ids][]'
+    click_button 'Create Conversation'
+    expect(BetterTogether::Conversation.count).to eq(1)
+  end
+end

--- a/spec/features/conversations/create_spec.rb
+++ b/spec/features/conversations/create_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe 'creating a new conversation', type: :feature do
 
   let!(:user) { create(:better_together_user) }
 
-  scenario 'with two members' do
+  scenario 'between a platform manager and normal user' do
     visit new_conversation_path(locale: I18n.default_locale)
-    # byebug
     select "#{user.person.name} - @#{user.person.identifier}", from: 'conversation[participant_ids][]'
+    fill_in 'conversation[title]', with: Faker::Lorem.sentence(word_count: 3)
     click_button 'Create Conversation'
     expect(BetterTogether::Conversation.count).to eq(1)
   end

--- a/spec/features/conversations/send_message_spec.rb
+++ b/spec/features/conversations/send_message_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'sending a message', type: :feature do
     login_as_platform_manager
   end
 
-  let(:user) { build(:better_together_user) }
+  let(:user) { create(:better_together_user) }
   let(:message) { Faker::Lorem.sentence }
 
   scenario 'message text appears in chat window', :js do

--- a/spec/features/conversations/send_message_spec.rb
+++ b/spec/features/conversations/send_message_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'sending a message', type: :feature do
   let(:message) { Faker::Lorem.sentence }
 
   scenario 'message text appears in chat window', :js do
-    create_conversation(user)
+    create_conversation([user.person])
     first('trix-editor').click.set(message)
     click_button 'Send'
   end

--- a/spec/features/conversations/send_message_spec.rb
+++ b/spec/features/conversations/send_message_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'sending a message', type: :feature do # rubocop:todo Metrics/BlockLength
+RSpec.describe 'sending a message', type: :feature do
   include ActiveJob::TestHelper
   include ActiveSupport::Testing::TimeHelpers
   include BetterTogether::DeviseSessionHelpers
@@ -18,6 +18,7 @@ RSpec.describe 'sending a message', type: :feature do # rubocop:todo Metrics/Blo
 
   context 'when message is sent', :js do
     before do
+      # clear_enqueued_jobs
       create_conversation([user.person])
       first('trix-editor').click.set(message)
     end
@@ -28,11 +29,18 @@ RSpec.describe 'sending a message', type: :feature do # rubocop:todo Metrics/Blo
       expect(page).to have_content(message)
     end
 
-    it 'schedules a notification job for 15 minutes later' do
-      expect do
-        find_button('Send').click
-        expect(page).to have_content(message, wait: 5)
-      end.to have_enqueued_job(Noticed::EventJob).once
-    end
+    # TODO: fix race condition on event jobs
+    # it 'schedules a notification job for 15 minutes later' do
+    #   travel_to Time.now do
+    #     expect do
+    #       find_button('Send').click
+    #       expect(page).to have_content(message)
+    #       byebug
+    #     end.to have_enqueued_job(Noticed::EventJob).once
+    #     perform_enqueued_jobs
+    #     expect(Noticed::DeliveryMethods::Email)
+    #       .to have_been_enqueued.at(15.minutes.from_now).once
+    #   end
+    # end
   end
 end

--- a/spec/features/conversations/send_message_spec.rb
+++ b/spec/features/conversations/send_message_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'sending a message', type: :feature do
+  include BetterTogether::DeviseSessionHelpers
+  include BetterTogether::ConversationHelpers
+
+  before do
+    configure_host_platform
+    login_as_platform_manager
+  end
+
+  let(:user) { build(:better_together_user) }
+  let(:message) { Faker::Lorem.sentence }
+
+  scenario 'message text appears in chat window', :js do
+    create_conversation(user)
+    first('trix-editor').click.set(message)
+    click_button 'Send'
+    save_and_open_page
+  end
+end

--- a/spec/features/conversations/send_message_spec.rb
+++ b/spec/features/conversations/send_message_spec.rb
@@ -18,6 +18,5 @@ RSpec.describe 'sending a message', type: :feature do
     create_conversation(user)
     first('trix-editor').click.set(message)
     click_button 'Send'
-    save_and_open_page
   end
 end

--- a/spec/features/conversations/send_message_spec.rb
+++ b/spec/features/conversations/send_message_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe 'sending a message', type: :feature do
     login_as_platform_manager
   end
 
-  let(:user) { create(:better_together_user) }
+  let(:user) { create(:better_together_user, :confirmed) }
   let(:message) { Faker::Lorem.sentence }
 
   scenario 'message text appears in chat window', :js do
     create_conversation([user.person])
     first('trix-editor').click.set(message)
-    click_button 'Send'
+    find_button('Send').click
+    visit conversations_path(locale: I18n.default_locale)
+    expect(page).to have_content(message)
   end
 end

--- a/spec/features/conversations/send_message_spec.rb
+++ b/spec/features/conversations/send_message_spec.rb
@@ -2,7 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe 'sending a message', type: :feature do
+RSpec.describe 'sending a message', type: :feature do # rubocop:todo Metrics/BlockLength
+  include ActiveJob::TestHelper
+  include ActiveSupport::Testing::TimeHelpers
   include BetterTogether::DeviseSessionHelpers
   include BetterTogether::ConversationHelpers
 
@@ -14,11 +16,23 @@ RSpec.describe 'sending a message', type: :feature do
   let(:user) { create(:better_together_user, :confirmed) }
   let(:message) { Faker::Lorem.sentence }
 
-  scenario 'message text appears in chat window', :js do
-    create_conversation([user.person])
-    first('trix-editor').click.set(message)
-    find_button('Send').click
-    visit conversations_path(locale: I18n.default_locale)
-    expect(page).to have_content(message)
+  context 'when message is sent', :js do
+    before do
+      create_conversation([user.person])
+      first('trix-editor').click.set(message)
+    end
+
+    it 'appears in the chat window' do
+      find_button('Send').click
+      visit conversations_path(locale: I18n.default_locale)
+      expect(page).to have_content(message)
+    end
+
+    it 'schedules a notification job for 15 minutes later' do
+      expect do
+        find_button('Send').click
+        expect(page).to have_content(message, wait: 5)
+      end.to have_enqueued_job(Noticed::EventJob).once
+    end
   end
 end

--- a/spec/features/invitations/platform_invitation_accept_spec.rb
+++ b/spec/features/invitations/platform_invitation_accept_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'accepting a platform invitation', type: :feature do
+  include BetterTogether::DeviseSessionHelpers
+
+  let(:invitation) do
+    create(:better_together_platform_invitation,
+           invitable: configure_host_platform)
+  end
+  let(:person) { build(:better_together_person) }
+  let(:password) { Faker::Internet.password(min_length: 12, max_length: 20) }
+
+  scenario 'by signing up a new user' do
+    sign_up_new_user(invitation.token, invitation.invitee_email, password, person)
+    sign_in_user(invitation.invitee_email, password)
+    expect(page).to have_content('Signed in successfully.')
+  end
+end

--- a/spec/features/invitations/platform_invitation_create_spec.rb
+++ b/spec/features/invitations/platform_invitation_create_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'creating a platform invitation', type: :feature do
+  include BetterTogether::DeviseSessionHelpers
+
+  let!(:host_platform) do
+    configure_host_platform
+  end
+  let(:invitee_email) { Faker::Internet.unique.email }
+
+  before do
+    login_as_platform_manager
+  end
+
+  scenario 'with valid inputs' do
+    visit platform_path(host_platform, locale: I18n.default_locale)
+    within '#newInvitationModal' do
+      select 'Platform Invitation', from: 'platform_invitation[type]'
+      select 'Community Facilitator', from: 'platform_invitation[community_role_id]'
+      select 'Platform Manager', from: 'platform_invitation[platform_role_id]'
+      fill_in 'platform_invitation[invitee_email]', with: invitee_email
+      click_button 'Invite'
+    end
+    expect(page).to have_content(invitee_email)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,6 +40,12 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
+
+  config.include Devise::Test::IntegrationHelpers, type: :feature
+
+  config.include Warden::Test::Helpers
+  config.after { Warden.test_reset! }
+
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{Rails.root}/spec/fixtures"
 

--- a/spec/support/better_together/conversation_helpers.rb
+++ b/spec/support/better_together/conversation_helpers.rb
@@ -5,11 +5,18 @@ module BetterTogether
     include Rails.application.routes.url_helpers
     include BetterTogether::Engine.routes.url_helpers
 
-    def create_conversation(*participants)
+    def create_conversation(participants)
       visit new_conversation_path(locale: I18n.default_locale)
+
+      slim_select = find('select[name="conversation[participant_ids][]"]+div.form-select')
+
+      slim_select.click
+
       participants.each do |participant|
-        select "#{participant.person.name} - @#{participant.person.identifier}", from: 'conversation[participant_ids][]'
+        find('.ss-content > .ss-list > .ss-option',
+             text: Regexp.new(participant.slug)).click
       end
+
       click_button 'Create Conversation'
     end
   end

--- a/spec/support/better_together/conversation_helpers.rb
+++ b/spec/support/better_together/conversation_helpers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module ConversationHelpers
+    include Rails.application.routes.url_helpers
+    include BetterTogether::Engine.routes.url_helpers
+
+    def create_conversation(*participants)
+      visit new_conversation_path(locale: I18n.default_locale)
+      participants.each do |participant|
+        select "#{participant.person.name} - @#{participant.person.identifier}", from: 'conversation[participant_ids][]'
+      end
+      click_button 'Create Conversation'
+    end
+  end
+end

--- a/spec/support/better_together/conversation_helpers.rb
+++ b/spec/support/better_together/conversation_helpers.rb
@@ -17,6 +17,7 @@ module BetterTogether
              text: Regexp.new(participant.slug)).click
       end
 
+      fill_in 'conversation[title]', with: Faker::Lorem.sentence(word_count: 3)
       click_button 'Create Conversation'
     end
   end

--- a/spec/support/better_together/devise_session_helpers.rb
+++ b/spec/support/better_together/devise_session_helpers.rb
@@ -27,6 +27,11 @@ module BetterTogether
       click_button 'Sign In'
     end
 
+    def sign_out_current_user
+      click_on 'Log Out'
+      Capybara.reset_session!
+    end
+
     def sign_up_new_user(token, email, password, person)
       visit new_user_registration_path(invitation_code: token, locale: I18n.default_locale)
       fill_in 'user[email]', with: email

--- a/spec/support/better_together/devise_session_helpers.rb
+++ b/spec/support/better_together/devise_session_helpers.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module DeviseSessionHelpers
+    include FactoryBot::Syntax::Methods
+    include Rails.application.routes.url_helpers
+    include BetterTogether::Engine.routes.url_helpers
+
+    def configure_host_platform
+      platform = build(:better_together_platform)
+      visit '/'
+      fill_in 'platform[name]', with: platform.name
+      fill_in 'platform[description]', with: platform.description
+      select 'Public', from: 'Privacy'
+      click_button 'Next Step'
+
+      setup_admin_user
+      BetterTogether::Platform.find_by(host: true)
+    end
+
+    def login_as_platform_manager
+      visit new_user_session_url(locale: I18n.default_locale)
+      fill_in 'user[email]', with: 'manager@example.test'
+      fill_in 'user[password]', with: 'password12345'
+      click_button 'Sign In'
+    end
+
+    def setup_admin_user
+      person = build(:better_together_person)
+      fill_in 'user[email]', with: 'manager@example.test'
+      fill_in 'user[password]', with: 'password12345'
+      fill_in 'user[password_confirmation]', with: 'password12345'
+      fill_in 'user[person_attributes][name]', with: person.name
+      fill_in 'user[person_attributes][identifier]', with: person.identifier
+      fill_in 'user[person_attributes][description]', with: person.description
+      click_button 'Finish Setup'
+
+      platform_manager = BetterTogether::User.find_by(email: 'manager@example.test')
+      platform_manager.confirm
+    end
+
+    def sign_in_user(email, password)
+      visit new_user_session_url(locale: I18n.default_locale)
+      fill_in 'user[email]', with: email
+      fill_in 'user[password]', with: password
+      click_button 'Sign In'
+    end
+
+    def sign_up_new_user(token, email, password, person)
+      visit new_user_registration_path(invitation_code: token, locale: I18n.default_locale)
+      fill_in 'user[email]', with: email
+      fill_in 'user[password]', with: password
+      fill_in 'user[password_confirmation]', with: password
+      fill_in 'user[person_attributes][name]', with: person.name
+      fill_in 'user[person_attributes][identifier]', with: person.identifier
+      fill_in 'user[person_attributes][description]', with: person.description
+      click_button 'Sign Up'
+
+      created_user = BetterTogether::User.find_by(email: email)
+      created_user.confirm
+    end
+  end
+end

--- a/spec/support/better_together/devise_session_helpers.rb
+++ b/spec/support/better_together/devise_session_helpers.rb
@@ -10,13 +10,14 @@ module BetterTogether
       host_platform = create(:better_together_platform, :host, privacy: 'public')
       wizard = BetterTogether::Wizard.find_or_create_by(identifier: 'host_setup')
       wizard.mark_completed
+      create(:user, :confirmed, :platform_manager,
+             email: 'manager@example.test',
+             password: 'password12345')
       host_platform
     end
 
     def login_as_platform_manager
-      user = create(:user, :confirmed, :platform_manager)
-      sign_in_user(user.email, user.password)
-      user
+      sign_in_user('manager@example.test', 'password12345')
     end
 
     def sign_in_user(email, password)

--- a/spec/support/better_together/devise_session_helpers.rb
+++ b/spec/support/better_together/devise_session_helpers.rb
@@ -21,7 +21,7 @@ module BetterTogether
 
     def sign_in_user(email, password)
       # Capybara.reset_session!
-      visit new_user_session_url(locale: I18n.default_locale)
+      visit new_user_session_path(locale: I18n.default_locale)
       fill_in 'user[email]', with: email
       fill_in 'user[password]', with: password
       click_button 'Sign In'

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,7 +5,7 @@ require 'tmpdir'
 
 Capybara.server = :puma, { Silent: true }
 
-Capybara.register_driver :selenium_headless_chrome do |app|
+Capybara.register_driver :selenium_chrome_headless do |app|
   options = Selenium::WebDriver::Options.chrome(
     args: %w[
       headless
@@ -25,4 +25,4 @@ Capybara.register_driver :selenium_headless_chrome do |app|
   )
 end
 
-Capybara.javascript_driver = :selenium_headless_chrome
+Capybara.javascript_driver = :selenium_chrome_headless


### PR DESCRIPTION
## Summary
This PR introduces end-to-end feature specs for Conversations and Invitations, expands spec support helpers, and stabilizes CI by wiring the test environment and master key. Minor model/factory tweaks and infra updates improve developer ergonomics and cross-platform builds.

## Key Changes

### Messaging & Conversations (Feature Specs)
- **Create conversation (platform manager)** — adds a feature spec that selects a participant, sets a title, and asserts the conversation record is created.
- **Restrict normal users** — verifies a non-manager cannot create conversations with private users.
- **Send message flow** — adds a JS feature spec that composes text in the `trix-editor`, sends it, and confirms the message appears in the conversation list.
- **Notification scheduling (TODO)** — a pending spec notes a race condition around enqueueing Noticed jobs for delayed emails.

### Invitations (Feature Specs)
- **Accept platform invitation (signup path)** — covers registering via invitation token and seeing a successful sign-in.
- **Create platform invitation (manager)** — exercises the modal flow to select invitation type/roles, set an email, and submit.

### Spec Support Helpers
- **`BetterTogether::ConversationHelpers`** — helper to open the new-conversation page, pick participants via Slim-Select, set a title, and submit.
- **`BetterTogether::DeviseSessionHelpers`** — utilities to configure a host platform, create/login a default platform manager, sign in/out users, and complete invitation-driven signup.

### Model & Factory Adjustments
- **`BetterTogether::User`** — removes `autosave: true` from the `has_one :person_identification` association (still using `class_name: 'BetterTogether::Identification'`).
- **People factory** — associates a `community` by default for `better_together_person`.
- **Users factory**
  - Generates `confirmation_token` via `Faker::Alphanumeric` instead of a hardcoded value.
  - Adds a `:platform_manager` trait to ensure the created user is a platform manager on the host platform.

### CI / Test Infrastructure
- **GitHub Actions** — sets `environment: test` for the `rspec` job and passes `RAILS_MASTER_KEY` from repository secrets to the test step.
- **Capybara** — standardizes driver naming to `:selenium_chrome_headless` and uses it for `javascript_driver`.
- **RSpec config** — includes `Devise::Test::IntegrationHelpers` (feature), `Warden::Test::Helpers`, and resets Warden after each example.
- **Docker Compose** — updates PostGIS image to `imresamu/postgis:17-recent` for a more current stack.
- **Gemfile.lock (platforms)** — adds ARM platforms (aarch64-linux, arm64-darwin-24), enabling native installs on Apple Silicon and ARM Linux.

## Notes
- A notification-timing spec is intentionally left commented with a TODO due to a known race condition; follow-up work will stabilize async event delivery assertions.


* AI-enhanced PR summary added by @rsmithlal 