### PR TITLE
Fix GitHub action Rails update

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -55,6 +55,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Disable Bundler frozen mode
+        run: bundle config set frozen false
       - name: Update Rails
         run: bundle update rails --conservative
       # Add or replace database setup steps here
@@ -77,6 +79,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - name: Disable Bundler frozen mode
+        run: bundle config set frozen false
       - name: Update Rails
         run: bundle update rails --conservative
       - name: Lint Ruby files with Rubocop
@@ -93,6 +97,8 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+      - name: Disable Bundler frozen mode
+        run: bundle config set frozen false
       - name: Update Rails
         run: bundle update rails --conservative
       - name: Generate binstubs


### PR DESCRIPTION
## Summary
- disable bundler frozen mode in rails CI job before updating gems

## Testing
- `bin/codex_style_guard` *(fails: No such file or directory)*
- `bin/ci` *(fails: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_688be92922a8832196fb67faaf7aa1df