### PR TITLE
fix: address deprecations

### DIFF
--- a/app/assets/config/better_together_manifest.js
+++ b/app/assets/config/better_together_manifest.js
@@ -4,6 +4,7 @@
 //= link_tree ../stylesheets .css
 //= link_tree ../../../vendor/stylesheets .css
 //= link_tree ../stylesheets .scss
+//= link better_together/mailer.css
 //= link_tree ../images
 
 //= link actioncable.js

--- a/app/assets/stylesheets/better_together/application.scss
+++ b/app/assets/stylesheets/better_together/application.scss
@@ -14,29 +14,29 @@
  *= require_self
  */
 
-@import 'theme';
+@use 'theme' as *;
 
 // Import Bootstrap and Font Awesome
 
-@import 'bootstrap';
-@import 'cards';
-@import 'devise';
-@import 'font-awesome';
-@import 'actiontext';
-@import 'contact_details';
-@import 'content_blocks';
-@import 'conversations';
-@import 'forms';
-@import 'image-galleries';
-@import 'maps';
-@import 'metrics';
-@import 'navigation';
-@import 'notifications';
-@import 'profiles';
-@import 'simple_calendar';
-@import 'share';
-@import 'sidebar_nav';
-@import 'trix-extensions/richtext';
+@use 'bootstrap' as *;
+@use 'cards';
+@use 'devise';
+@use 'font-awesome';
+@use 'actiontext';
+@use 'contact_details';
+@use 'content_blocks';
+@use 'conversations';
+@use 'forms';
+@use 'image-galleries';
+@use 'maps';
+@use 'metrics';
+@use 'navigation';
+@use 'notifications';
+@use 'profiles';
+@use 'simple_calendar';
+@use 'share';
+@use 'sidebar_nav';
+@use 'trix-extensions/richtext';
 
 // Styles that use the variables
 .text-opposite-theme {

--- a/app/assets/stylesheets/better_together/contact_details.scss
+++ b/app/assets/stylesheets/better_together/contact_details.scss
@@ -1,4 +1,4 @@
-@import 'theme';
+@use 'theme' as *;
 
 .contact-detail-item {
   margin-bottom: 15px;

--- a/app/assets/stylesheets/better_together/forms.scss
+++ b/app/assets/stylesheets/better_together/forms.scss
@@ -1,4 +1,4 @@
-@import "theme";
+@use "theme" as *;
 
 .required-indicator {
   color: $danger;

--- a/app/assets/stylesheets/better_together/share.scss
+++ b/app/assets/stylesheets/better_together/share.scss
@@ -1,5 +1,4 @@
-
-@import 'theme';
+@use 'theme' as *;
 
 .social-share-buttons {
   margin-top: 40px;

--- a/app/assets/stylesheets/better_together/sidebar_nav.scss
+++ b/app/assets/stylesheets/better_together/sidebar_nav.scss
@@ -1,4 +1,4 @@
-@import 'theme';
+@use 'theme' as *;
 
 #sidebar_nav {
   // Sidebar heading styles

--- a/app/assets/stylesheets/better_together/theme.scss
+++ b/app/assets/stylesheets/better_together/theme.scss
@@ -1,6 +1,6 @@
-@use "bootstrap/functions" as *;
-@use "bootstrap/mixins" as *;
-@use "bootstrap/variables" as *;
+@import "bootstrap/functions";
+@import "bootstrap/mixins";
+@import "bootstrap/variables";
 
 // Define default color variables (if not overridden by the host app)
 $text-opposite-theme-color: #333 !default;

--- a/app/assets/stylesheets/better_together/theme.scss
+++ b/app/assets/stylesheets/better_together/theme.scss
@@ -1,6 +1,6 @@
-@import "bootstrap/functions";
-@import "bootstrap/mixins";
-@import "bootstrap/variables";
+@use "bootstrap/functions" as *;
+@use "bootstrap/mixins" as *;
+@use "bootstrap/variables" as *;
 
 // Define default color variables (if not overridden by the host app)
 $text-opposite-theme-color: #333 !default;

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -23,7 +23,8 @@ module Dummy
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
-    config.active_storage.replace_on_assign_to_many = true
+    # Use the latest cache format and remove deprecated Active Storage setting
+    config.active_support.cache_format_version = 7.1
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   config.after { Warden.test_reset! }
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.fixture_paths = [Rails.root.join('spec/fixtures')]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
## Summary
- remove deprecated Active Storage config
- move stylesheets to modern Sass `@use`
- adopt Rails 7.1 cache serialization format

## Testing
- `bin/codex_style_guard`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bundle exec rspec` *(fails: Missing Active Record encryption credential; 359 examples, 11 failures)*

------
https://chatgpt.com/codex/tasks/task_e_68913cc354c48321b7aaeec157a857b0