### PR TITLE
Fix BetterTogether notifier unread count spec

### DIFF
--- a/spec/notifiers/better_together/new_message_notifier_spec.rb
+++ b/spec/notifiers/better_together/new_message_notifier_spec.rb
@@ -42,7 +42,7 @@ module BetterTogether
     end
 
     it 'includes unread notification count in message' do
-      unread = double('Unread', size: 2)
+      unread = double('Unread', count: 2)
       allow(recipient).to receive(:notifications).and_return(double('Notifications', unread: unread))
       result = notifier.send(:build_message, notification)
       expect(result[:unread_count]).to eq(2)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,7 @@ RSpec.configure do |config|
   config.after { Warden.test_reset! }
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.fixture_paths = [Rails.root.join('spec/fixtures')]
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
## Summary
- adjust new message notifier spec to use count
- switch Rails test fixture configuration to new `fixture_paths` array

## Testing
- `bin/codex_style_guard`
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bundle exec rspec` *(fails: 366 examples, 8 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689152b4aac483219eab98e6ae7a0526