### PR TITLE
Add hub index view spec

### DIFF
--- a/spec/views/better_together/hub/index.html.erb_spec.rb
+++ b/spec/views/better_together/hub/index.html.erb_spec.rb
@@ -3,5 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'hub/index.html.erb', type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it 'renders the page title' do
+    assign(:activities, [])
+    render
+
+    expect(rendered).to include('Community Hub')
+  end
 end


### PR DESCRIPTION
## Summary
- replace pending hub index view example with real expectation

## Testing
- `bundle exec rspec spec/views/better_together/hub/index.html.erb_spec.rb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886d1ccfb488321a246ac2ea278c992