### PR TITLE
Fix autoload path mutation for Rails 8 compatibility

### DIFF
--- a/app/models/concerns/better_together/privacy.rb
+++ b/app/models/concerns/better_together/privacy.rb
@@ -14,8 +14,7 @@ module BetterTogether
       include ::TranslateEnum
 
       attribute :privacy, :string
-      enum privacy: PRIVACY_LEVELS,
-           _prefix: :privacy
+      enum :privacy, PRIVACY_LEVELS, prefix: :privacy
 
       translate_enum :privacy
 

--- a/lib/better_together/engine.rb
+++ b/lib/better_together/engine.rb
@@ -44,7 +44,7 @@ module BetterTogether
     isolate_namespace BetterTogether
 
     # Avoid modifying frozen autoload path arrays (Rails 8 compatibility)
-    config.autoload_paths = Dir["#{root}/lib/better_together/**/"] + config.autoload_paths.to_a
+    config.autoload_paths = Array(config.autoload_paths) + Dir["#{root}/lib/better_together/**/"]
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid
@@ -82,8 +82,9 @@ module BetterTogether
     initializer 'better_together.action_mailer' do |app|
       if Rails.env.development?
         app.config.action_mailer.show_previews = true
-        app.config.action_mailer.preview_paths = app.config.action_mailer.preview_paths +
-                                                 [BetterTogether::Engine.root.join('spec/mailers/previews')]
+        app.config.action_mailer.preview_paths =
+          app.config.action_mailer.preview_paths.to_a +
+          [BetterTogether::Engine.root.join('spec/mailers/previews')]
       else
         app.config.action_mailer.show_previews = false
       end
@@ -92,12 +93,15 @@ module BetterTogether
     # Add engine manifest to precompile assets in production
     initializer 'better_together.assets' do |app|
       # Ensure we are not modifying frozen arrays
-      app.config.assets.precompile += %w[better_together_manifest.js]
-      app.config.assets.paths = [root.join('app', 'assets', 'images'),
-                                 root.join('app', 'javascript'),
-                                 root.join('vendor', 'javascript'),
-                                 root.join('vendor', 'stylesheets'),
-                                 root.join('vendor', 'javascripts')] + app.config.assets.paths.to_a
+      app.config.assets.precompile =
+        app.config.assets.precompile.to_a + %w[better_together_manifest.js]
+      app.config.assets.paths =
+        app.config.assets.paths.to_a +
+        [root.join('app', 'assets', 'images'),
+         root.join('app', 'javascript'),
+         root.join('vendor', 'javascript'),
+         root.join('vendor', 'stylesheets'),
+         root.join('vendor', 'javascripts')]
     end
 
     initializer 'better_together.i18n' do |app|
@@ -108,9 +112,11 @@ module BetterTogether
 
     initializer 'better_together.importmap', before: 'importmap' do |app|
       # Ensure we are not modifying frozen arrays
-      app.config.importmap.paths = [Engine.root.join('config/importmap.rb')] + app.config.importmap.paths.to_a
-      app.config.importmap.cache_sweepers = [root.join('app/assets/javascripts'),
-                                             root.join('app/javascript')] + app.config.importmap.cache_sweepers.to_a
+      app.config.importmap.paths =
+        app.config.importmap.paths.to_a + [Engine.root.join('config/importmap.rb')]
+      app.config.importmap.cache_sweepers =
+        app.config.importmap.cache_sweepers.to_a +
+        [root.join('app/assets/javascripts'), root.join('app/javascript')]
     end
 
     initializer 'better_together.importmap.pins', after: 'importmap' do |app|

--- a/lib/better_together/engine.rb
+++ b/lib/better_together/engine.rb
@@ -43,7 +43,8 @@ module BetterTogether
     engine_name 'better_together'
     isolate_namespace BetterTogether
 
-    config.autoload_paths += Dir["#{config.root}/lib/better_together/**/"]
+    # Avoid modifying frozen autoload path arrays (Rails 8 compatibility)
+    config.autoload_paths = Dir["#{root}/lib/better_together/**/"] + config.autoload_paths.to_a
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid


### PR DESCRIPTION
## Summary
- prevent autoload path mutation in engine to avoid Rails 8 FrozenError

## Testing
- `bin/ci` *(fails: ActiveRecord::ConnectionNotEstablished: connection to server at "::1", port 5432 failed: Connection refused)*
- `bin/codex_style_guard`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`


------
https://chatgpt.com/codex/tasks/task_e_68926fe5069083219e22dd49073e17f7