### PR TITLE
Add user blocking, reporting, and block-filter scope

### DIFF
--- a/app/controllers/better_together/person_blocks_controller.rb
+++ b/app/controllers/better_together/person_blocks_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  class PersonBlocksController < ApplicationController # rubocop:todo Style/Documentation
+    before_action :set_person_block, only: :destroy
+    after_action :verify_authorized
+
+    def index
+      authorize PersonBlock
+      @blocked_people = current_person.blocked_people
+    end
+
+    def create
+      @person_block = current_person.person_blocks.new(person_block_params)
+      authorize @person_block
+
+      if @person_block.save
+        redirect_to blocks_path, notice: 'Person was successfully blocked.'
+      else
+        redirect_to blocks_path, alert: @person_block.errors.full_messages.to_sentence
+      end
+    end
+
+    def destroy
+      authorize @person_block
+      @person_block.destroy
+      redirect_to blocks_path, notice: 'Person was successfully unblocked.'
+    end
+
+    private
+
+    def current_person
+      current_user.person
+    end
+
+    def set_person_block
+      @person_block = current_person.person_blocks.find(params[:id])
+    end
+
+    def person_block_params
+      params.require(:person_block).permit(:blocked_id)
+    end
+  end
+end

--- a/app/controllers/better_together/reports_controller.rb
+++ b/app/controllers/better_together/reports_controller.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  class ReportsController < ApplicationController # rubocop:todo Style/Documentation
+    after_action :verify_authorized
+
+    def create
+      @report = current_person.reports_made.new(report_params)
+      authorize @report
+
+      if @report.save
+        redirect_back fallback_location: root_path, notice: 'Report was successfully submitted.'
+      else
+        redirect_back fallback_location: root_path, alert: @report.errors.full_messages.to_sentence
+      end
+    end
+
+    private
+
+    def current_person
+      current_user.person
+    end
+
+    def report_params
+      params.require(:report).permit(:reportable_id, :reportable_type, :reason)
+    end
+  end
+end

--- a/app/models/better_together/person.rb
+++ b/app/models/better_together/person.rb
@@ -27,6 +27,14 @@ module BetterTogether
     has_many :conversations, through: :conversation_participants
     has_many :created_conversations, as: :creator, class_name: 'BetterTogether::Conversation', dependent: :destroy
 
+    has_many :person_blocks, foreign_key: :blocker_id, dependent: :destroy, class_name: 'BetterTogether::PersonBlock'
+    has_many :blocked_people, through: :person_blocks, source: :blocked
+    has_many :blocked_by_person_blocks, foreign_key: :blocked_id, dependent: :destroy, class_name: 'BetterTogether::PersonBlock'
+    has_many :blockers, through: :blocked_by_person_blocks, source: :blocker
+
+    has_many :reports_made, foreign_key: :reporter_id, class_name: 'BetterTogether::Report', dependent: :destroy
+    has_many :reports_received, as: :reportable, class_name: 'BetterTogether::Report', dependent: :destroy
+
     has_many :notifications, as: :recipient, dependent: :destroy, class_name: 'Noticed::Notification'
     has_many :notification_mentions, as: :record, dependent: :destroy, class_name: 'Noticed::Event'
 

--- a/app/models/better_together/person_block.rb
+++ b/app/models/better_together/person_block.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  # Join model tracking which people block other people
+  class PersonBlock < ApplicationRecord
+    belongs_to :blocker, class_name: 'BetterTogether::Person'
+    belongs_to :blocked, class_name: 'BetterTogether::Person'
+
+    validates :blocked_id, uniqueness: { scope: :blocker_id }
+    validate :not_self
+    validate :blocked_not_platform_manager
+
+    private
+
+    def not_self
+      errors.add(:blocked_id, 'cannot block yourself') if blocker_id == blocked_id
+    end
+
+    def blocked_not_platform_manager
+      return unless blocked&.permitted_to?('manage_platform')
+
+      errors.add(:blocked, 'cannot be a platform manager')
+    end
+  end
+end

--- a/app/models/better_together/post.rb
+++ b/app/models/better_together/post.rb
@@ -4,6 +4,7 @@ module BetterTogether
   # Represents a blog post
   class Post < ApplicationRecord
     include Authorable
+    include BlockFilterable
     include FriendlySlug
     include Categorizable
     include Identifier

--- a/app/models/better_together/report.rb
+++ b/app/models/better_together/report.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  # Record of a person reporting inappropriate content or users
+  class Report < ApplicationRecord
+    belongs_to :reporter, class_name: 'BetterTogether::Person'
+    belongs_to :reportable, polymorphic: true
+
+    validates :reason, presence: true
+  end
+end

--- a/app/models/concerns/better_together/block_filterable.rb
+++ b/app/models/concerns/better_together/block_filterable.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  # Adds a scope to filter out records authored by people blocked by the given person
+  module BlockFilterable
+    extend ActiveSupport::Concern
+
+    included do
+      scope :excluding_blocked_for, lambda { |person|
+        next all unless person
+
+        blocked_ids = person.blocked_people.select(:id)
+        joins(:authorships).where.not(better_together_authorships: { author_id: blocked_ids }).distinct
+      }
+    end
+  end
+end

--- a/app/policies/better_together/person_block_policy.rb
+++ b/app/policies/better_together/person_block_policy.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  class PersonBlockPolicy < ApplicationPolicy # rubocop:todo Style/Documentation
+    def index?
+      user.present?
+    end
+
+    def create?
+      user.present? && record.blocker == agent && !record.blocked.permitted_to?('manage_platform')
+    end
+
+    def destroy?
+      user.present? && record.blocker == agent
+    end
+
+    class Scope < Scope # rubocop:todo Style/Documentation
+      def resolve
+        scope.where(blocker: agent)
+      end
+    end
+  end
+end

--- a/app/policies/better_together/report_policy.rb
+++ b/app/policies/better_together/report_policy.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  class ReportPolicy < ApplicationPolicy # rubocop:todo Style/Documentation
+    def create?
+      user.present? && record.reporter == agent && record.reporter != record.reportable
+    end
+  end
+end

--- a/app/views/better_together/person_blocks/index.html.erb
+++ b/app/views/better_together/person_blocks/index.html.erb
@@ -1,0 +1,6 @@
+<h1>Blocked People</h1>
+<ul>
+  <% @blocked_people.each do |person| %>
+    <li id="<%= dom_id(person) %>"><%= person.name %></li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,9 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
           end
         end
 
+        resources :person_blocks, path: :blocks, only: %i[index create destroy]
+        resources :reports, only: [:create]
+
         resources :maps, module: :geography
 
         scope path: :p do

--- a/db/migrate/20250710120000_create_better_together_person_blocks.rb
+++ b/db/migrate/20250710120000_create_better_together_person_blocks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Creates table to track blocks between people
+class CreateBetterTogetherPersonBlocks < ActiveRecord::Migration[7.0]
+  def change
+    create_bt_table :person_blocks do |t|
+      t.references :blocker, null: false, type: :uuid, foreign_key: { to_table: :better_together_people }
+      t.references :blocked, null: false, type: :uuid, foreign_key: { to_table: :better_together_people }
+
+      t.index %i[blocker_id blocked_id], unique: true
+    end
+  end
+end

--- a/db/migrate/20250710121000_create_better_together_reports.rb
+++ b/db/migrate/20250710121000_create_better_together_reports.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Creates reports for flagged content or users
+class CreateBetterTogetherReports < ActiveRecord::Migration[7.0]
+  def change
+    create_bt_table :reports do |t|
+      t.references :reporter, null: false, type: :uuid, foreign_key: { to_table: :better_together_people }
+      t.uuid :reportable_id, null: false
+      t.string :reportable_type, null: false
+      t.text :reason
+    end
+  end
+end

--- a/spec/factories/better_together/person_blocks.rb
+++ b/spec/factories/better_together/person_blocks.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  FactoryBot.define do
+    factory :person_block, class: PersonBlock do
+      association :blocker, factory: :better_together_person
+      association :blocked, factory: :better_together_person
+    end
+  end
+end

--- a/spec/factories/better_together/posts.rb
+++ b/spec/factories/better_together/posts.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  FactoryBot.define do
+    factory :better_together_post, class: Post, aliases: [:post] do
+      id { SecureRandom.uuid }
+      title { 'Sample Post' }
+      content { 'Post content' }
+
+      transient do
+        author { create(:better_together_person) }
+      end
+
+      after(:build) do |post, evaluator|
+        post.authorships.build(author: evaluator.author)
+      end
+    end
+  end
+end

--- a/spec/factories/better_together/reports.rb
+++ b/spec/factories/better_together/reports.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  FactoryBot.define do
+    factory :report, class: Report do
+      association :reporter, factory: :better_together_person
+      association :reportable, factory: :better_together_person
+      reason { 'Inappropriate behaviour' }
+    end
+  end
+end

--- a/spec/models/better_together/block_filterable_spec.rb
+++ b/spec/models/better_together/block_filterable_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BetterTogether::BlockFilterable, type: :model do
+  let(:person) { create(:better_together_person) }
+  let(:blocked_person) { create(:better_together_person) }
+  let!(:post_by_blocked) { create(:better_together_post, author: blocked_person) }
+  let!(:post_by_other) { create(:better_together_post) }
+
+  before do
+    BetterTogether::PersonBlock.create!(blocker: person, blocked: blocked_person)
+  end
+
+  it 'filters out posts from blocked people' do
+    results = BetterTogether::Post.excluding_blocked_for(person)
+    expect(results).to include(post_by_other)
+    expect(results).not_to include(post_by_blocked)
+  end
+end

--- a/spec/models/better_together/person_block_spec.rb
+++ b/spec/models/better_together/person_block_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BetterTogether::PersonBlock, type: :model do
+  let(:blocker) { create(:better_together_person) }
+  let(:blocked) { create(:better_together_person) }
+
+  it 'allows a person to block another person' do
+    block = described_class.create(blocker:, blocked:)
+    expect(block).to be_persisted
+    expect(blocker.blocked_people).to include(blocked)
+  end
+
+  it 'does not allow blocking platform managers' do
+    platform = create(:platform)
+    role = create(:better_together_role, identifier: 'platform_manager', resource_type: 'BetterTogether::Platform')
+    BetterTogether::PersonPlatformMembership.create!(member: blocked, joinable: platform, role:)
+
+    block = described_class.new(blocker:, blocked:)
+    expect(block).not_to be_valid
+    expect(block.errors[:blocked]).to include('cannot be a platform manager')
+  end
+end

--- a/spec/models/better_together/report_spec.rb
+++ b/spec/models/better_together/report_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BetterTogether::Report, type: :model do
+  it 'requires a reason' do
+    report = described_class.new
+    expect(report).not_to be_valid
+    expect(report.errors[:reason]).to include("can't be blank")
+  end
+
+  it 'allows a person to report another person' do
+    reporter = create(:better_together_person)
+    reported = create(:better_together_person)
+    report = described_class.create(reporter:, reportable: reported, reason: 'spam')
+    expect(report).to be_persisted
+  end
+end


### PR DESCRIPTION
## Summary
- add `PersonBlock` and associations for managing block lists
- add reporting model/controller and routes to submit user reports
- add `BlockFilterable` concern and apply to posts to hide blocked authors

## Testing
- `bundle exec bin/codex_style_guard`
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bin/ci` *(0 examples)*
- `bundle exec rspec` *(fails: Selenium manager cannot download Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68927abc1a64832180846fca30b88617