### PR TITLE
Internationalize navigation management views

### DIFF
--- a/app/views/better_together/navigation_areas/edit.html.erb
+++ b/app/views/better_together/navigation_areas/edit.html.erb
@@ -1,7 +1,7 @@
 <!-- app/views/better_together/navigation_areas/edit.html.erb -->
 
 <div class="container">
-  <h1>Edit Navigation Area</h1>
+  <h1><%= t('better_together.navigation_areas.edit.title') %></h1>
   <%= render 'form', navigation_area: @navigation_area %>
-  <%= link_to 'Back', navigation_areas_path, class: 'btn btn-secondary' %>
+  <%= link_to t('shared.links.back'), navigation_areas_path, class: 'btn btn-secondary' %>
 </div>

--- a/app/views/better_together/navigation_areas/new.html.erb
+++ b/app/views/better_together/navigation_areas/new.html.erb
@@ -1,7 +1,7 @@
 <!-- app/views/better_together/navigation_areas/new.html.erb -->
 
 <div class="container">
-  <h1>New Navigation Area</h1>
+  <h1><%= t('better_together.navigation_areas.new.title') %></h1>
   <%= render 'form', navigation_area: @navigation_area %>
-  <%= link_to 'Back', navigation_areas_path, class: 'btn btn-secondary' %>
+  <%= link_to t('shared.links.back'), navigation_areas_path, class: 'btn btn-secondary' %>
 </div>

--- a/app/views/better_together/navigation_items/_form.html.erb
+++ b/app/views/better_together/navigation_items/_form.html.erb
@@ -31,7 +31,7 @@
     <%= form.hidden_field :navigation_area_id, value: @navigation_area.id %>
 
     <div class="mb-3">
-      <%= form.label :parent_id, 'Parent Item' %>
+      <%= form.label :parent_id, t('better_together.navigation_items.form.parent_item') %>
       <%= form.collection_select :parent_id, available_parent_items, :id, :select_option_title, { include_blank: true }, { class: 'form-select' + (@navigation_item.errors[:parent_id].any? ? ' is-invalid' : ''), data: { controller: "better_together--slim-select" } } %>
       <% if @navigation_item.errors[:parent_id].any? %>
         <div class="invalid-feedback">
@@ -52,7 +52,7 @@
 
     <!-- Control field for linkable_id -->
     <div id="nav-item-linkable" class="bt-mb-3" data-better_together--dependent-fields-target="dependentField" data-dependent-fields-control="navigation_item_route_name" data-show-if-control_navigation_item_route_name="*not_present*">
-      <%= form.label :linkable_id, 'Link to Page' %>
+      <%= form.label :linkable_id, t('better_together.navigation_items.form.link_to_page') %>
       <%= form.collection_select :linkable_id, @pages, :id, :select_option_title, { include_blank: true }, { id: 'navigation_item_linkable_id', class: ('form-select' + (@navigation_item.errors[:linkable_id].any? ? ' is-invalid' : '')), data: { controller: "better_together--slim-select" }, 'data-better_together--dependent-fields-target' => "controlField" } %>
       <% if @navigation_item.errors[:linkable_id].any? %>
         <div class="invalid-feedback">
@@ -64,12 +64,12 @@
     <!-- Dependent field 1 (shown when no value is present) -->
     <div id="nav-item-title" class="bt-mb-3" data-better_together--dependent-fields-target="dependentField" data-dependent-fields-control="navigation_item_linkable_id" data-show-if-control_navigation_item_linkable_id="*not_present*">
       <%= render partial: 'better_together/shared/translated_string_field', locals: { model: navigation_item, form: form, attribute: 'title' } %>
-      <small class="form-text text-muted mt-2">Enter the nav item title.</small> <!-- Help text added here -->
+      <small class="form-text text-muted mt-2"><%= t('better_together.navigation_items.form.enter_nav_item_title') %></small> <!-- Help text added here -->
     </div>
 
     <!-- Dependent field 2 (shown when no value is present) -->
     <div id="nav-item-route-name" class="bt-mb-3" data-better_together--dependent-fields-target="dependentField" data-dependent-fields-control="navigation_item_linkable_id" data-show-if-control_navigation_item_linkable_id="*not_present*">
-      <%= form.label :route_name, "Dynamic Route" %>
+      <%= form.label :route_name, t('better_together.navigation_items.form.dynamic_route') %>
       <%= form.select :route_name, route_names_for_select(@navigation_item), { include_blank: true }, { id: 'navigation_item_route_name', class: 'form-select', 'data-better_together--dependent-fields-target' => "controlField", data: { controller: "better_together--slim-select" } } %>
       <% if @navigation_item.errors[:linkable_id].any? %>
         <div class="invalid-feedback">

--- a/app/views/better_together/navigation_items/edit.html.erb
+++ b/app/views/better_together/navigation_items/edit.html.erb
@@ -1,7 +1,7 @@
 <!-- app/views/better_together/navigation_items/edit.html.erb -->
 
 <div class="container my-3">
-  <h1>Edit Navigation Item: <%= @navigation_item.title %></h1>
+  <h1><%= t('better_together.navigation_items.edit.title', title: @navigation_item.title) %></h1>
 
   <%= render 'form', navigation_area: @navigation_area, navigation_item: @navigation_item, pages: @pages %>
 </div>

--- a/app/views/better_together/navigation_items/index.html.erb
+++ b/app/views/better_together/navigation_items/index.html.erb
@@ -1,12 +1,12 @@
 <!-- app/views/better_together/navigation_items/index.html.erb -->
 
 <% content_for :page_title do %>
-  Navigation Items for <%= @navigation_area.name %>
+  <%= t('better_together.navigation_items.index.title', name: @navigation_area.name) %>
 <% end %>
 
 <div class="container my-3">
-  <h1>Navigation Items for <%= @navigation_area.name %></h1>
-  <%= link_to 'New Navigation Item', new_navigation_area_navigation_item_path(@navigation_area), class: 'btn btn-primary' %>
+  <h1><%= t('better_together.navigation_items.index.title', name: @navigation_area.name) %></h1>
+  <%= link_to t('better_together.navigation_items.index.new_navigation_item'), new_navigation_area_navigation_item_path(@navigation_area), class: 'btn btn-primary' %>
 
   <%= render partial: 'navigation_items_table', locals: { navigation_items: @navigation_items } %>
 </div>

--- a/app/views/better_together/navigation_items/new.html.erb
+++ b/app/views/better_together/navigation_items/new.html.erb
@@ -1,7 +1,7 @@
 <!-- app/views/better_together/navigation_items/new.html.erb -->
 
 <div class="container my-3">
-  <h1>New Navigation Item for <%= @navigation_area.name %></h1>
+  <h1><%= t('better_together.navigation_items.new.title', name: @navigation_area.name) %></h1>
 
   <%= render 'form', navigation_area: @navigation_area, navigation_item: @navigation_item, page: @pages %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -768,7 +768,23 @@ en:
         new_navigation_area: New navigation area
       show:
         new_navigation_item: New navigation item
+      new:
+        title: New Navigation Area
+      edit:
+        title: Edit Navigation Area
     navigation_items:
+      index:
+        title: "Navigation Items for %{name}"
+        new_navigation_item: New Navigation Item
+      new:
+        title: "New Navigation Item for %{name}"
+      edit:
+        title: "Edit Navigation Item: %{title}"
+      form:
+        parent_item: Parent Item
+        link_to_page: Link to Page
+        enter_nav_item_title: Enter the nav item title.
+        dynamic_route: Dynamic Route
       route_names:
         calendars: Calendars
         calls_for_interest: Calls for Interest

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -771,16 +771,32 @@ es:
         new_navigation_area: Nueva área de navegación
       show:
         new_navigation_item: Nuevo elemento de navegación
+      new:
+        title: Nueva área de navegación
+      edit:
+        title: Editar área de navegación
     navigation_items:
+      index:
+        title: "Elementos de navegación para %{name}"
+        new_navigation_item: Nuevo elemento de navegación
+      new:
+        title: "Nuevo elemento de navegación para %{name}"
+      edit:
+        title: "Editar elemento de navegación: %{title}"
+      form:
+        parent_item: Elemento padre
+        link_to_page: Enlace a la página
+        enter_nav_item_title: Ingrese el título del elemento de navegación.
+        dynamic_route: Ruta dinámica
       route_names:
-        calendars: Calendars
-        calls_for_interest: Calls for Interest
+        calendars: Calendarios
+        calls_for_interest: Convocatorias de interés
         communities: Comunidades
         content_blocks: Bloques de contenido
-        events: Events
+        events: Eventos
         geography_continents: Continentes
         geography_countries: Países
-        geography_maps: Maps
+        geography_maps: Mapas
         geography_regions: Regiones
         geography_settlements: Asentamientos
         geography_states: Estados

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -774,16 +774,32 @@ fr:
         new_navigation_area: Nouvelle zone de navigation
       show:
         new_navigation_item: Nouvel élément de navigation
+      new:
+        title: Nouvelle zone de navigation
+      edit:
+        title: Modifier la zone de navigation
     navigation_items:
+      index:
+        title: "Éléments de navigation pour %{name}"
+        new_navigation_item: Nouvel élément de navigation
+      new:
+        title: "Nouvel élément de navigation pour %{name}"
+      edit:
+        title: "Modifier l'élément de navigation : %{title}"
+      form:
+        parent_item: Élément parent
+        link_to_page: Lien vers la page
+        enter_nav_item_title: Saisissez le titre de l'élément de navigation.
+        dynamic_route: Route dynamique
       route_names:
-        calendars: Calendars
-        calls_for_interest: Calls for Interest
+        calendars: Calendriers
+        calls_for_interest: Appels à intérêt
         communities: Communautés
         content_blocks: Blocs de contenu
-        events: Events
+        events: Événements
         geography_continents: Continents
         geography_countries: Pays
-        geography_maps: Maps
+        geography_maps: Cartes
         geography_regions: Régions
         geography_settlements: Implantations
         geography_states: États


### PR DESCRIPTION
## Summary
- replace hardcoded navigation area and item strings with I18n keys
- add English, French, and Spanish translations for navigation views and fields
- translate remaining French and Spanish navigation item route names

## Testing
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_6894cc51c55c8321a32906a6145250a1