### PR TITLE
Add Stimulus auto-read for notifications and live counts

### DIFF
--- a/app/javascript/controllers/better_together/notifications_controller.js
+++ b/app/javascript/controllers/better_together/notifications_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from "@hotwired/stimulus"
+import { updateUnreadNotifications } from "better_together/notifications"
+
+// Marks a notification as read when it enters the viewport or is clicked
+export default class extends Controller {
+  static values = { markReadUrl: String }
+
+  connect() {
+    this.markAsRead = this.markAsRead.bind(this)
+    this.observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          this.markAsRead()
+        }
+      })
+    }, { threshold: 0.5 })
+    this.observer.observe(this.element)
+    this.element.addEventListener("click", this.markAsRead)
+  }
+
+  disconnect() {
+    if (this.observer) this.observer.disconnect()
+    this.element.removeEventListener("click", this.markAsRead)
+  }
+
+  markAsRead(event) {
+    if (this.marked) return
+    this.marked = true
+
+    const link = event?.target.closest("a")
+    if (link) event.preventDefault()
+
+    fetch(this.markReadUrlValue, {
+      method: "PATCH",
+      headers: {
+        "X-CSRF-Token": document.querySelector('meta[name="csrf-token"]').content,
+        "Accept": "application/json",
+      },
+    })
+      .then((response) => response.json())
+      .then((data) => {
+        this.element.classList.remove("list-group-item-action")
+        const badge = this.element.querySelector(".badge")
+        if (badge) badge.remove()
+        if (data.unread_count !== undefined) {
+          updateUnreadNotifications(data.unread_count)
+          const counter = document.getElementById("notifications_unread_count")
+          if (counter) counter.textContent = data.unread_count
+        }
+        if (link) { window.location = link.href }
+      })
+      .catch(() => { this.marked = false })
+  }
+}
+

--- a/app/views/better_together/notifications/_notification.html.erb
+++ b/app/views/better_together/notifications/_notification.html.erb
@@ -1,5 +1,8 @@
 <!-- app/views/better_together/notifications/_notification.html.erb -->
-<div id="<%= dom_id(notification) %>" class="notification list-group-item rounded-0 p-3 <%= 'list-group-item-action' unless notification.read_at %>" data-controller="better_together--notification" data-notification-mark-read-url-value="<%= mark_as_read_notification_path(notification) %>">
+<div id="<%= dom_id(notification) %>"
+     class="notification list-group-item rounded-0 p-3 <%= 'list-group-item-action' unless notification.read_at %>"
+     data-controller="better_together--notifications"
+     data-notifications-mark-read-url-value="<%= mark_as_read_notification_path(notification) %>">
   <div class="d-flex justify-content-between">
     <h6 class="mb-1">
       <% if notification_url.present? %>
@@ -14,7 +17,6 @@
   <div class="d-flex justify-content-between align-items-center mt-2">
     <% unless notification.read_at %>
       <span class="badge bg-success"><%= t('better_together.notifications.new') %></span>
-      <%= button_to t('better_together.notifications.mark_as_read'), mark_as_read_notification_path(notification), method: :post, class: 'btn btn-sm btn-outline-secondary', data: { turbo_stream: true } %>
     <% end %>
   </div>
 </div>

--- a/app/views/better_together/notifications/_notifications.html.erb
+++ b/app/views/better_together/notifications/_notifications.html.erb
@@ -1,5 +1,10 @@
 <div id="notifications">
-  <%= button_to t('better_together.notifications.mark_all_as_read'), mark_all_as_read_notifications_path, method: :post, class: 'btn btn-primary mb-3', id: 'mark_notifications_read', data: { turbo_stream: true } if unread_count > 0 %>
+  <%= button_to t('better_together.notifications.mark_all_as_read'),
+                mark_all_as_read_notifications_path,
+                method: :patch,
+                class: 'btn btn-primary mb-3',
+                id: 'mark_notifications_read',
+                data: { turbo_stream: true } if unread_count > 0 %>
 
   <% notifications.each do |notification| %>
     <%= render notification if notification.record.present? %>

--- a/app/views/better_together/notifications/index.html.erb
+++ b/app/views/better_together/notifications/index.html.erb
@@ -1,6 +1,9 @@
 <!-- app/views/notifications/index.html.erb -->
 <div class="container my-3">
-  <h1 class="mb-4"><%= t('.notifications') %></h1>
+  <h1 class="mb-4">
+    <%= t('.notifications') %>
+    (<span id="notifications_unread_count"><%= @unread_count %></span>)
+  </h1>
   <% if @notifications.any? %>
     <div class="list-group">
       <%= render partial: 'better_together/notifications/notifications', locals: { notifications: @notifications, unread_count: @unread_count } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,12 +51,12 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
 
         resources :notifications, only: %i[index] do
           member do
-            post :mark_as_read
+            patch :mark_as_read
           end
 
           collection do
-            post :mark_all_as_read, to: 'notifications#mark_as_read'
-            post :mark_record_as_read, to: 'notifications#mark_as_read'
+            patch :mark_all_as_read, to: 'notifications#mark_as_read'
+            patch :mark_record_as_read, to: 'notifications#mark_as_read'
           end
         end
 

--- a/spec/system/notifications_mark_as_read_spec.rb
+++ b/spec/system/notifications_mark_as_read_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'notifications', type: :system do
+  include BetterTogether::DeviseSessionHelpers
+
+  before do
+    driven_by(:selenium_chrome_headless)
+    configure_host_platform
+    login_as_platform_manager
+  end
+
+  it 'marks notifications as read without reloading and updates counts', :js do
+    user = BetterTogether::User.find_by(email: 'manager@example.test')
+    conversation = create(:conversation)
+    create(:conversation_participant, conversation:, person: user.person)
+    other = create(:user, :confirmed)
+    create(:conversation_participant, conversation:, person: other.person)
+    create_list(:message, 2, conversation:, person: other.person)
+
+    visit notifications_path(locale: I18n.default_locale)
+
+    expect(page).to have_css('#notifications_unread_count', text: '1')
+    expect(page).to have_css('#person_notification_count', text: '1')
+    expect(page).to have_css('.notification .badge', count: 1)
+
+    all('.notification').last.click
+
+    expect(page).to have_css('#notifications_unread_count', text: '0')
+    expect(page).to have_no_css('#person_notification_count')
+    expect(page).to have_no_css('.notification .badge')
+  end
+end


### PR DESCRIPTION
## Summary
- Mark notifications as read via Stimulus controller when viewed or clicked
- Serve `mark_as_read` with Turbo Stream/JSON responses and PATCH routes
- Update notifications UI for dynamic unread counts and add system spec

## Testing
- `bundle exec bundler-audit --update` *(fails: command not found)*
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec brakeman -q -w2` *(fails: command not found)*
- `bin/codex_style_guard` *(fails: command not found)*
- `bin/ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a50d60b308321a0f07f54ff84677d