### PR TITLE
Fix table prefix for Joatu models

### DIFF
--- a/app/models/better_together/joatu.rb
+++ b/app/models/better_together/joatu.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu # rubocop:todo Style/Documentation
+    def self.table_name_prefix
+      'better_together_joatu_'
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- ensure Joatu models use better_together_joatu_ table prefix

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost/community_engine_test bin/ci`
- `DATABASE_URL=postgres://postgres:postgres@localhost/community_engine_test bundle exec rspec spec/models/better_together/joatu`
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bin/codex_style_guard`


------
https://chatgpt.com/codex/tasks/task_e_689a4e47ba2c8321a1f5eae21fa22a89