### PR TITLE
Add form field helper and refactor form views

### DIFF
--- a/app/helpers/form_field_helper.rb
+++ b/app/helpers/form_field_helper.rb
@@ -12,19 +12,19 @@ module FormFieldHelper
   #   custom label string
   # @param wrapper_class [String,nil] CSS classes for the wrapper div. Pass nil
   #   to skip the wrapper.
-  # @param class [String] base CSS classes for the input element
+  # @param input_class [String] base CSS classes for the input element
   # @param help_text [String,nil] optional help text displayed under the field
   # @param options [Hash] additional options passed to the form builder method
   # @yield [input_class] yields the computed input class when a block is given.
   # @return [String] HTML safe string for the field
-  def form_field(form, attribute, method: nil, label: true, wrapper_class: 'mb-3', class: nil, help_text: nil, **options, &block)
+  def form_field(form, attribute, method: nil, label: true, wrapper_class: 'mb-3', input_class: nil, help_text: nil, **options, &block)
     errors = form.object.errors[attribute]
-    input_class = [class, (errors.any? ? 'is-invalid' : nil)].compact.join(' ')
+    final_input_class = [input_class, (errors.any? ? 'is-invalid' : nil)].compact.join(' ')
 
     field_html = if block_given?
-                   capture(input_class, &block)
+                   capture(final_input_class, &block)
                  else
-                   options[:class] = input_class
+                   options[:class] = final_input_class
                    form.public_send(method || :text_field, attribute, **options)
                  end
 

--- a/app/helpers/form_field_helper.rb
+++ b/app/helpers/form_field_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Helper for rendering form fields with consistent error handling and
+# Bootstrap invalid-feedback blocks.
+module FormFieldHelper
+  # Renders a form field wrapped with label and error markup.
+  #
+  # @param form [ActionView::Helpers::FormBuilder]
+  # @param attribute [Symbol] model attribute name
+  # @param method [Symbol] form builder method (:text_field, :select, ...)
+  # @param label [Boolean,String] true for default label, false to omit or a
+  #   custom label string
+  # @param wrapper_class [String,nil] CSS classes for the wrapper div. Pass nil
+  #   to skip the wrapper.
+  # @param class [String] base CSS classes for the input element
+  # @param help_text [String,nil] optional help text displayed under the field
+  # @param options [Hash] additional options passed to the form builder method
+  # @yield [input_class] yields the computed input class when a block is given.
+  # @return [String] HTML safe string for the field
+  def form_field(form, attribute, method: nil, label: true, wrapper_class: 'mb-3', class: nil, help_text: nil, **options, &block)
+    errors = form.object.errors[attribute]
+    input_class = [class, (errors.any? ? 'is-invalid' : nil)].compact.join(' ')
+
+    field_html = if block_given?
+                   capture(input_class, &block)
+                 else
+                   options[:class] = input_class
+                   form.public_send(method || :text_field, attribute, **options)
+                 end
+
+    content = ActiveSupport::SafeBuffer.new
+    label_text = label.is_a?(String) ? label : nil
+    content << form.label(attribute, label_text) if label
+    content << field_html
+    content << content_tag(:div, errors.join(', '), class: 'invalid-feedback') if errors.any?
+    content << content_tag(:small, help_text, class: 'form-text text-muted mt-2') if help_text
+
+    wrapper_class ? content_tag(:div, content, class: wrapper_class) : content
+  end
+end

--- a/app/views/better_together/navigation_areas/_form.html.erb
+++ b/app/views/better_together/navigation_areas/_form.html.erb
@@ -12,9 +12,9 @@
     </div>
   <% end %>
   
-  <%= form_field form, :name, method: :text_field, class: 'form-control' %>
+  <%= form_field form, :name, method: :text_field, input_class: 'form-control' %>
 
-  <%= form_field form, :visible, method: :check_box, class: 'form-check-input' %>
+  <%= form_field form, :visible, method: :check_box, input_class: 'form-check-input' %>
 
   <div class="actions">
     <%= form.submit class: 'btn btn-primary' %>

--- a/app/views/better_together/navigation_areas/_form.html.erb
+++ b/app/views/better_together/navigation_areas/_form.html.erb
@@ -12,25 +12,9 @@
     </div>
   <% end %>
   
-  <div class="mb-3">
-    <%= form.label :name %>
-    <%= form.text_field :name, class: 'form-control' + (@navigation_area.errors[:name].any? ? ' is-invalid' : '') %>
-    <% if @navigation_area.errors[:name].any? %>
-      <div class="invalid-feedback">
-        <%= @navigation_area.errors[:name].join(", ") %>
-      </div>
-    <% end %>
-  </div>
+  <%= form_field form, :name, method: :text_field, class: 'form-control' %>
 
-  <div class="mb-3">
-    <%= form.label :visible %>
-    <%= form.check_box :visible, class: 'form-check-input' + (@navigation_area.errors[:visible].any? ? ' is-invalid' : '') %>
-    <% if @navigation_area.errors[:visible].any? %>
-      <div class="invalid-feedback">
-        <%= @navigation_area.errors[:visible].join(", ") %>
-      </div>
-    <% end %>
-  </div>
+  <%= form_field form, :visible, method: :check_box, class: 'form-check-input' %>
 
   <div class="actions">
     <%= form.submit class: 'btn btn-primary' %>

--- a/app/views/better_together/navigation_items/_form.html.erb
+++ b/app/views/better_together/navigation_items/_form.html.erb
@@ -30,17 +30,17 @@
 
     <%= form.hidden_field :navigation_area_id, value: @navigation_area.id %>
 
-    <%= form_field form, :parent_id, label: t('better_together.navigation_items.form.parent_item'), class: 'form-select' do |input_class| %>
+    <%= form_field form, :parent_id, label: t('better_together.navigation_items.form.parent_item'), input_class: 'form-select' do |input_class| %>
       <%= form.collection_select :parent_id, available_parent_items, :id, :select_option_title, { include_blank: true }, { class: input_class, data: { controller: "better_together--slim-select" } } %>
     <% end %>
 
-    <%= form_field form, :item_type, class: 'form-select' do |input_class| %>
+    <%= form_field form, :item_type, input_class: 'form-select' do |input_class| %>
       <%= form.select :item_type, options_for_select(['link', 'dropdown', 'separator'], @navigation_item.item_type), { include_blank: true }, { class: input_class } %>
     <% end %>
 
     <!-- Control field for linkable_id -->
     <div id="nav-item-linkable" class="bt-mb-3" data-better_together--dependent-fields-target="dependentField" data-dependent-fields-control="navigation_item_route_name" data-show-if-control_navigation_item_route_name="*not_present*">
-      <%= form_field form, :linkable_id, label: t('better_together.navigation_items.form.link_to_page'), class: 'form-select', wrapper_class: nil do |input_class| %>
+      <%= form_field form, :linkable_id, label: t('better_together.navigation_items.form.link_to_page'), input_class: 'form-select', wrapper_class: nil do |input_class| %>
         <%= form.collection_select :linkable_id, @pages, :id, :select_option_title, { include_blank: true }, { id: 'navigation_item_linkable_id', class: input_class, data: { controller: "better_together--slim-select" }, 'data-better_together--dependent-fields-target' => "controlField" } %>
       <% end %>
     </div>
@@ -64,12 +64,12 @@
 
     <!-- Dependent field for url, shown when both linkable_id and route_name are not present -->
     <div id="nav-item-url" class="bt-mb-3 url-field" data-better_together--dependent-fields-target="dependentField" data-dependent-fields-control="navigation_item_linkable_id navigation_item_route_name" data-show-if-control_navigation_item_linkable_id="*not_present*" data-show-if-control_navigation_item_route_name="*not_present*">
-      <%= form_field form, :url, method: :text_field, class: 'form-control', wrapper_class: nil %>
+      <%= form_field form, :url, method: :text_field, input_class: 'form-control', wrapper_class: nil %>
     </div>
 
-    <%= form_field form, :position, method: :number_field, class: 'form-control' %>
+    <%= form_field form, :position, method: :number_field, input_class: 'form-control' %>
 
-    <%= form_field form, :visible, method: :check_box, class: 'form-check-input' %>
+    <%= form_field form, :visible, method: :check_box, input_class: 'form-check-input' %>
 
     <%= yield :action_toolbar %>
   <% end %>

--- a/app/views/better_together/navigation_items/_form.html.erb
+++ b/app/views/better_together/navigation_items/_form.html.erb
@@ -30,34 +30,18 @@
 
     <%= form.hidden_field :navigation_area_id, value: @navigation_area.id %>
 
-    <div class="mb-3">
-      <%= form.label :parent_id, t('better_together.navigation_items.form.parent_item') %>
-      <%= form.collection_select :parent_id, available_parent_items, :id, :select_option_title, { include_blank: true }, { class: 'form-select' + (@navigation_item.errors[:parent_id].any? ? ' is-invalid' : ''), data: { controller: "better_together--slim-select" } } %>
-      <% if @navigation_item.errors[:parent_id].any? %>
-        <div class="invalid-feedback">
-          <%= @navigation_item.errors[:parent_id].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :parent_id, label: t('better_together.navigation_items.form.parent_item'), class: 'form-select' do |input_class| %>
+      <%= form.collection_select :parent_id, available_parent_items, :id, :select_option_title, { include_blank: true }, { class: input_class, data: { controller: "better_together--slim-select" } } %>
+    <% end %>
 
-    <div class="mb-3">
-      <%= form.label :item_type %>
-      <%= form.select :item_type, options_for_select(['link', 'dropdown', 'separator'], @navigation_item.item_type), { include_blank: true }, { class: 'form-select' + (@navigation_item.errors[:item_type].any? ? ' is-invalid' : '') } %>
-      <% if @navigation_item.errors[:item_type].any? %>
-        <div class="invalid-feedback">
-          <%= @navigation_item.errors[:item_type].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :item_type, class: 'form-select' do |input_class| %>
+      <%= form.select :item_type, options_for_select(['link', 'dropdown', 'separator'], @navigation_item.item_type), { include_blank: true }, { class: input_class } %>
+    <% end %>
 
     <!-- Control field for linkable_id -->
     <div id="nav-item-linkable" class="bt-mb-3" data-better_together--dependent-fields-target="dependentField" data-dependent-fields-control="navigation_item_route_name" data-show-if-control_navigation_item_route_name="*not_present*">
-      <%= form.label :linkable_id, t('better_together.navigation_items.form.link_to_page') %>
-      <%= form.collection_select :linkable_id, @pages, :id, :select_option_title, { include_blank: true }, { id: 'navigation_item_linkable_id', class: ('form-select' + (@navigation_item.errors[:linkable_id].any? ? ' is-invalid' : '')), data: { controller: "better_together--slim-select" }, 'data-better_together--dependent-fields-target' => "controlField" } %>
-      <% if @navigation_item.errors[:linkable_id].any? %>
-        <div class="invalid-feedback">
-          <%= @navigation_item.errors[:linkable_id].join(", ") %>
-        </div>
+      <%= form_field form, :linkable_id, label: t('better_together.navigation_items.form.link_to_page'), class: 'form-select', wrapper_class: nil do |input_class| %>
+        <%= form.collection_select :linkable_id, @pages, :id, :select_option_title, { include_blank: true }, { id: 'navigation_item_linkable_id', class: input_class, data: { controller: "better_together--slim-select" }, 'data-better_together--dependent-fields-target' => "controlField" } %>
       <% end %>
     </div>
 
@@ -80,34 +64,12 @@
 
     <!-- Dependent field for url, shown when both linkable_id and route_name are not present -->
     <div id="nav-item-url" class="bt-mb-3 url-field" data-better_together--dependent-fields-target="dependentField" data-dependent-fields-control="navigation_item_linkable_id navigation_item_route_name" data-show-if-control_navigation_item_linkable_id="*not_present*" data-show-if-control_navigation_item_route_name="*not_present*">
-      <%= form.label :url %>
-      <%= form.text_field :url, class: 'form-control' + (@navigation_item.errors[:url].any? ? ' is-invalid' : '') %>
-      <% if @navigation_item.errors[:url].any? %>
-        <div class="invalid-feedback">
-          <%= @navigation_item.errors[:url].join(", ") %>
-        </div>
-      <% end %>
+      <%= form_field form, :url, method: :text_field, class: 'form-control', wrapper_class: nil %>
     </div>
 
-    <div class="mb-3">
-      <%= form.label :position %>
-      <%= form.number_field :position, class: 'form-control' + (@navigation_item.errors[:position].any? ? ' is-invalid' : '') %>
-      <% if @navigation_item.errors[:position].any? %>
-        <div class="invalid-feedback">
-          <%= @navigation_item.errors[:position].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :position, method: :number_field, class: 'form-control' %>
 
-    <div class="mb-3">
-      <%= form.label :visible %>
-      <%= form.check_box :visible, class: 'form-check-input' + (@navigation_item.errors[:visible].any? ? ' is-invalid' : '') %>
-      <% if @navigation_item.errors[:visible].any? %>
-        <div class="invalid-feedback">
-          <%= @navigation_item.errors[:visible].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :visible, method: :check_box, class: 'form-check-input' %>
 
     <%= yield :action_toolbar %>
   <% end %>

--- a/app/views/better_together/pages/_form.html.erb
+++ b/app/views/better_together/pages/_form.html.erb
@@ -53,19 +53,19 @@
       <%= privacy_field(form:, klass: resource_class, class: input_class) %>
     <% end %>
 
-    <%= form_field form, :published_at, method: :datetime_field, include_seconds: false, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
+    <%= form_field form, :published_at, method: :datetime_field, include_seconds: false, input_class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
 
-    <%= form_field form, :layout, class: 'form-select', wrapper_class: 'col mb-3 pb-3 border-bottom' do |input_class| %>
+    <%= form_field form, :layout, input_class: 'form-select', wrapper_class: 'col mb-3 pb-3 border-bottom' do |input_class| %>
       <%= form.select :layout, options_for_select(::BetterTogether::Page::PAGE_LAYOUTS, page.layout), {}, { class: input_class } %>
     <% end %>
 
-    <%= form_field form, :template, method: :text_field, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
+    <%= form_field form, :template, method: :text_field, input_class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
 
-    <%= form_field form, :meta_description, method: :text_area, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
+    <%= form_field form, :meta_description, method: :text_area, input_class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
 
-    <%= form_field form, :keywords, method: :text_field, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom align-self-top' %>
+    <%= form_field form, :keywords, method: :text_field, input_class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom align-self-top' %>
 
-    <%= form_field form, :sidebar_nav_id, label: 'Sidebar Navigation', class: 'form-select', wrapper_class: 'col mb-3 pb-3 border-bottom' do |input_class| %>
+    <%= form_field form, :sidebar_nav_id, label: 'Sidebar Navigation', input_class: 'form-select', wrapper_class: 'col mb-3 pb-3 border-bottom' do |input_class| %>
       <%= form.collection_select :sidebar_nav_id, BetterTogether::NavigationArea.all, :id, :name, { include_blank: true }, { class: input_class, data: { controller: "better_together--slim-select" } } %>
     <% end %>
   </div>

--- a/app/views/better_together/pages/_form.html.erb
+++ b/app/views/better_together/pages/_form.html.erb
@@ -49,76 +49,25 @@
       <%= render partial: 'better_together/shared/translated_string_field', locals: { model: page, form: form, attribute: 'slug' } %>
     </div>
 
-    <div class="col mb-3 pb-3 border-bottom">
-      <%= form.label :privacy %>
-      <%= privacy_field(form:, klass: resource_class) %>
-      <% if page.errors[:privacy].any? %>
-        <div class="invalid-feedback">
-          <%= page.errors[:privacy].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :privacy, wrapper_class: 'col mb-3 pb-3 border-bottom' do |input_class| %>
+      <%= privacy_field(form:, klass: resource_class, class: input_class) %>
+    <% end %>
 
-    <div class="col mb-3 pb-3 border-bottom">
-      <%= form.label :published_at %>
-      <%= form.datetime_field :published_at, include_seconds: false, class: "form-control#{' is-invalid' if page.errors[:published_at].any?}" %>
+    <%= form_field form, :published_at, method: :datetime_field, include_seconds: false, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
 
-      <% if page.errors[:published_at].any? %>
-        <div class="invalid-feedback">
-          <%= page.errors[:published_at].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :layout, class: 'form-select', wrapper_class: 'col mb-3 pb-3 border-bottom' do |input_class| %>
+      <%= form.select :layout, options_for_select(::BetterTogether::Page::PAGE_LAYOUTS, page.layout), {}, { class: input_class } %>
+    <% end %>
 
-    <div class="col mb-3 pb-3 border-bottom">
-      <%= form.label :layout %>
-      <%= form.select :layout, options_for_select(::BetterTogether::Page::PAGE_LAYOUTS, page.layout), {}, { class: "form-select#{' is-invalid' if page.errors[:layout].any?}" } %>
-      <% if page.errors[:layout].any? %>
-        <div class="invalid-feedback">
-          <%= page.errors[:layout].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :template, method: :text_field, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
 
-    <div class="col mb-3 pb-3 border-bottom">
-      <%= form.label :template %>
-      <%= form.text_field :template, class: "form-control#{' is-invalid' if page.errors[:template].any?}" %>
-      <% if page.errors[:template].any? %>
-        <div class="invalid-feedback">
-          <%= page.errors[:template].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :meta_description, method: :text_area, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom' %>
 
-    <div class="col mb-3 pb-3 border-bottom">
-      <%= form.label :meta_description %>
-      <%= form.text_area :meta_description, class: "form-control#{' is-invalid' if page.errors[:meta_description].any?}" %>
-      <% if page.errors[:meta_description].any? %>
-        <div class="invalid-feedback">
-          <%= page.errors[:meta_description].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :keywords, method: :text_field, class: 'form-control', wrapper_class: 'col mb-3 pb-3 border-bottom align-self-top' %>
 
-    <div class="col mb-3 pb-3 border-bottom align-self-top">
-      <%= form.label :keywords %>
-      <%= form.text_field :keywords, class: "form-control#{' is-invalid' if page.errors[:keywords].any?}" %>
-      <% if page.errors[:keywords].any? %>
-        <div class="invalid-feedback">
-          <%= page.errors[:keywords].join(", ") %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="col mb-3 pb-3 border-bottom">
-      <%= form.label :sidebar_nav_id, 'Sidebar Navigation' %>
-      <%= form.collection_select :sidebar_nav_id, BetterTogether::NavigationArea.all, :id, :name, { include_blank: true }, { class: ('form-select' + (page.errors[:sidebar_nav_id].any? ? ' is-invalid' : '')), data: { controller: "better_together--slim-select" } } %>
-      <% if page.errors[:sidebar_nav_id].any? %>
-        <div class="invalid-feedback">
-          <%= page.errors[:sidebar_nav_id].join(", ") %>
-        </div>
-      <% end %>
-    </div>
+    <%= form_field form, :sidebar_nav_id, label: 'Sidebar Navigation', class: 'form-select', wrapper_class: 'col mb-3 pb-3 border-bottom' do |input_class| %>
+      <%= form.collection_select :sidebar_nav_id, BetterTogether::NavigationArea.all, :id, :name, { include_blank: true }, { class: input_class, data: { controller: "better_together--slim-select" } } %>
+    <% end %>
   </div>
 
   <%= render partial: 'better_together/pages/extra_page_fields', locals: { form:, page: } %>

--- a/spec/helpers/form_field_helper_spec.rb
+++ b/spec/helpers/form_field_helper_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class DummyModel
+  include ActiveModel::Model
+  attr_accessor :name
+  validates :name, presence: true
+end
+
+RSpec.describe FormFieldHelper, type: :helper do
+  let(:dummy) { DummyModel.new }
+
+  it 'renders invalid feedback when attribute has errors' do
+    dummy.validate
+    render inline: "<%= form_with model: dummy do |f| %><%= form_field f, :name, input_class: 'form-control' %><% end %>", locals: { dummy: dummy }
+    node = Capybara::Node::Simple.new(rendered)
+    expect(node).to have_css('input.is-invalid')
+    expect(node).to have_css('div.invalid-feedback', text: "can't be blank")
+  end
+
+  it 'renders help text when provided' do
+    render inline: "<%= form_with model: dummy do |f| %><%= form_field f, :name, input_class: 'form-control', help_text: 'Enter name' %><% end %>", locals: { dummy: dummy }
+    node = Capybara::Node::Simple.new(rendered)
+    expect(node).to have_text('Enter name')
+  end
+end


### PR DESCRIPTION
## Summary
- add reusable `form_field` helper for consistent error and invalid-feedback markup
- refactor BetterTogether page, navigation area, and navigation item forms to use the helper

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a557efb14832182dd5aecd8c3d57d