### PR TITLE
Localize controllers models and views

### DIFF
--- a/app/controllers/better_together/metrics/link_click_reports_controller.rb
+++ b/app/controllers/better_together/metrics/link_click_reports_controller.rb
@@ -41,7 +41,7 @@ module BetterTogether
 
         respond_to do |format| # rubocop:todo Metrics/BlockLength
           if @link_click_report.persisted?
-            flash[:notice] = 'Report was successfully created.'
+            flash[:notice] = t('flash.generic.created', resource: t('resources.report'))
             format.html { redirect_to metrics_link_click_reports_path, notice: flash[:notice] }
             format.turbo_stream do
               render turbo_stream: [
@@ -55,7 +55,7 @@ module BetterTogether
               ]
             end
           else
-            flash.now[:alert] = 'Error creating report.'
+            flash.now[:alert] = t('flash.generic.error_create', resource: t('resources.report'))
             format.html { render :new, status: :unprocessable_entity }
             format.turbo_stream do
               render turbo_stream: [

--- a/app/controllers/better_together/metrics/page_view_reports_controller.rb
+++ b/app/controllers/better_together/metrics/page_view_reports_controller.rb
@@ -39,7 +39,7 @@ module BetterTogether
 
         respond_to do |format| # rubocop:todo Metrics/BlockLength
           if @page_view_report.persisted?
-            flash[:notice] = 'Report was successfully created.'
+            flash[:notice] = t('flash.generic.created', resource: t('resources.report'))
             format.html { redirect_to metrics_page_view_reports_path, notice: flash[:notice] }
             format.turbo_stream do
               render turbo_stream: [
@@ -55,7 +55,7 @@ module BetterTogether
               ]
             end
           else
-            flash.now[:alert] = 'Error creating report.'
+            flash.now[:alert] = t('flash.generic.error_create', resource: t('resources.report'))
             format.html { render :new, status: :unprocessable_entity }
             format.turbo_stream do
               render turbo_stream: [

--- a/app/controllers/better_together/pages_controller.rb
+++ b/app/controllers/better_together/pages_controller.rb
@@ -37,7 +37,7 @@ module BetterTogether
       authorize @page
 
       if @page.save
-        redirect_to edit_page_path(@page), notice: 'Page was successfully created.'
+        redirect_to edit_page_path(@page), notice: t('flash.generic.created', resource: t('resources.page'))
       else
         render :new
       end
@@ -53,11 +53,11 @@ module BetterTogether
       respond_to do |format|
         if @page.update(page_params)
           format.html do
-            flash[:notice] = 'Page was successfully updated.'
-            redirect_to edit_page_path(@page), notice: 'Page was successfully updated.'
+            flash[:notice] = t('flash.generic.updated', resource: t('resources.page'))
+            redirect_to edit_page_path(@page), notice: t('flash.generic.updated', resource: t('resources.page'))
           end
           format.turbo_stream do
-            flash.now[:notice] = 'Page was successfully updated.'
+            flash.now[:notice] = t('flash.generic.updated', resource: t('resources.page'))
             render turbo_stream: [
               turbo_stream.replace(helpers.dom_id(@page, 'form'), partial: 'form',
                                                                   locals: { page: @page }),
@@ -77,7 +77,7 @@ module BetterTogether
     def destroy
       authorize @page
       @page.destroy
-      redirect_to pages_url, notice: 'Page was successfully destroyed.'
+      redirect_to pages_url, notice: t('flash.generic.destroyed', resource: t('resources.page'))
     end
 
     protected

--- a/app/controllers/better_together/person_community_memberships_controller.rb
+++ b/app/controllers/better_together/person_community_memberships_controller.rb
@@ -13,7 +13,7 @@ module BetterTogether
 
       respond_to do |format|
         if @person_community_membership.save
-          flash[:notice] = 'Member was successfully added.'
+          flash[:notice] = t('flash.generic.created', resource: t('resources.member'))
           format.html { redirect_to @community, notice: flash[:notice] }
           format.turbo_stream do
             render turbo_stream: [
@@ -26,7 +26,7 @@ module BetterTogether
             ]
           end
         else
-          flash.now[:alert] = 'Error adding member.'
+          flash.now[:alert] = t('flash.generic.error_create', resource: t('resources.member'))
           format.html { redirect_to @community, alert: @person_community_membership.errors.full_messages.to_sentence }
           format.turbo_stream do
             render turbo_stream: [
@@ -44,7 +44,7 @@ module BetterTogether
       authorize @person_community_membership
 
       if @person_community_membership.destroy
-        flash.now[:notice] = 'Member was successfully removed.'
+        flash.now[:notice] = t('flash.generic.removed', resource: t('resources.member'))
         respond_to do |format|
           format.html { redirect_to @community }
           format.turbo_stream do
@@ -56,7 +56,7 @@ module BetterTogether
           end
         end
       else
-        flash.now[:error] = 'Failed to remove member.'
+        flash.now[:error] = t('flash.generic.error_remove', resource: t('resources.member'))
         respond_to do |format|
           format.html { redirect_to @community, alert: flash.now[:error] }
           format.turbo_stream do

--- a/app/controllers/better_together/platform_invitations_controller.rb
+++ b/app/controllers/better_together/platform_invitations_controller.rb
@@ -21,7 +21,7 @@ module BetterTogether
 
       respond_to do |format|
         if @platform_invitation.save
-          flash[:notice] = 'Invitation was successfully created.'
+          flash[:notice] = t('flash.generic.created', resource: t('resources.invitation'))
           format.html { redirect_to @platform, notice: flash[:notice] }
           format.turbo_stream do
             render turbo_stream: [
@@ -34,7 +34,7 @@ module BetterTogether
             ]
           end
         else
-          flash.now[:alert] = 'Error creating platform_invitation.'
+          flash.now[:alert] = t('flash.generic.error_create', resource: t('resources.invitation'))
           format.html { redirect_to @platform, alert: @platform_invitation.errors.full_messages.to_sentence }
           format.turbo_stream do
             render turbo_stream: [
@@ -52,7 +52,7 @@ module BetterTogether
       authorize @platform_invitation
 
       if @platform_invitation.destroy
-        flash.now[:notice] = 'Invitation was successfully removed.'
+        flash.now[:notice] = t('flash.generic.removed', resource: t('resources.invitation'))
         respond_to do |format|
           format.html { redirect_to @platform }
           format.turbo_stream do
@@ -64,7 +64,7 @@ module BetterTogether
           end
         end
       else
-        flash.now[:error] = 'Failed to remove platform_invitation.'
+        flash.now[:error] = t('flash.generic.error_remove', resource: t('resources.invitation'))
         respond_to do |format|
           format.html { redirect_to @platform, alert: flash.now[:error] }
           format.turbo_stream do
@@ -82,7 +82,7 @@ module BetterTogether
       authorize @platform_invitation
 
       BetterTogether::PlatformInvitationMailerJob.perform_later(@platform_invitation.id)
-      flash[:notice] = 'Invitation email has been queued for sending.'
+      flash[:notice] = t('flash.generic.queued', resource: t('resources.invitation_email'))
 
       respond_to do |format|
         format.html { redirect_to @platform, notice: flash[:notice] }

--- a/app/models/better_together/address.rb
+++ b/app/models/better_together/address.rb
@@ -68,7 +68,7 @@ module BetterTogether
     def at_least_one_address_type
       return if physical || postal
 
-      errors.add(:base, 'Address must be either physical, postal, or both')
+      errors.add(:base, I18n.t('errors.models.address_missing_type'))
     end
 
     def resolve_format(format, included, excluded)

--- a/app/models/better_together/person_block.rb
+++ b/app/models/better_together/person_block.rb
@@ -13,13 +13,13 @@ module BetterTogether
     private
 
     def not_self
-      errors.add(:blocked_id, 'cannot block yourself') if blocker_id == blocked_id
+      errors.add(:blocked_id, I18n.t('errors.person_block.cannot_block_self')) if blocker_id == blocked_id
     end
 
     def blocked_not_platform_manager
       return unless blocked&.permitted_to?('manage_platform')
 
-      errors.add(:blocked, 'cannot be a platform manager')
+      errors.add(:blocked, I18n.t('errors.person_block.cannot_block_manager'))
     end
   end
 end

--- a/app/models/better_together/wizard_step.rb
+++ b/app/models/better_together/wizard_step.rb
@@ -43,7 +43,7 @@ module BetterTogether
 
         # If the number of completed steps is equal to or exceeds the max completions allowed, add an error
         if completed_steps_count >= wizard.max_completions
-          errors.add(:base, 'Maximum number of completions reached for this wizard and step definition.')
+          errors.add(:base, I18n.t('errors.wizard.max_completions'))
           return
         end
       end
@@ -57,7 +57,7 @@ module BetterTogether
 
       return unless existing_step
 
-      errors.add(:base, 'Only one uncompleted step per person is allowed.')
+      errors.add(:base, I18n.t('errors.wizard.one_uncompleted'))
     end
     # rubocop:enable Metrics/MethodLength
 
@@ -68,7 +68,7 @@ module BetterTogether
 
       return unless completed_steps_count >= wizard.max_completions
 
-      errors.add(:base, "Number of completions for this step has reached the wizard's max completions limit.")
+      errors.add(:base, I18n.t('errors.wizard.step_limit'))
     end
   end
 end

--- a/app/models/concerns/better_together/host.rb
+++ b/app/models/concerns/better_together/host.rb
@@ -29,7 +29,7 @@ module BetterTogether
     def single_host_record
       return unless host && self.class.where.not(id:).exists?(host: true)
 
-      errors.add(:host, 'can only be set for one record')
+      errors.add(:host, I18n.t('errors.models.host_single'))
     end
   end
 end

--- a/app/models/concerns/better_together/protected.rb
+++ b/app/models/concerns/better_together/protected.rb
@@ -10,7 +10,7 @@ module BetterTogether
 
       before_destroy do
         if protected?
-          errors.add(:base, 'This record is protected and cannot be destroyed.')
+          errors.add(:base, I18n.t('errors.models.protected_destroy'))
           throw(:abort)
         end
       end

--- a/app/views/better_together/metrics/link_click_reports/_index.html.erb
+++ b/app/views/better_together/metrics/link_click_reports/_index.html.erb
@@ -1,8 +1,8 @@
 <turbo-frame id="link_click_reports" class="container-fluid mt-5">
-  <h2>Link Click Reports</h2>
+  <h2><%= t('views.headers.link_click_reports') %></h2>
 
   <!-- Button that loads the new report form into the turbo frame below -->
-  <%= link_to "New Report", new_metrics_link_click_report_path, class: "btn btn-primary mb-3", data: { turbo_frame: "new_link_click_report" } %>
+  <%= link_to t('views.buttons.new', resource: t('resources.report')), new_metrics_link_click_report_path, class: "btn btn-primary mb-3", data: { turbo_frame: "new_link_click_report" } %>
 
   <!-- Turbo frame for the new report form -->
   <turbo-frame id="new_link_click_report"></turbo-frame>
@@ -12,12 +12,12 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Created At</th>
-          <th>Filters</th>
-          <th>Sort by total clicks</th>
-          <th>File Format</th>
-          <th>Actions</th>
+          <th><%= t('views.labels.id') %></th>
+          <th><%= t('views.labels.created_at') %></th>
+          <th><%= t('views.labels.filters') %></th>
+          <th><%= t('views.labels.sort_by_total_clicks') %></th>
+          <th><%= t('views.labels.file_format') %></th>
+          <th><%= t('views.labels.actions') %></th>
         </tr>
       </thead>
       <tbody id="link_click_reports_table_body">

--- a/app/views/better_together/metrics/link_click_reports/_link_click_report.html.erb
+++ b/app/views/better_together/metrics/link_click_reports/_link_click_report.html.erb
@@ -5,18 +5,18 @@
     <% if link_click_report.filters.present? %>
       <%= link_click_report.filters.to_json %>
     <% else %>
-      All
+      <%= t('views.labels.all') %>
     <% end %>
   </td>
   <td><%= link_click_report.sort_by_total_clicks ? t('yes') : t('no') %></td>
   <td><%= link_click_report.file_format %></td>
   <td>
     <% if link_click_report.report_file.attached? %>
-      <%= link_to "Download", download_metrics_link_click_report_path(link_click_report),
+      <%= link_to t('views.buttons.download'), download_metrics_link_click_report_path(link_click_report),
                   class: "btn btn-primary btn-sm",
                   data: { turbo: false } %>
     <% else %>
-      <span class="text-muted">No file</span>
+      <span class="text-muted"><%= t('views.labels.no_file') %></span>
     <% end %>
   </td>
 </tr>

--- a/app/views/better_together/metrics/link_click_reports/new.html.erb
+++ b/app/views/better_together/metrics/link_click_reports/new.html.erb
@@ -1,22 +1,22 @@
 <turbo-frame id="new_link_click_report">
-  <h3>New Link Click Report</h3>
+  <h3><%= t('views.headers.new_link_click_report') %></h3>
 
   <%= form_with model: @link_click_report, url: metrics_link_click_reports_path, local: true, class: "form" do |f| %>
     <%= turbo_frame_tag 'form_errors' %>
     <div class="form-group">
-      <%= f.label :from_date, "From Date" %>
+      <%= f.label :from_date, t('views.labels.from_date') %>
       <%= f.date_field :from_date, name: "metrics_link_click_report[filters][from_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :to_date, "To Date" %>
+      <%= f.label :to_date, t('views.labels.to_date') %>
       <%= f.date_field :to_date, name: "metrics_link_click_report[filters][to_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :filter_internal, "Internal Filter" %>
+      <%= f.label :filter_internal, t('views.labels.internal_filter') %>
       <%= f.select :filter_internal,
-            options_for_select([["All", ""], ["Internal", true], ["External", false]],
+            options_for_select([[t('views.labels.all'), ""], [t('views.labels.internal'), true], [t('views.labels.external'), false]],
             @link_click_report.filters["filter_internal"]),
             { include_blank: false },
             name: "metrics_link_click_report[filters][filter_internal]",
@@ -25,41 +25,41 @@
 
     <div class="form-check">
       <%= f.check_box :sort_by_total_clicks, class: "form-check-input" %>
-      <%= f.label :sort_by_total_clicks, "Sort by Total Clicks", class: "form-check-label" %>
+      <%= f.label :sort_by_total_clicks, t('views.labels.sort_by_total_clicks'), class: "form-check-label" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.label :file_format, "File Format" %>
+      <%= f.label :file_format, t('views.labels.file_format') %>
       <%= f.select :file_format, options_for_select([["CSV", "csv"]], "csv"), {}, class: "form-control" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.submit "Create Report", class: "btn btn-primary" %>
-      <%= link_to "Back", metrics_link_click_reports_path, class: "btn btn-secondary" %>
+      <%= f.submit t('views.buttons.create_report'), class: "btn btn-primary" %>
+      <%= link_to t('views.buttons.back'), metrics_link_click_reports_path, class: "btn btn-secondary" %>
     </div>
   <% end %>
 </turbo-frame>
 
 
 <div class="container mt-5">
-  <h1>New Link Click Report</h1>
+  <h1><%= t('views.headers.new_link_click_report') %></h1>
 
   <%= form_with model: @link_click_report, url: metrics_link_click_reports_path, local: true, class: "form" do |f| %>
     <%= turbo_frame_tag 'form_errors' %>
     <div class="form-group">
-      <%= f.label :from_date, "From Date" %>
+      <%= f.label :from_date, t('views.labels.from_date') %>
       <%= f.date_field :from_date, name: "metrics_link_click_report[filters][from_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :to_date, "To Date" %>
+      <%= f.label :to_date, t('views.labels.to_date') %>
       <%= f.date_field :to_date, name: "metrics_link_click_report[filters][to_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :filter_internal, "Internal Filter" %>
+      <%= f.label :filter_internal, t('views.labels.internal_filter') %>
       <%= f.select :filter_internal,
-            options_for_select([["All", ""], ["Internal", true], ["External", false]],
+            options_for_select([[t('views.labels.all'), ""], [t('views.labels.internal'), true], [t('views.labels.external'), false]],
             @link_click_report.filters["filter_internal"]),
             { include_blank: false },
             name: "metrics_link_click_report[filters][filter_internal]",
@@ -68,17 +68,17 @@
 
     <div class="form-check">
       <%= f.check_box :sort_by_total_clicks, class: "form-check-input" %>
-      <%= f.label :sort_by_total_clicks, "Sort by Total Clicks", class: "form-check-label" %>
+      <%= f.label :sort_by_total_clicks, t('views.labels.sort_by_total_clicks'), class: "form-check-label" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.label :file_format, "File Format" %>
+      <%= f.label :file_format, t('views.labels.file_format') %>
       <%= f.select :file_format, options_for_select([["CSV", "csv"]], "csv"), {}, class: "form-control" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.submit "Create Report", class: "btn btn-primary" %>
-      <%= link_to "Back", metrics_link_click_reports_path, class: "btn btn-secondary" %>
+      <%= f.submit t('views.buttons.create_report'), class: "btn btn-primary" %>
+      <%= link_to t('views.buttons.back'), metrics_link_click_reports_path, class: "btn btn-secondary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/better_together/metrics/page_view_reports/_index.html.erb
+++ b/app/views/better_together/metrics/page_view_reports/_index.html.erb
@@ -1,8 +1,8 @@
 <turbo-frame id="page_view_reports" class="container-fluid mt-5">
-  <h2>Page View Reports</h2>
+  <h2><%= t('views.headers.page_view_reports') %></h2>
 
   <!-- Button that loads the new report form into the turbo frame below -->
-  <%= link_to "New Report", new_metrics_page_view_report_path, class: "btn btn-primary mb-3", data: { turbo_frame: "new_report" } %>
+  <%= link_to t('views.buttons.new', resource: t('resources.report')), new_metrics_page_view_report_path, class: "btn btn-primary mb-3", data: { turbo_frame: "new_report" } %>
 
   <!-- Turbo frame for the new report form -->
   <turbo-frame id="new_report"></turbo-frame>
@@ -12,12 +12,12 @@
     <table class="table table-striped">
       <thead>
         <tr>
-          <th>ID</th>
-          <th>Created At</th>
-          <th>Filters</th>
-          <th>Sort by total views</th>
-          <th>File Format</th>
-          <th>Actions</th>
+          <th><%= t('views.labels.id') %></th>
+          <th><%= t('views.labels.created_at') %></th>
+          <th><%= t('views.labels.filters') %></th>
+          <th><%= t('views.labels.sort_by_total_views') %></th>
+          <th><%= t('views.labels.file_format') %></th>
+          <th><%= t('views.labels.actions') %></th>
         </tr>
       </thead>
       <tbody id="page_view_reports_table_body">

--- a/app/views/better_together/metrics/page_view_reports/_page_view_report.html.erb
+++ b/app/views/better_together/metrics/page_view_reports/_page_view_report.html.erb
@@ -5,18 +5,18 @@
     <% if page_view_report.filters.present? %>
       <%= page_view_report.filters.to_json %>
     <% else %>
-      All
+      <%= t('views.labels.all') %>
     <% end %>
   </td>
   <td><%= page_view_report.sort_by_total_views ? t('yes') : t('no') %></td>
   <td><%= page_view_report.file_format %></td>
   <td>
     <% if page_view_report.report_file.attached? %>
-      <%= link_to "Download", download_metrics_page_view_report_path(page_view_report),
+      <%= link_to t('views.buttons.download'), download_metrics_page_view_report_path(page_view_report),
                   class: "btn btn-primary btn-sm",
                   data: { turbo: false } %>
     <% else %>
-      <span class="text-muted">No file</span>
+      <span class="text-muted"><%= t('views.labels.no_file') %></span>
     <% end %>
   </td>
 </tr>

--- a/app/views/better_together/metrics/page_view_reports/new.html.erb
+++ b/app/views/better_together/metrics/page_view_reports/new.html.erb
@@ -1,20 +1,20 @@
 <turbo-frame id="new_report">
-  <h3>New Page View Report</h3>
+  <h3><%= t('views.headers.new_page_view_report') %></h3>
 
   <%= form_with model: @page_view_report, url: metrics_page_view_reports_path, local: true, class: "form" do |f| %>
     <%= turbo_frame_tag 'form_errors' %>
     <div class="form-group">
-      <%= f.label :from_date, "From Date" %>
+      <%= f.label :from_date, t('views.labels.from_date') %>
       <%= f.date_field :from_date, name: "metrics_page_view_report[filters][from_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :to_date, "To Date" %>
+      <%= f.label :to_date, t('views.labels.to_date') %>
       <%= f.date_field :to_date, name: "metrics_page_view_report[filters][to_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :filter_pageable_type, "Pageable Type Filter" %>
+      <%= f.label :filter_pageable_type, t('views.labels.pageable_type_filter') %>
       <%= f.select :filter_pageable_type,
             options_for_select(@pageable_types.map { |type| [type, type] },
             @page_view_report.filters["filter_pageable_type"]),
@@ -25,39 +25,39 @@
 
     <div class="form-check">
       <%= f.check_box :sort_by_total_views, class: "form-check-input" %>
-      <%= f.label :sort_by_total_views, "Sort by Total Views", class: "form-check-label" %>
+      <%= f.label :sort_by_total_views, t('views.labels.sort_by_total_views'), class: "form-check-label" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.label :file_format, "File Format" %>
+      <%= f.label :file_format, t('views.labels.file_format') %>
       <%= f.select :file_format, options_for_select([["CSV", "csv"]], "csv"), {}, class: "form-control" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.submit "Create Report", class: "btn btn-primary" %>
-      <%= link_to "Back", metrics_page_view_reports_path, class: "btn btn-secondary" %>
+      <%= f.submit t('views.buttons.create_report'), class: "btn btn-primary" %>
+      <%= link_to t('views.buttons.back'), metrics_page_view_reports_path, class: "btn btn-secondary" %>
     </div>
   <% end %>
 </turbo-frame>
 
 
 <div class="container mt-5">
-  <h1>New Page View Report</h1>
+  <h1><%= t('views.headers.new_page_view_report') %></h1>
 
   <%= form_with model: @page_view_report, url: metrics_page_view_reports_path, local: true, class: "form" do |f| %>
     <%= turbo_frame_tag 'form_errors' %>
     <div class="form-group">
-      <%= f.label :from_date, "From Date" %>
+      <%= f.label :from_date, t('views.labels.from_date') %>
       <%= f.date_field :from_date, name: "metrics_page_view_report[filters][from_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :to_date, "To Date" %>
+      <%= f.label :to_date, t('views.labels.to_date') %>
       <%= f.date_field :to_date, name: "metrics_page_view_report[filters][to_date]", class: "form-control", placeholder: "YYYY-MM-DD" %>
     </div>
 
     <div class="form-group">
-      <%= f.label :filter_pageable_type, "Pageable Type Filter" %>
+      <%= f.label :filter_pageable_type, t('views.labels.pageable_type_filter') %>
       <%= f.select :filter_pageable_type,
             options_for_select(@pageable_types.map { |type| [type, type] },
             @page_view_report.filters["filter_pageable_type"]),
@@ -68,17 +68,17 @@
 
     <div class="form-check">
       <%= f.check_box :sort_by_total_views, class: "form-check-input" %>
-      <%= f.label :sort_by_total_views, "Sort by Total Views", class: "form-check-label" %>
+      <%= f.label :sort_by_total_views, t('views.labels.sort_by_total_views'), class: "form-check-label" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.label :file_format, "File Format" %>
+      <%= f.label :file_format, t('views.labels.file_format') %>
       <%= f.select :file_format, options_for_select([["CSV", "csv"]], "csv"), {}, class: "form-control" %>
     </div>
 
     <div class="form-group mt-3">
-      <%= f.submit "Create Report", class: "btn btn-primary" %>
-      <%= link_to "Back", metrics_page_view_reports_path, class: "btn btn-secondary" %>
+      <%= f.submit t('views.buttons.create_report'), class: "btn btn-primary" %>
+      <%= link_to t('views.buttons.back'), metrics_page_view_reports_path, class: "btn btn-secondary" %>
     </div>
   <% end %>
 </div>

--- a/app/views/better_together/pages/_form.html.erb
+++ b/app/views/better_together/pages/_form.html.erb
@@ -9,7 +9,7 @@
       </div>
       <% if page.persisted? %>
         <div class="btn-group" role="group" aria-label="Third group">
-          <%= link_to 'View Page', render_page_path(page), class: 'btn btn-info', target: "_#{dom_id(page, 'view')}" %>
+          <%= link_to t('views.buttons.view_page'), render_page_path(page), class: 'btn btn-info', target: "_#{dom_id(page, 'view')}" %>
         </div>
       <% end %>
     </div>
@@ -19,7 +19,7 @@
 
   <% if page.errors.any? %>
     <div class="alert alert-danger">
-      <h4>Please correct the following errors:</h4>
+      <h4><%= t('views.labels.please_correct') %></h4>
       <ul>
         <% page.errors.full_messages.each do |msg| %>
           <li><%= msg %></li>
@@ -31,9 +31,9 @@
   <% if page.protected %>
     <div class="row">
       <div class="col mb-3">
-        <span class="badge bg-danger"><strong>Protected</strong></span>
+        <span class="badge bg-danger"><strong><%= t('views.labels.protected') %></strong></span>
         <div class="text-danger mt-1">
-          This record is protected and cannot be deleted.
+          <%= t('errors.models.protected_destroy') %>
         </div>
       </div>
     </div>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -5,5 +5,5 @@
 <div class="container mt-4">
   <h1><%= t('errors.not_found.title') %></h1>
   <p><%= t('errors.not_found.description') %></p>
-  <p><%= link_to 'Go to Home', home_page_path, class: 'btn btn-primary' %></p>
+  <p><%= link_to t('views.buttons.go_home'), home_page_path, class: 'btn btn-primary' %></p>
 </div>

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -5,5 +5,5 @@
 <div class="container mt-4">
   <h1><%= t('errors.internal_server_error.title') %></h1>
   <p><%= t('errors.internal_server_error.description') %></p>
-  <p><%= link_to 'Go to Home', home_page_path, class: 'btn btn-primary' %></p>
+  <p><%= link_to t('views.buttons.go_home'), home_page_path, class: 'btn btn-primary' %></p>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1493,3 +1493,61 @@ en:
       short: "%b %d %-I:%M %p"
     pm: pm
   'yes': 'Yes'
+  flash:
+    generic:
+      created: "%{resource} was successfully created."
+      updated: "%{resource} was successfully updated."
+      destroyed: "%{resource} was successfully destroyed."
+      removed: "%{resource} was successfully removed."
+      error_create: "Error creating %{resource}."
+      error_remove: "Failed to remove %{resource}."
+      queued: "%{resource} has been queued for sending."
+  errors:
+    wizard:
+      max_completions: "Maximum number of completions reached for this wizard and step definition."
+      one_uncompleted: "Only one uncompleted step per person is allowed."
+      step_limit: "Number of completions for this step has reached the wizard's max completions limit."
+    models:
+      protected_destroy: "This record is protected and cannot be destroyed."
+      address_missing_type: "Address must be either physical, postal, or both."
+      host_single: "can only be set for one record"
+    person_block:
+      cannot_block_self: "cannot block yourself"
+      cannot_block_manager: "cannot be a platform manager"
+  resources:
+    member: "Member"
+    report: "Report"
+    invitation: "Invitation"
+    invitation_email: "Invitation email"
+    page: "Page"
+  views:
+    buttons:
+      back: "Back"
+      create_report: "Create Report"
+      download: "Download"
+      go_home: "Go to Home"
+      new: "New %{resource}"
+      view_page: "View Page"
+    headers:
+      link_click_reports: "Link Click Reports"
+      page_view_reports: "Page View Reports"
+      new_link_click_report: "New Link Click Report"
+      new_page_view_report: "New Page View Report"
+    labels:
+      from_date: "From Date"
+      to_date: "To Date"
+      internal_filter: "Internal Filter"
+      pageable_type_filter: "Pageable Type Filter"
+      sort_by_total_clicks: "Sort by Total Clicks"
+      sort_by_total_views: "Sort by Total Views"
+      file_format: "File Format"
+      id: "ID"
+      created_at: "Created At"
+      filters: "Filters"
+      actions: "Actions"
+      all: "All"
+      internal: "Internal"
+      external: "External"
+      no_file: "No file"
+      protected: "Protected"
+      please_correct: "Please correct the following errors:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1492,3 +1492,61 @@ es:
       short: "%-d de %b %H:%M"
     pm: pm
   'yes': Sí
+  flash:
+    generic:
+      created: "%{resource} se creó correctamente."
+      updated: "%{resource} se actualizó correctamente."
+      destroyed: "%{resource} se eliminó correctamente."
+      removed: "%{resource} se eliminó correctamente."
+      error_create: "Error al crear %{resource}."
+      error_remove: "No se pudo eliminar %{resource}."
+      queued: "%{resource} se ha puesto en cola para enviar."
+  errors:
+    wizard:
+      max_completions: "Se alcanzó el número máximo de completaciones para este asistente y paso."
+      one_uncompleted: "Solo se permite un paso sin completar por persona."
+      step_limit: "El número de completaciones para este paso alcanzó el límite del asistente."
+    models:
+      protected_destroy: "Este registro está protegido y no se puede eliminar."
+      address_missing_type: "La dirección debe ser física, postal o ambas."
+      host_single: "solo se puede establecer para un registro"
+    person_block:
+      cannot_block_self: "no puedes bloquearte a ti mismo"
+      cannot_block_manager: "no puede ser un administrador de la plataforma"
+  resources:
+    member: "Miembro"
+    report: "Informe"
+    invitation: "Invitación"
+    invitation_email: "Correo de invitación"
+    page: "Página"
+  views:
+    buttons:
+      back: "Volver"
+      create_report: "Crear informe"
+      download: "Descargar"
+      go_home: "Ir al inicio"
+      new: "Nuevo %{resource}"
+      view_page: "Ver página"
+    headers:
+      link_click_reports: "Informes de clics en enlaces"
+      page_view_reports: "Informes de vistas de página"
+      new_link_click_report: "Nuevo informe de clics en enlaces"
+      new_page_view_report: "Nuevo informe de vistas de página"
+    labels:
+      from_date: "Desde fecha"
+      to_date: "Hasta fecha"
+      internal_filter: "Filtro interno"
+      pageable_type_filter: "Filtro de tipo"
+      sort_by_total_clicks: "Ordenar por clics totales"
+      sort_by_total_views: "Ordenar por vistas totales"
+      file_format: "Formato de archivo"
+      id: "ID"
+      created_at: "Creado el"
+      filters: "Filtros"
+      actions: "Acciones"
+      all: "Todos"
+      internal: "Interno"
+      external: "Externo"
+      no_file: "Sin archivo"
+      protected: "Protegido"
+      please_correct: "Corrige los siguientes errores:"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1514,3 +1514,61 @@ fr:
       short: "%d %b %Hh%M"
     pm: pm
   'yes': Oui
+  flash:
+    generic:
+      created: "%{resource} a été créé avec succès."
+      updated: "%{resource} a été mis à jour avec succès."
+      destroyed: "%{resource} a été supprimé avec succès."
+      removed: "%{resource} a été supprimé avec succès."
+      error_create: "Erreur lors de la création de %{resource}."
+      error_remove: "Échec de la suppression de %{resource}."
+      queued: "%{resource} a été mis en file d'attente pour l'envoi."
+  errors:
+    wizard:
+      max_completions: "Nombre maximal de validations atteint pour cet assistant et cette étape."
+      one_uncompleted: "Une seule étape non terminée par personne est autorisée."
+      step_limit: "Le nombre de validations pour cette étape a atteint la limite de l'assistant."
+    models:
+      protected_destroy: "Cet enregistrement est protégé et ne peut pas être supprimé."
+      address_missing_type: "L'adresse doit être physique, postale ou les deux."
+      host_single: "ne peut être défini que pour un seul enregistrement"
+    person_block:
+      cannot_block_self: "ne peut pas vous bloquer vous-même"
+      cannot_block_manager: "ne peut pas être un gestionnaire de plateforme"
+  resources:
+    member: "Membre"
+    report: "Rapport"
+    invitation: "Invitation"
+    invitation_email: "E-mail d'invitation"
+    page: "Page"
+  views:
+    buttons:
+      back: "Retour"
+      create_report: "Créer un rapport"
+      download: "Télécharger"
+      go_home: "Aller à l'accueil"
+      new: "Nouveau %{resource}"
+      view_page: "Voir la page"
+    headers:
+      link_click_reports: "Rapports de clics sur les liens"
+      page_view_reports: "Rapports de vues de page"
+      new_link_click_report: "Nouveau rapport de clics sur les liens"
+      new_page_view_report: "Nouveau rapport de vues de page"
+    labels:
+      from_date: "Date de début"
+      to_date: "Date de fin"
+      internal_filter: "Filtre interne"
+      pageable_type_filter: "Filtre de type"
+      sort_by_total_clicks: "Trier par clics totaux"
+      sort_by_total_views: "Trier par vues totales"
+      file_format: "Format de fichier"
+      id: "ID"
+      created_at: "Créé le"
+      filters: "Filtres"
+      actions: "Actions"
+      all: "Tous"
+      internal: "Interne"
+      external: "Externe"
+      no_file: "Aucun fichier"
+      protected: "Protégé"
+      please_correct: "Veuillez corriger les erreurs suivantes :"


### PR DESCRIPTION
## Summary
- Replace hard-coded flash messages in membership, invitation, report, and page controllers with i18n lookups.
- Move model validation strings into locale files for address, wizard steps, person blocks, and host protection.
- Translate metrics report views and error pages, adding corresponding keys to English, Spanish, and French locales.

## Testing
- `rubocop`
- `brakeman -q -w2`
- `bundler-audit --update`
- `bin/codex_style_guard` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.4)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a5049cf108321b1c13fa6c06922d0