### PR TITLE
Extract shared not-found handler

### DIFF
--- a/app/controllers/better_together/application_controller.rb
+++ b/app/controllers/better_together/application_controller.rb
@@ -23,8 +23,8 @@ module BetterTogether
       Rack::MiniProfiler.authorize_request if current_user&.permitted_to?('manage_platform')
     end
 
-    rescue_from ActiveRecord::RecordNotFound, with: :handle404
-    rescue_from ActionController::RoutingError, with: :handle404
+    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+    rescue_from ActionController::RoutingError, with: :render_not_found
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
     rescue_from StandardError, with: :handle_error
 
@@ -126,11 +126,7 @@ module BetterTogether
 
     private
 
-    def handle404
-      render_404
-    end
-
-    def render_404 # rubocop:todo Naming/VariableNumber
+    def render_not_found
       render 'errors/404', status: :not_found
     end
 

--- a/app/controllers/better_together/friendly_resource_controller.rb
+++ b/app/controllers/better_together/friendly_resource_controller.rb
@@ -23,7 +23,7 @@ module BetterTogether
       # 2. By friendly on all available locales
       @resource ||= find_by_translatable
 
-      handle404 && return if @resource.nil?
+      render_not_found && return if @resource.nil?
 
       @resource
     end

--- a/app/controllers/better_together/pages_controller.rb
+++ b/app/controllers/better_together/pages_controller.rb
@@ -17,7 +17,7 @@ module BetterTogether
 
     def show
       if @page.nil? || !@page.published?
-        render_404
+        render_not_found
       else
         authorize @page
         @content_blocks = @page.content_blocks
@@ -95,14 +95,14 @@ module BetterTogether
 
     private
 
-    def handle404
+    def render_not_found
       path = params[:path]
 
       # If page is not found and the path is one of the variants of the root path, render community engine promo page
       if ['home-page', 'home', "/#{I18n.locale}/", "/#{I18n.locale}", I18n.locale.to_s, 'bt', '/'].include?(path)
         render 'better_together/static_pages/community_engine'
       else
-        render_404
+        super
       end
     end
 
@@ -122,7 +122,7 @@ module BetterTogether
     def set_page
       @page = set_resource_instance
     rescue ActiveRecord::RecordNotFound
-      handle404
+      render_not_found && return
     end
 
     def page_params # rubocop:todo Metrics/MethodLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -204,7 +204,7 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
     end
 
     if Rails.env.development?
-      get '/404', to: 'application#render_404'
+      get '/404', to: 'application#render_not_found'
       get '/500', to: 'application#render_500'
     end
 

--- a/spec/requests/better_together/not_found_handler_spec.rb
+++ b/spec/requests/better_together/not_found_handler_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'NotFoundHandler', type: :request do
+  include BetterTogether::DeviseSessionHelpers
+
+  before do
+    configure_host_platform
+    post better_together.user_session_path, params: {
+      user: { email: 'manager@example.test', password: 'password12345' }
+    }
+  end
+
+  describe 'pages' do
+    it 'renders 404 for missing page' do
+      get '/en/nonexistent-page'
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'renders promo page for root variants' do
+      get '/en/home-page'
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Community Engine')
+    end
+  end
+
+  describe 'other resources' do
+    it 'renders 404 for missing post' do
+      get '/en/posts/nonexistent'
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- centralize not-found logic via `ApplicationController#render_not_found`
- call shared handler from pages and friendly resource controllers
- add request specs covering page and post not-found scenarios

## Testing
- `bundle exec rubocop` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0)*
- `bundle exec brakeman -q -w2` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0)*
- `bundle exec bundler-audit --update` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0)*
- `bin/codex_style_guard` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0)*
- `bin/ci` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0)*

------
https://chatgpt.com/codex/tasks/task_e_689a5593b9088321b39d55aa47834ad0