### PR TITLE
Localize host dashboard headings

### DIFF
--- a/app/views/better_together/host_dashboard/index.html.erb
+++ b/app/views/better_together/host_dashboard/index.html.erb
@@ -1,16 +1,16 @@
 <% content_for :page_title do %>
-  Dashboard
+  <%= t('host_dashboard.index.page_title') %>
 <% end %>
 
 <div class="container my-3">
-  <h1>Dashboard</h1>
+  <h1><%= t('host_dashboard.index.title') %></h1>
 
   <!-- Custom section for the host app -->
   <%= render partial: 'host_app_resources' %>
 
   <!-- Better Together Resources Section -->
   <div class="better-together-resources mt-4">
-    <h2><%= t('.better_together') %></h2>
+    <h2><%= t('host_dashboard.index.better_together') %></h2>
     <div class="row mt-3 row-cols-1 row-cols-sm-2 row-cols-md-3">
       <!-- Communities -->
       <%= render partial: 'resource_card', locals: { collection: @communities, count: @community_count, url_helper: :community_path } %>
@@ -42,14 +42,14 @@
 
     <div id="content-section" class="row mt-3">
       <div class="col-12">
-        <h3><%= t('.content') %></h3>
+        <h3><%= t('host_dashboard.index.content') %></h3>
       </div>
       <%= render partial: 'resource_card', locals: { model_class: ::BetterTogether::Content::Block, collection: @content_blocks, count: @content_block_count, url_helper: :content_block_path } %>
     </div>
 
     <div id="geography-section" class="row mt-3">
       <div class="col-12">
-        <h3><%= t('.geography') %></h3>
+        <h3><%= t('host_dashboard.index.geography') %></h3>
       </div>
       <%= render partial: 'resource_card', locals: {collection: @geography_continents, count: @geography_continent_count, url_helper: :geography_continent_path } %>
       <%= render partial: 'resource_card', locals: {collection: @geography_countries, count: @geography_country_count, url_helper: :geography_country_path } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -727,11 +727,6 @@ en:
           title: Title
     global:
       add: Add
-    host_dashboard:
-      index:
-        better_together: Better together
-        content: Content
-        geography: Geography
     hub:
       index:
         activity: Activity
@@ -1349,6 +1344,12 @@ en:
       type: Type
     type_select_field: Select the type for this field.
   host_dashboard:
+    index:
+      page_title: Host Dashboard
+      title: Host Dashboard
+      better_together: Better together
+      content: Content
+      geography: Geography
     resource_card:
       new_resource: New %{resource}
       none_yet: None yet

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -730,11 +730,6 @@ es:
           title: Título
     global:
       add: Agregar
-    host_dashboard:
-      index:
-        better_together: Mejor juntos
-        content: Contenido
-        geography: Geografía
     hub:
       index:
         activity: Activity
@@ -1337,6 +1332,12 @@ es:
       type: Tipo
     type_select_field: Seleccione el tipo para este campo.
   host_dashboard:
+    index:
+      page_title: Panel de control del anfitrión
+      title: Panel de control del anfitrión
+      better_together: Mejor juntos
+      content: Contenido
+      geography: Geografía
     resource_card:
       new_resource: Nuevo %{resource}
       none_yet: Ninguno aún

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -733,11 +733,6 @@ fr:
           title: Titre
     global:
       add: Ajouter
-    host_dashboard:
-      index:
-        better_together: Mieux ensemble
-        content: Contenu
-        geography: Géographie
     hub:
       index:
         activity: Activity
@@ -1363,6 +1358,12 @@ fr:
       type: Type
     type_select_field: Sélectionnez le type pour ce champ.
   host_dashboard:
+    index:
+      page_title: Tableau de bord de l'hôte
+      title: Tableau de bord de l'hôte
+      better_together: Mieux ensemble
+      content: Contenu
+      geography: Géographie
     resource_card:
       new_resource: Nouveau %{resource}
       none_yet: Aucun pour l'instant


### PR DESCRIPTION
## Summary
- localize host dashboard titles and section headings

## Testing
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bin/codex_style_guard`
- `bin/ci` *(fails: connection to server at "::1", port 5432 failed: fe_sendauth: no password supplied)*

------
https://chatgpt.com/codex/tasks/task_e_689a5904f1e0832196acf1596ee0555c