### PR TITLE
Refactor host dashboard resource listing

### DIFF
--- a/app/controllers/better_together/host_dashboard_controller.rb
+++ b/app/controllers/better_together/host_dashboard_controller.rb
@@ -1,44 +1,50 @@
 # frozen_string_literal: true
 
 module BetterTogether
-  class HostDashboardController < ApplicationController # rubocop:todo Style/Documentation
-    def index # rubocop:todo Metrics/MethodLength
-      root_classes = [
-        Community, NavigationArea, Page, Platform, Person, Role, ResourcePermission, User,
-        Conversation, Message, Category
-      ]
+  # Displays recent resources and counts on the host dashboard
+  class HostDashboardController < ApplicationController
+    ROOT_RESOURCE_DEFINITIONS = [
+      [Community, :community_path],
+      [NavigationArea, :navigation_area_path],
+      [Page, :page_path],
+      [Platform, :platform_path],
+      [Person, :person_path],
+      [Role, :role_path],
+      [ResourcePermission, :resource_permission_path],
+      [User, :user_path],
+      [Conversation, :conversation_path],
+      [Message, :message_path],
+      [Category, :category_path]
+    ].freeze
 
-      root_classes.each do |klass|
-        # sets @klasses and @klass_count instance variables
-        set_resource_variables(klass)
-      end
+    CONTENT_RESOURCE_DEFINITIONS = [
+      [Content::Block, :content_block_path]
+    ].freeze
 
-      content_classes = [
-        Content::Block
-      ]
+    GEOGRAPHY_RESOURCE_DEFINITIONS = [
+      [Geography::Continent, :geography_continent_path],
+      [Geography::Country, :geography_country_path],
+      [Geography::State, :geography_state_path],
+      [Geography::Region, :geography_region_path],
+      [Geography::Settlement, :geography_settlement_path]
+    ].freeze
 
-      content_classes.each do |klass|
-        # sets @content_klasses and @content_klass_count instance variables
-        set_resource_variables(klass, prefix: 'content')
-      end
-
-      geography_classes = [
-        Geography::Continent, Geography::Country, Geography::State, Geography::Region, Geography::Settlement
-      ]
-
-      geography_classes.each do |klass|
-        # sets @geography_klasses and @geography_klass_count instance variables
-        set_resource_variables(klass, prefix: 'geography')
-      end
+    def index
+      @root_resources = build_resources(ROOT_RESOURCE_DEFINITIONS)
+      @content_resources = build_resources(CONTENT_RESOURCE_DEFINITIONS)
+      @geography_resources = build_resources(GEOGRAPHY_RESOURCE_DEFINITIONS)
     end
 
-    protected
+    private
 
-    def set_resource_variables(klass, prefix: nil)
-      variable_name = klass.model_name.name.demodulize.underscore
-      instance_variable_set(:"@#{"#{prefix}_" if prefix}#{variable_name.pluralize}",
-                            klass.order(created_at: :desc).limit(3))
-      instance_variable_set(:"@#{"#{prefix}_" if prefix}#{variable_name}_count", klass.count)
+    def build_resources(definitions)
+      definitions.map do |klass, helper|
+        {
+          collection: klass.order(created_at: :desc).limit(3),
+          count: klass.count,
+          url_helper: helper
+        }
+      end
     end
   end
 end

--- a/app/views/better_together/host_dashboard/index.html.erb
+++ b/app/views/better_together/host_dashboard/index.html.erb
@@ -12,50 +12,27 @@
   <div class="better-together-resources mt-4">
     <h2><%= t('.better_together') %></h2>
     <div class="row mt-3 row-cols-1 row-cols-sm-2 row-cols-md-3">
-      <!-- Communities -->
-      <%= render partial: 'resource_card', locals: { collection: @communities, count: @community_count, url_helper: :community_path } %>
-
-      <!-- Navigation Areas -->
-      <%= render partial: 'resource_card', locals: { collection: @navigation_areas, count: @navigation_area_count, url_helper: :navigation_area_path } %>
-
-      <!-- Pages -->
-      <%= render partial: 'resource_card', locals: { collection: @pages, count: @page_count, url_helper: :page_path } %>
-
-      <!-- Platforms -->
-      <%= render partial: 'resource_card', locals: { collection: @platforms, count: @platform_count, url_helper: :platform_path } %>
-
-      <!-- People -->
-      <%= render partial: 'resource_card', locals: { collection: @people, count: @person_count, url_helper: :person_path } %>
-
-      <!-- Roles -->
-      <%= render partial: 'resource_card', locals: { collection: @roles, count: @role_count, url_helper: :role_path } %>
-
-      <!-- Resource Permissions -->
-      <%= render partial: 'resource_card', locals: { collection: @resource_permissions, count: @resource_permission_count, url_helper: :resource_permission_path } %>
-
-      <!-- Users -->
-      <%= render partial: 'resource_card', locals: { collection: @users, count: @user_count, url_helper: :user_path } %>
-      <%= render partial: 'resource_card', locals: { collection: @conversations, count: @conversation_count, url_helper: :conversation_path } %>
-      <%= render partial: 'resource_card', locals: { collection: @messages, count: @message_count, url_helper: :message_path } %>
-      <%= render partial: 'resource_card', locals: { collection: @categories, count: @category_count, url_helper: :category_path } %>
+      <% @root_resources.each do |resource| %>
+        <%= render partial: 'resource_card', locals: resource %>
+      <% end %>
     </div>
 
     <div id="content-section" class="row mt-3">
       <div class="col-12">
         <h3><%= t('.content') %></h3>
       </div>
-      <%= render partial: 'resource_card', locals: { model_class: ::BetterTogether::Content::Block, collection: @content_blocks, count: @content_block_count, url_helper: :content_block_path } %>
+      <% @content_resources.each do |resource| %>
+        <%= render partial: 'resource_card', locals: resource %>
+      <% end %>
     </div>
 
     <div id="geography-section" class="row mt-3">
       <div class="col-12">
         <h3><%= t('.geography') %></h3>
       </div>
-      <%= render partial: 'resource_card', locals: {collection: @geography_continents, count: @geography_continent_count, url_helper: :geography_continent_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_countries, count: @geography_country_count, url_helper: :geography_country_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_states, count: @geography_state_count, url_helper: :geography_state_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_regions, count: @geography_region_count, url_helper: :geography_region_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_settlements, count: @geography_settlement_count, url_helper: :geography_settlement_path } %>
+      <% @geography_resources.each do |resource| %>
+        <%= render partial: 'resource_card', locals: resource %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/spec/controllers/better_together/host_dashboard_controller_spec.rb
+++ b/spec/controllers/better_together/host_dashboard_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BetterTogether::HostDashboardController, type: :controller do
+  describe '#build_resources' do
+    it 'returns hashes with collection, count, and url helper' do
+      create_list(:community, 4)
+
+      result = controller.send(:build_resources, [[BetterTogether::Community, :community_path]])
+      resource = result.first
+
+      expect(resource[:collection]).to eq(BetterTogether::Community.order(created_at: :desc).limit(3))
+      expect(resource[:count]).to eq(BetterTogether::Community.count)
+      expect(resource[:url_helper]).to eq(:community_path)
+    end
+  end
+end

--- a/spec/requests/better_together/host_dashboard_spec.rb
+++ b/spec/requests/better_together/host_dashboard_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'HostDashboard', type: :request do
+  describe 'GET /host/host_dashboard' do
+    let(:user) { create(:user, :confirmed, :platform_manager) }
+
+    before do
+      sign_in user
+    end
+
+    it 'renders recent resources for each resource group' do
+      community = create(:community)
+      block = create(:content_block_base)
+      country = create(:geography_country)
+
+      get better_together_host_dashboard_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(community.to_s)
+      expect(response.body).to include(block.to_s)
+      expect(response.body).to include(country.to_s)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Promote host dashboard resource configuration to frozen constants for simpler extension
- Add controller and request specs covering dashboard resource rendering

## Testing
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.4)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a591289ec832192620621a4d82f91