### PR TITLE
Validate categories presence for Joatu offers and requests

### DIFF
--- a/app/models/better_together/joatu/offer.rb
+++ b/app/models/better_together/joatu/offer.rb
@@ -22,6 +22,7 @@ module BetterTogether
       translates :description, type: :text
 
       validates :name, :description, :creator, presence: true
+      validates :categories, presence: true
       validates :status, presence: true, inclusion: { in: STATUS_VALUES.values }
 
       enum status: STATUS_VALUES, _prefix: :status

--- a/app/models/better_together/joatu/request.rb
+++ b/app/models/better_together/joatu/request.rb
@@ -22,6 +22,7 @@ module BetterTogether
       translates :description, type: :text
 
       validates :name, :description, :creator, presence: true
+      validates :categories, presence: true
       validates :status, presence: true, inclusion: { in: STATUS_VALUES.values }
 
       enum status: STATUS_VALUES, _prefix: :status

--- a/spec/factories/better_together/joatu/offers.rb
+++ b/spec/factories/better_together/joatu/offers.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     name { Faker::Commerce.product_name }
     description { Faker::Lorem.paragraph }
     creator { association :better_together_person }
+
+    after(:build) do |offer|
+      offer.categories << build(:better_together_joatu_category) if offer.categories.blank?
+    end
   end
 end

--- a/spec/factories/better_together/joatu/requests.rb
+++ b/spec/factories/better_together/joatu/requests.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     name { Faker::Commerce.material }
     description { Faker::Lorem.paragraph }
     creator { association :better_together_person }
+
+    after(:build) do |request|
+      request.categories << build(:better_together_joatu_category) if request.categories.blank?
+    end
   end
 end

--- a/spec/models/better_together/joatu/offer_spec.rb
+++ b/spec/models/better_together/joatu/offer_spec.rb
@@ -15,6 +15,11 @@ module BetterTogether
         offer.creator = nil
         expect(offer).not_to be_valid
       end
+
+      it 'is invalid without categories' do
+        offer.categories = []
+        expect(offer).not_to be_valid
+      end
     end
   end
 end

--- a/spec/models/better_together/joatu/request_spec.rb
+++ b/spec/models/better_together/joatu/request_spec.rb
@@ -15,6 +15,11 @@ module BetterTogether
         request_model.creator = nil
         expect(request_model).not_to be_valid
       end
+
+      it 'is invalid without categories' do
+        request_model.categories = []
+        expect(request_model).not_to be_valid
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- enforce categories presence for Joatu offers and requests
- ensure factories attach at least one category
- test validations for category presence

## Testing
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689a5b5040e883219a82c326078ee09f