### PR TITLE
Document host dashboard extensions and reference in view

### DIFF
--- a/app/views/better_together/host_dashboard/index.html.erb
+++ b/app/views/better_together/host_dashboard/index.html.erb
@@ -5,7 +5,7 @@
 <div class="container my-3">
   <h1>Dashboard</h1>
 
-  <!-- Custom section for the host app -->
+  <!-- Custom section for the host app. See docs/host_dashboard_extensions.md for details. -->
   <%= render partial: 'host_app_resources' %>
 
   <!-- Better Together Resources Section -->

--- a/docs/host_dashboard_extensions.md
+++ b/docs/host_dashboard_extensions.md
@@ -1,0 +1,24 @@
+# Host Dashboard Extensions
+
+The host dashboard provided by Better Together includes a hook for host applications to display custom resources.
+
+To add your own content, create the following partial in your host application:
+
+```
+app/views/better_together/host_dashboard/_host_app_resources.html.erb
+```
+
+Any markup placed in this partial will be rendered near the top of the dashboard. This is useful for linking to admin areas or providing host-specific information.
+
+Example:
+
+```erb
+<!-- host app: app/views/better_together/host_dashboard/_host_app_resources.html.erb -->
+<div class="row my-4">
+  <div class="col">
+    <%= link_to 'My Custom Admin Area', my_custom_path, class: 'btn btn-primary' %>
+  </div>
+</div>
+```
+
+If the partial is absent, the dashboard simply skips this section.


### PR DESCRIPTION
## Summary
- document how host apps can inject custom resources into the host dashboard via a `_host_app_resources` partial
- reference the new doc from the host dashboard view

## Testing
- `bundle install` *(failed: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.4)*
- `bin/ci` *(failed: bundler: command not found: rails)*
- `bundle exec rubocop` *(failed: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(failed: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(failed: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(failed: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689a5b7a3f2c83219e744f552ea3a056