### PR TITLE
Add Joatu matchmaking and agreement controllers

### DIFF
--- a/app/controllers/better_together/joatu/agreements_controller.rb
+++ b/app/controllers/better_together/joatu/agreements_controller.rb
@@ -1,0 +1,37 @@
+module BetterTogether
+  module Joatu
+    # AgreementsController manages offer-request agreements
+    class AgreementsController < ApplicationController
+      before_action :set_agreement, only: %i[show accept reject]
+
+      # POST /joatu/requests/:request_id/agreements
+      def create
+        request = BetterTogether::Joatu::Request.find(params[:request_id])
+        offer = BetterTogether::Joatu::Offer.find(params[:offer_id])
+        @agreement = BetterTogether::Joatu::Agreement.create!(request:, offer:, terms: params[:terms], value: params[:value])
+        redirect_to joatu_agreement_path(@agreement)
+      end
+
+      # GET /joatu/agreements/:id
+      def show; end
+
+      # POST /joatu/agreements/:id/accept
+      def accept
+        @agreement.accept!
+        redirect_to joatu_agreement_path(@agreement), notice: 'Agreement accepted'
+      end
+
+      # POST /joatu/agreements/:id/reject
+      def reject
+        @agreement.reject!
+        redirect_to joatu_agreement_path(@agreement), notice: 'Agreement rejected'
+      end
+
+      private
+
+      def set_agreement
+        @agreement = BetterTogether::Joatu::Agreement.find(params[:id])
+      end
+    end
+  end
+end

--- a/app/controllers/better_together/joatu/requests_controller.rb
+++ b/app/controllers/better_together/joatu/requests_controller.rb
@@ -1,0 +1,12 @@
+module BetterTogether
+  module Joatu
+    # RequestsController handles Joatu request operations
+    class RequestsController < ApplicationController
+      # GET /joatu/requests/:id/matches
+      def matches
+        @request = BetterTogether::Joatu::Request.find(params[:id])
+        @matches = BetterTogether::Joatu::Matchmaker.match(@request)
+      end
+    end
+  end
+end

--- a/app/views/better_together/joatu/agreements/show.html.erb
+++ b/app/views/better_together/joatu/agreements/show.html.erb
@@ -1,0 +1,9 @@
+<h1>Agreement</h1>
+<p>Offer: <%= @agreement.offer.name %></p>
+<p>Request: <%= @agreement.request.name %></p>
+<p>Status: <%= @agreement.status %></p>
+
+<% unless @agreement.status_accepted? || @agreement.status_rejected? %>
+  <%= button_to 'Accept', accept_joatu_agreement_path(@agreement), method: :post %>
+  <%= button_to 'Reject', reject_joatu_agreement_path(@agreement), method: :post %>
+<% end %>

--- a/app/views/better_together/joatu/requests/matches.html.erb
+++ b/app/views/better_together/joatu/requests/matches.html.erb
@@ -1,0 +1,9 @@
+<h1>Matching Offers</h1>
+<ul>
+  <% @matches.each do |offer| %>
+    <li>
+      <%= offer.name %>
+      <%= button_to 'Create Agreement', joatu_request_agreements_path(@request, offer_id: offer.id), method: :post %>
+    </li>
+  <% end %>
+</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,6 +170,23 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
         resources :search_queries, only: [:create]
       end
 
+      namespace :joatu do
+        resources :requests, only: [] do
+          member do
+            get :matches
+          end
+
+          resources :agreements, only: [:create]
+        end
+
+        resources :agreements, only: [:show] do
+          member do
+            post :accept
+            post :reject
+          end
+        end
+      end
+
       resources :wizards, only: [:show] do
         # Custom route for wizard steps
         get ':wizard_step_definition_id', to: 'wizard_steps#show', as: :step

--- a/spec/requests/better_together/joatu/matchmaking_spec.rb
+++ b/spec/requests/better_together/joatu/matchmaking_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Joatu matchmaking', type: :request do
+  let(:requestor) { create(:better_together_person) }
+  let(:offeror) { create(:better_together_person) }
+  let(:category) { create(:better_together_joatu_category) }
+  let!(:offer) do
+    create(:better_together_joatu_offer, creator: offeror).tap do |o|
+      o.categories << category
+    end
+  end
+  let!(:request_model) do
+    create(:better_together_joatu_request, creator: requestor).tap do |r|
+      r.categories << category
+    end
+  end
+  let(:locale) { I18n.default_locale }
+
+  describe 'GET /joatu/requests/:id/matches' do
+    it 'renders matching offers' do
+      get "/#{locale}/joatu/requests/#{request_model.id}/matches"
+      expect(response.body).to include(offer.name)
+    end
+  end
+
+  describe 'POST /joatu/requests/:request_id/agreements' do
+    it 'creates an agreement and accepts it' do
+      post "/#{locale}/joatu/requests/#{request_model.id}/agreements", params: { offer_id: offer.id }
+      agreement = BetterTogether::Joatu::Agreement.last
+      expect(agreement.offer).to eq(offer)
+
+      post "/#{locale}/joatu/agreements/#{agreement.id}/accept"
+      expect(agreement.reload.status_accepted?).to be true
+    end
+
+    it 'rejects an agreement' do
+      agreement = BetterTogether::Joatu::Agreement.create!(offer:, request: request_model, terms: '', value: '')
+      post "/#{locale}/joatu/agreements/#{agreement.id}/reject"
+      expect(agreement.reload.status_rejected?).to be true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `Joatu::RequestsController#matches` calling Matchmaker
- implement agreements controller with create, accept, and reject actions
- render match and agreement views with controls to create and finalize agreements
- add request specs for matchmaking flow

## Testing
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: command not found: rubocop)*
- `bin/ci` *(fails: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a5b4c0f0483219c0a4208c9a73431