### PR TITLE
Add Joatu CRUD controllers with routes and specs

### DIFF
--- a/app/controllers/better_together/joatu/agreements_controller.rb
+++ b/app/controllers/better_together/joatu/agreements_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # CRUD for Joatu agreements
+    class AgreementsController < ResourceController
+      private
+
+      def resource_class
+        BetterTogether::Joatu::Agreement
+      end
+
+      def permitted_attributes
+        super + %i[offer_id request_id terms value status]
+      end
+    end
+  end
+end

--- a/app/controllers/better_together/joatu/offers_controller.rb
+++ b/app/controllers/better_together/joatu/offers_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # CRUD for Joatu offers
+    class OffersController < ResourceController
+      private
+
+      def resource_class
+        BetterTogether::Joatu::Offer
+      end
+
+      def permitted_attributes
+        super + %i[status name description]
+      end
+    end
+  end
+end

--- a/app/controllers/better_together/joatu/requests_controller.rb
+++ b/app/controllers/better_together/joatu/requests_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # CRUD for Joatu requests
+    class RequestsController < ResourceController
+      private
+
+      def resource_class
+        BetterTogether::Joatu::Request
+      end
+
+      def permitted_attributes
+        super + %i[status name description]
+      end
+    end
+  end
+end

--- a/app/policies/better_together/joatu/agreement_policy.rb
+++ b/app/policies/better_together/joatu/agreement_policy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # Authorization for Joatu agreements
+    class AgreementPolicy < ApplicationPolicy
+      def index?
+        user.present?
+      end
+
+      def show?
+        user.present?
+      end
+
+      def create?
+        user.present?
+      end
+
+      def update?
+        user.present?
+      end
+
+      def destroy?
+        user.present?
+      end
+
+      class Scope < ApplicationPolicy::Scope
+      end
+    end
+  end
+end

--- a/app/policies/better_together/joatu/offer_policy.rb
+++ b/app/policies/better_together/joatu/offer_policy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # Authorization for Joatu offers
+    class OfferPolicy < ApplicationPolicy
+      def index?
+        user.present?
+      end
+
+      def show?
+        user.present?
+      end
+
+      def create?
+        user.present?
+      end
+
+      def update?
+        user.present?
+      end
+
+      def destroy?
+        user.present?
+      end
+
+      class Scope < ApplicationPolicy::Scope
+      end
+    end
+  end
+end

--- a/app/policies/better_together/joatu/request_policy.rb
+++ b/app/policies/better_together/joatu/request_policy.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # Authorization for Joatu requests
+    class RequestPolicy < ApplicationPolicy
+      def index?
+        user.present?
+      end
+
+      def show?
+        user.present?
+      end
+
+      def create?
+        user.present?
+      end
+
+      def update?
+        user.present?
+      end
+
+      def destroy?
+        user.present?
+      end
+
+      class Scope < ApplicationPolicy::Scope
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,12 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
         resources :person_blocks, path: :blocks, only: %i[index create destroy]
         resources :reports, only: [:create]
 
+        namespace :joatu do
+          resources :offers
+          resources :requests
+          resources :agreements
+        end
+
         resources :maps, module: :geography
 
         scope path: :p do

--- a/spec/requests/better_together/joatu/agreements_spec.rb
+++ b/spec/requests/better_together/joatu/agreements_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BetterTogether::Joatu::Agreements', type: :request do
+  routes { BetterTogether::Engine.routes }
+
+  let(:user) { create(:user, :confirmed) }
+  let(:offer) { create(:joatu_offer) }
+  let(:request_record) { create(:joatu_request) }
+  let(:valid_attributes) { { offer_id: offer.id, request_id: request_record.id, terms: 'terms', value: 'value' } }
+  let(:agreement) { create(:joatu_agreement) }
+
+  before { login(user) }
+
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: "/#{I18n.locale}/joatu/agreements").to route_to('better_together/joatu/agreements#index', locale: I18n.locale.to_s)
+    end
+  end
+
+  describe 'GET /index' do
+    it 'returns success' do
+      get better_together.joatu_agreements_path(locale: I18n.locale)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    it 'creates an agreement' do
+      expect do
+        post better_together.joatu_agreements_path(locale: I18n.locale), params: { agreement: valid_attributes }
+      end.to change(BetterTogether::Joatu::Agreement, :count).by(1)
+    end
+  end
+
+  describe 'GET /show' do
+    it 'returns success' do
+      get better_together.joatu_agreement_path(agreement, locale: I18n.locale)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'PATCH /update' do
+    it 'updates the agreement' do
+      patch better_together.joatu_agreement_path(agreement, locale: I18n.locale), params: { agreement: { status: 'accepted' } }
+      expect(response).to redirect_to(better_together.joatu_agreement_path(agreement, locale: I18n.locale))
+      expect(agreement.reload.status).to eq('accepted')
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the agreement' do
+      to_delete = create(:joatu_agreement)
+      expect do
+        delete better_together.joatu_agreement_path(to_delete, locale: I18n.locale)
+      end.to change(BetterTogether::Joatu::Agreement, :count).by(-1)
+    end
+  end
+end

--- a/spec/requests/better_together/joatu/offers_spec.rb
+++ b/spec/requests/better_together/joatu/offers_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BetterTogether::Joatu::Offers', type: :request do
+  routes { BetterTogether::Engine.routes }
+
+  let(:user) { create(:user, :confirmed) }
+  let(:person) { user.person }
+  let(:valid_attributes) { { name: 'New Offer', description: 'Offer description', creator_id: person.id } }
+  let(:offer) { create(:joatu_offer) }
+
+  before { login(user) }
+
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: "/#{I18n.locale}/joatu/offers").to route_to('better_together/joatu/offers#index', locale: I18n.locale.to_s)
+    end
+  end
+
+  describe 'GET /index' do
+    it 'returns success' do
+      get better_together.joatu_offers_path(locale: I18n.locale)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    it 'creates an offer' do
+      expect do
+        post better_together.joatu_offers_path(locale: I18n.locale), params: { offer: valid_attributes }
+      end.to change(BetterTogether::Joatu::Offer, :count).by(1)
+    end
+  end
+
+  describe 'GET /show' do
+    it 'returns success' do
+      get better_together.joatu_offer_path(offer, locale: I18n.locale)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'PATCH /update' do
+    it 'updates the offer' do
+      patch better_together.joatu_offer_path(offer, locale: I18n.locale), params: { offer: { status: 'closed' } }
+      expect(response).to redirect_to(better_together.joatu_offer_path(offer, locale: I18n.locale))
+      expect(offer.reload.status).to eq('closed')
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the offer' do
+      offer_to_delete = create(:joatu_offer)
+      expect do
+        delete better_together.joatu_offer_path(offer_to_delete, locale: I18n.locale)
+      end.to change(BetterTogether::Joatu::Offer, :count).by(-1)
+    end
+  end
+end

--- a/spec/requests/better_together/joatu/requests_spec.rb
+++ b/spec/requests/better_together/joatu/requests_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BetterTogether::Joatu::Requests', type: :request do
+  routes { BetterTogether::Engine.routes }
+
+  let(:user) { create(:user, :confirmed) }
+  let(:person) { user.person }
+  let(:valid_attributes) { { name: 'New Request', description: 'Request description', creator_id: person.id } }
+  let(:request_record) { create(:joatu_request) }
+
+  before { login(user) }
+
+  describe 'routing' do
+    it 'routes to #index' do
+      expect(get: "/#{I18n.locale}/joatu/requests").to route_to('better_together/joatu/requests#index', locale: I18n.locale.to_s)
+    end
+  end
+
+  describe 'GET /index' do
+    it 'returns success' do
+      get better_together.joatu_requests_path(locale: I18n.locale)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'POST /create' do
+    it 'creates a request' do
+      expect do
+        post better_together.joatu_requests_path(locale: I18n.locale), params: { request: valid_attributes }
+      end.to change(BetterTogether::Joatu::Request, :count).by(1)
+    end
+  end
+
+  describe 'GET /show' do
+    it 'returns success' do
+      get better_together.joatu_request_path(request_record, locale: I18n.locale)
+      expect(response).to be_successful
+    end
+  end
+
+  describe 'PATCH /update' do
+    it 'updates the request' do
+      patch better_together.joatu_request_path(request_record, locale: I18n.locale), params: { request: { status: 'closed' } }
+      expect(response).to redirect_to(better_together.joatu_request_path(request_record, locale: I18n.locale))
+      expect(request_record.reload.status).to eq('closed')
+    end
+  end
+
+  describe 'DELETE /destroy' do
+    it 'destroys the request' do
+      to_delete = create(:joatu_request)
+      expect do
+        delete better_together.joatu_request_path(to_delete, locale: I18n.locale)
+      end.to change(BetterTogether::Joatu::Request, :count).by(-1)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add Joatu offers, requests, and agreements controllers with CRUD support
- namespace Joatu resources in routes
- provide request specs and basic policies

## Testing
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: command not found: rubocop)*
- `bin/ci` *(fails: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a5b4427e88321863a18e8d46922ab