### PR TITLE
Add Joatu offer/request views and feature specs

### DIFF
--- a/app/controllers/better_together/joatu/offers_controller.rb
+++ b/app/controllers/better_together/joatu/offers_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # CRUD for BetterTogether::Joatu::Offer
+    class OffersController < ResourceController
+      protected
+
+      def resource_class
+        ::BetterTogether::Joatu::Offer
+      end
+
+      def resource_params
+        super.tap do |attrs|
+          attrs[:creator_id] = helpers.current_person&.id if action_name == 'create'
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/better_together/joatu/requests_controller.rb
+++ b/app/controllers/better_together/joatu/requests_controller.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # CRUD for BetterTogether::Joatu::Request
+    class RequestsController < ResourceController
+      protected
+
+      def resource_class
+        ::BetterTogether::Joatu::Request
+      end
+
+      def resource_params
+        super.tap do |attrs|
+          attrs[:creator_id] = helpers.current_person&.id if action_name == 'create'
+        end
+      end
+    end
+  end
+end

--- a/app/views/better_together/joatu/offers/_form.html.erb
+++ b/app/views/better_together/joatu/offers/_form.html.erb
@@ -1,0 +1,47 @@
+<%= form_with(model: offer, class: 'form', id: dom_id(offer, 'form'), data: { controller: "better_together--form-validation" }) do |form| %>
+  <%= form.hidden_field :creator_id, value: current_person&.id unless form.object.creator_id %>
+  <% content_for :resource_toolbar do %>
+    <div class="btn-toolbar mb-3" role="toolbar" aria-label="<%= t('helpers.toolbar.aria_label') %>">
+      <div class="btn-group me-2" role="group">
+        <%= link_to t('better_together.joatu.offers.back_to_offers', default: 'Back to Offers'), joatu_offers_path, class: 'btn btn-secondary' %>
+      </div>
+      <div class="btn-group me-2" role="group">
+        <%= form.submit t('better_together.joatu.offers.save_offer', default: 'Save Offer'), class: 'btn btn-primary' %>
+      </div>
+      <% if offer.persisted? %>
+        <div class="btn-group me-2" role="group">
+          <%= link_to t('better_together.joatu.offers.view_offer', default: 'View Offer'), offer, class: 'btn btn-info' %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= yield :resource_toolbar %>
+
+  <% if offer.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= t('helpers.errors.heading') %></h4>
+      <ul>
+        <% offer.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= render partial: 'better_together/shared/translated_string_field', locals: { model: offer, form: form, attribute: 'name' } %>
+  </div>
+
+  <div class="mb-3">
+    <%= render partial: 'better_together/shared/translated_text_field', locals: { model: offer, form: form, attribute: 'description' } %>
+  </div>
+
+  <div class="mb-3">
+    <%= required_label form, :categories %>
+    <%= form.select :category_ids, options_from_collection_for_select(BetterTogether::Joatu::Category.positioned.all.includes(:string_translations), :id, :name, offer.category_ids), { include_blank: true, multiple: true }, class: 'form-select', data: { controller: 'better_together--slim_select' } %>
+    <small class="form-text text-muted"><%= t('hints.categories.select_multiple') %></small>
+  </div>
+
+  <%= yield :resource_toolbar %>
+<% end %>

--- a/app/views/better_together/joatu/offers/edit.html.erb
+++ b/app/views/better_together/joatu/offers/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title do %>
+  <%= t('better_together.joatu.offers.edit_offer', default: 'Edit Offer') %>
+<% end %>
+
+<div class="container my-3">
+  <h1><%= t('better_together.joatu.offers.edit_offer', default: 'Edit Offer') %></h1>
+
+  <%= render 'form', offer: @offer %>
+</div>

--- a/app/views/better_together/joatu/offers/index.html.erb
+++ b/app/views/better_together/joatu/offers/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title do %>
+  <%= resource_class.model_name.human.pluralize %>
+<% end %>
+
+<div class="container my-3">
+  <div class="d-flex justify-content-between align-items-center">
+    <h1><%= resource_class.model_name.human.pluralize %></h1>
+    <% if policy(resource_class).create? %>
+      <%= link_to new_joatu_offer_path, class: 'btn btn-primary', 'aria-label' => 'Add Offer' do %>
+        <i class="fas fa-plus"></i> <%= t('better_together.joatu.offers.new_offer', default: 'New Offer') %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <ul id="offers" class="list-unstyled">
+    <% @offers.each do |offer| %>
+      <li><%= link_to offer.name, offer %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/better_together/joatu/offers/new.html.erb
+++ b/app/views/better_together/joatu/offers/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title do %>
+  <%= t('better_together.joatu.offers.new_offer', default: 'New Offer') %>
+<% end %>
+
+<div class="container my-3">
+  <h1><%= t('better_together.joatu.offers.new_offer', default: 'New Offer') %></h1>
+
+  <%= render 'form', offer: @offer %>
+</div>

--- a/app/views/better_together/joatu/offers/show.html.erb
+++ b/app/views/better_together/joatu/offers/show.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title do %>
+  <%= @offer %> | <%= resource_class.model_name.human.pluralize %>
+<% end %>
+
+<div class="container my-3">
+  <h1 class="mb-4"><%= @offer.name %></h1>
+
+  <div class="mb-3">
+    <%= simple_format(@offer.description) %>
+  </div>
+
+  <div class="mt-3">
+    <% if policy(resource_class).index? %>
+      <%= link_to t('better_together.joatu.offers.back_to_offers', default: 'Back to Offers'), joatu_offers_path, class: 'btn btn-sm btn-outline-secondary' %>
+    <% end %>
+    <% if policy(@offer).edit? %>
+      <%= link_to edit_joatu_offer_path(@offer), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Offer' do %>
+        <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+      <% end %>
+    <% end %>
+    <% if policy(@offer).destroy? %>
+      <%= link_to joatu_offer_path(@offer), data: { turbo_method: :delete, turbo_confirm: t('globals.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Record' do %>
+        <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/better_together/joatu/requests/_form.html.erb
+++ b/app/views/better_together/joatu/requests/_form.html.erb
@@ -1,0 +1,47 @@
+<%= form_with(model: request, class: 'form', id: dom_id(request, 'form'), data: { controller: "better_together--form-validation" }) do |form| %>
+  <%= form.hidden_field :creator_id, value: current_person&.id unless form.object.creator_id %>
+  <% content_for :resource_toolbar do %>
+    <div class="btn-toolbar mb-3" role="toolbar" aria-label="<%= t('helpers.toolbar.aria_label') %>">
+      <div class="btn-group me-2" role="group">
+        <%= link_to t('better_together.joatu.requests.back_to_requests', default: 'Back to Requests'), joatu_requests_path, class: 'btn btn-secondary' %>
+      </div>
+      <div class="btn-group me-2" role="group">
+        <%= form.submit t('better_together.joatu.requests.save_request', default: 'Save Request'), class: 'btn btn-primary' %>
+      </div>
+      <% if request.persisted? %>
+        <div class="btn-group me-2" role="group">
+          <%= link_to t('better_together.joatu.requests.view_request', default: 'View Request'), request, class: 'btn btn-info' %>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <%= yield :resource_toolbar %>
+
+  <% if request.errors.any? %>
+    <div class="alert alert-danger">
+      <h4><%= t('helpers.errors.heading') %></h4>
+      <ul>
+        <% request.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="mb-3">
+    <%= render partial: 'better_together/shared/translated_string_field', locals: { model: request, form: form, attribute: 'name' } %>
+  </div>
+
+  <div class="mb-3">
+    <%= render partial: 'better_together/shared/translated_text_field', locals: { model: request, form: form, attribute: 'description' } %>
+  </div>
+
+  <div class="mb-3">
+    <%= required_label form, :categories %>
+    <%= form.select :category_ids, options_from_collection_for_select(BetterTogether::Joatu::Category.positioned.all.includes(:string_translations), :id, :name, request.category_ids), { include_blank: true, multiple: true }, class: 'form-select', data: { controller: 'better_together--slim_select' } %>
+    <small class="form-text text-muted"><%= t('hints.categories.select_multiple') %></small>
+  </div>
+
+  <%= yield :resource_toolbar %>
+<% end %>

--- a/app/views/better_together/joatu/requests/edit.html.erb
+++ b/app/views/better_together/joatu/requests/edit.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title do %>
+  <%= t('better_together.joatu.requests.edit_request', default: 'Edit Request') %>
+<% end %>
+
+<div class="container my-3">
+  <h1><%= t('better_together.joatu.requests.edit_request', default: 'Edit Request') %></h1>
+
+  <%= render 'form', request: @request %>
+</div>

--- a/app/views/better_together/joatu/requests/index.html.erb
+++ b/app/views/better_together/joatu/requests/index.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title do %>
+  <%= resource_class.model_name.human.pluralize %>
+<% end %>
+
+<div class="container my-3">
+  <div class="d-flex justify-content-between align-items-center">
+    <h1><%= resource_class.model_name.human.pluralize %></h1>
+    <% if policy(resource_class).create? %>
+      <%= link_to new_joatu_request_path, class: 'btn btn-primary', 'aria-label' => 'Add Request' do %>
+        <i class="fas fa-plus"></i> <%= t('better_together.joatu.requests.new_request', default: 'New Request') %>
+      <% end %>
+    <% end %>
+  </div>
+
+  <ul id="requests" class="list-unstyled">
+    <% @requests.each do |request| %>
+      <li><%= link_to request.name, request %></li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/better_together/joatu/requests/new.html.erb
+++ b/app/views/better_together/joatu/requests/new.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title do %>
+  <%= t('better_together.joatu.requests.new_request', default: 'New Request') %>
+<% end %>
+
+<div class="container my-3">
+  <h1><%= t('better_together.joatu.requests.new_request', default: 'New Request') %></h1>
+
+  <%= render 'form', request: @request %>
+</div>

--- a/app/views/better_together/joatu/requests/show.html.erb
+++ b/app/views/better_together/joatu/requests/show.html.erb
@@ -1,0 +1,27 @@
+<% content_for :page_title do %>
+  <%= @request %> | <%= resource_class.model_name.human.pluralize %>
+<% end %>
+
+<div class="container my-3">
+  <h1 class="mb-4"><%= @request.name %></h1>
+
+  <div class="mb-3">
+    <%= simple_format(@request.description) %>
+  </div>
+
+  <div class="mt-3">
+    <% if policy(resource_class).index? %>
+      <%= link_to t('better_together.joatu.requests.back_to_requests', default: 'Back to Requests'), joatu_requests_path, class: 'btn btn-sm btn-outline-secondary' %>
+    <% end %>
+    <% if policy(@request).edit? %>
+      <%= link_to edit_joatu_request_path(@request), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Request' do %>
+        <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+      <% end %>
+    <% end %>
+    <% if policy(@request).destroy? %>
+      <%= link_to joatu_request_path(@request), data: { turbo_method: :delete, turbo_confirm: t('globals.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Record' do %>
+        <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,11 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
           end
         end
 
+        namespace :joatu do
+          resources :offers, except: %i[index show]
+          resources :requests, except: %i[index show]
+        end
+
         authenticated :user, ->(u) { u.permitted_to?('manage_platform') } do # rubocop:todo Metrics/BlockLength
           scope path: 'host' do # rubocop:todo Metrics/BlockLength
             # Add route for the host dashboard
@@ -156,6 +161,11 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
       resources :calls_for_interest, only: %i[index show]
       resources :events, only: %i[index show]
       resources :posts, only: %i[index show]
+
+      namespace :joatu do
+        resources :offers, only: %i[index show]
+        resources :requests, only: %i[index show]
+      end
 
       resources :uploads, only: %i[index], path: :f, as: :file do
         member do

--- a/spec/features/joatu/offers_requests_forms_spec.rb
+++ b/spec/features/joatu/offers_requests_forms_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Joatu offer and request forms', type: :feature do
+  include BetterTogether::DeviseSessionHelpers
+
+  let!(:host_platform) { configure_host_platform }
+  let!(:category) { create(:better_together_joatu_category) }
+
+  before do
+    login_as_platform_manager
+  end
+
+  scenario 'creating an offer' do
+    visit new_joatu_offer_path(locale: I18n.default_locale)
+    fill_in name: 'offer[name_en]', with: 'Bike repair'
+    fill_in name: 'offer[description_en]', with: 'I can repair bikes'
+    select category.name, from: 'offer_category_ids'
+    click_button 'Save Offer'
+    expect(page).to have_content('Bike repair')
+  end
+
+  scenario 'creating a request' do
+    visit new_joatu_request_path(locale: I18n.default_locale)
+    fill_in name: 'request[name_en]', with: 'Need a ladder'
+    fill_in name: 'request[description_en]', with: 'Looking to borrow a ladder'
+    select category.name, from: 'request_category_ids'
+    click_button 'Save Request'
+    expect(page).to have_content('Need a ladder')
+  end
+end


### PR DESCRIPTION
## Summary
- add Joatu offer and request controllers and views for index, show, new, edit
- build offer/request forms with category selection and translation fields
- cover offer/request creation with feature specs

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a5b47a8a88321bc94f9d6be9ccff8