### PR TITLE
Namespace host admin routes

### DIFF
--- a/app/builders/better_together/navigation_builder.rb
+++ b/app/builders/better_together/navigation_builder.rb
@@ -219,56 +219,56 @@ module BetterTogether
               slug_en: 'host-dashboard',
               position: 0,
               item_type: 'link',
-              route_name: 'host_dashboard_url'
+              route_name: 'host_root_url'
             },
             {
               title_en: 'Communities',
               slug_en: 'communities',
               position: 1,
               item_type: 'link',
-              route_name: 'communities_url'
+              route_name: 'host_communities_url'
             },
             {
               title_en: 'Navigation Areas',
               slug_en: 'navigation-areas',
               position: 2,
               item_type: 'link',
-              route_name: 'navigation_areas_url'
+              route_name: 'host_navigation_areas_url'
             },
             {
               title_en: 'Pages',
               slug_en: 'pages',
               position: 3,
               item_type: 'link',
-              route_name: 'pages_url'
+              route_name: 'host_pages_url'
             },
             {
               title_en: 'People',
               slug_en: 'people',
               position: 4,
               item_type: 'link',
-              route_name: 'people_url'
+              route_name: 'host_people_url'
             },
             {
               title_en: 'Platforms',
               slug_en: 'platforms',
               position: 5,
               item_type: 'link',
-              route_name: 'platforms_url'
+              route_name: 'host_platforms_url'
             },
             {
               title_en: 'Roles',
               slug_en: 'roles',
               position: 6,
               item_type: 'link',
-              route_name: 'roles_url'
+              route_name: 'host_roles_url'
             },
             {
               title_en: 'Resource Permissions',
               slug_en: 'resource_permissions',
               position: 7,
               item_type: 'link',
-              route_name: 'resource_permissions_url'
+              route_name: 'host_resource_permissions_url'
             }
           ]
 

--- a/app/controllers/better_together/application_controller.rb
+++ b/app/controllers/better_together/application_controller.rb
@@ -228,7 +228,7 @@ module BetterTogether
     def after_sign_in_path_for(resource)
       stored_location_for(resource) ||
         if resource.permitted_to?('manage_platform')
-          host_dashboard_path
+          host_root_path
         else
           BetterTogether.base_path_with_locale
         end

--- a/app/controllers/better_together/navigation_areas_controller.rb
+++ b/app/controllers/better_together/navigation_areas_controller.rb
@@ -49,8 +49,8 @@ module BetterTogether
       @navigation_area = resource_class.new(navigation_area_params)
       authorize @navigation_area
 
-      if @navigation_area.save
-        redirect_to @navigation_area, only_path: true, notice: 'Navigation area was successfully created.'
+        if @navigation_area.save
+          redirect_to [:host, @navigation_area], only_path: true, notice: 'Navigation area was successfully created.'
       else
         render :new
       end
@@ -59,8 +59,8 @@ module BetterTogether
     def update
       authorize @navigation_area
 
-      if @navigation_area.update(navigation_area_params)
-        redirect_to @navigation_area, only_path: true, notice: 'Navigation area was successfully updated.'
+        if @navigation_area.update(navigation_area_params)
+          redirect_to [:host, @navigation_area], only_path: true, notice: 'Navigation area was successfully updated.'
       else
         render :edit
       end
@@ -69,7 +69,7 @@ module BetterTogether
     def destroy
       authorize @navigation_area
       @navigation_area.destroy
-      redirect_to navigation_areas_url, notice: 'Navigation area was successfully destroyed.'
+        redirect_to host_navigation_areas_url, notice: 'Navigation area was successfully destroyed.'
     end
 
     private

--- a/app/controllers/better_together/navigation_items_controller.rb
+++ b/app/controllers/better_together/navigation_items_controller.rb
@@ -37,8 +37,8 @@ module BetterTogether
       @navigation_item.assign_attributes(navigation_item_params)
       authorize @navigation_item
 
-      if @navigation_item.save
-        redirect_to @navigation_area, only_path: true, notice: 'Navigation item was successfully created.'
+        if @navigation_item.save
+          redirect_to [:host, @navigation_area], only_path: true, notice: 'Navigation item was successfully created.'
       else
         render :new
       end
@@ -49,11 +49,11 @@ module BetterTogether
 
       respond_to do |format|
         if @navigation_item.update(navigation_item_params)
-          flash[:notice] = t('navigation_item.updated')
-          format.html { redirect_to @navigation_area, notice: t('navigation_item.updated') }
-          format.turbo_stream do
-            redirect_to @navigation_area, only_path: true
-          end
+            flash[:notice] = t('navigation_item.updated')
+            format.html { redirect_to [:host, @navigation_area], notice: t('navigation_item.updated') }
+            format.turbo_stream do
+              redirect_to [:host, @navigation_area], only_path: true
+            end
         else
           flash.now[:alert] = t('navigation_item.update_failed')
           format.html { render :edit, status: :unprocessable_entity }
@@ -73,9 +73,9 @@ module BetterTogether
 
     def destroy
       authorize @navigation_item
-      @navigation_item.destroy
-      redirect_to navigation_area_navigation_items_url(@navigation_area),
-                  notice: 'Navigation item was successfully destroyed.'
+        @navigation_item.destroy
+        redirect_to host_navigation_area_navigation_items_url(@navigation_area),
+                    notice: 'Navigation item was successfully destroyed.'
     end
 
     private

--- a/app/controllers/better_together/pages_controller.rb
+++ b/app/controllers/better_together/pages_controller.rb
@@ -36,8 +36,8 @@ module BetterTogether
       @page = resource_class.new(page_params)
       authorize @page
 
-      if @page.save
-        redirect_to edit_page_path(@page), notice: 'Page was successfully created.'
+        if @page.save
+          redirect_to edit_host_page_path(@page), notice: 'Page was successfully created.'
       else
         render :new
       end
@@ -52,10 +52,10 @@ module BetterTogether
 
       respond_to do |format|
         if @page.update(page_params)
-          format.html do
-            flash[:notice] = 'Page was successfully updated.'
-            redirect_to edit_page_path(@page), notice: 'Page was successfully updated.'
-          end
+            format.html do
+              flash[:notice] = 'Page was successfully updated.'
+              redirect_to edit_host_page_path(@page), notice: 'Page was successfully updated.'
+            end
           format.turbo_stream do
             flash.now[:notice] = 'Page was successfully updated.'
             render turbo_stream: [
@@ -76,8 +76,8 @@ module BetterTogether
 
     def destroy
       authorize @page
-      @page.destroy
-      redirect_to pages_url, notice: 'Page was successfully destroyed.'
+        @page.destroy
+        redirect_to host_pages_url, notice: 'Page was successfully destroyed.'
     end
 
     protected

--- a/app/controllers/better_together/people_controller.rb
+++ b/app/controllers/better_together/people_controller.rb
@@ -24,7 +24,7 @@ module BetterTogether
       authorize_person
 
       if @person.save
-        redirect_to @person, only_path: true, notice: 'Person was successfully created.', status: :see_other
+        redirect_to [:host, @person], only_path: true, notice: 'Person was successfully created.', status: :see_other
       else
         render :new, status: :unprocessable_entity
       end
@@ -37,7 +37,7 @@ module BetterTogether
     def update
       ActiveRecord::Base.transaction do
         if @person.update(person_params)
-          redirect_to @person, only_path: true, notice: 'Profile was successfully updated.', status: :see_other
+          redirect_to (me? ? @person : [:host, @person]), only_path: true, notice: 'Profile was successfully updated.', status: :see_other
         else
           flash.now[:alert] = 'Please address the errors below.'
           render :edit, status: :unprocessable_entity
@@ -48,7 +48,7 @@ module BetterTogether
     # DELETE /people/1
     def destroy
       @person.destroy
-      redirect_to people_url, notice: 'Person was successfully deleted.', status: :see_other
+      redirect_to host_people_url, notice: 'Person was successfully deleted.', status: :see_other
     end
 
     protected

--- a/app/controllers/better_together/platforms_controller.rb
+++ b/app/controllers/better_together/platforms_controller.rb
@@ -41,7 +41,7 @@ module BetterTogether
       authorize_platform
 
       if @platform.save
-        redirect_to @platform, notice: 'Platform was successfully created.'
+        redirect_to [:host, @platform], notice: 'Platform was successfully created.'
       else
         render :new, status: :unprocessable_entity
       end
@@ -51,7 +51,7 @@ module BetterTogether
     def update
       authorize @platform
       if @platform.update(platform_params)
-        redirect_to @platform, notice: 'Platform was successfully updated.', status: :see_other
+        redirect_to [:host, @platform], notice: 'Platform was successfully updated.', status: :see_other
       else
         render :edit, status: :unprocessable_entity
       end
@@ -61,7 +61,7 @@ module BetterTogether
     def destroy
       authorize @platform
       @platform.destroy
-      redirect_to platforms_url, notice: 'Platform was successfully destroyed.', status: :see_other
+      redirect_to host_platforms_url, notice: 'Platform was successfully destroyed.', status: :see_other
     end
 
     private

--- a/app/controllers/better_together/resource_permissions_controller.rb
+++ b/app/controllers/better_together/resource_permissions_controller.rb
@@ -32,8 +32,8 @@ module BetterTogether
       @resource_permission = resource_class.new(resource_permission_params)
       authorize @resource_permission
 
-      if @resource_permission.save
-        redirect_to @resource_permission, only_path: true, notice: 'Resource permission was successfully created.'
+        if @resource_permission.save
+          redirect_to [:host, @resource_permission], only_path: true, notice: 'Resource permission was successfully created.'
       else
         render :new, status: :unprocessable_entity
       end
@@ -43,9 +43,9 @@ module BetterTogether
     def update
       authorize @resource_permission
 
-      if @resource_permission.update(resource_permission_params)
-        redirect_to @resource_permission, only_path: true, notice: 'Resource permission was successfully updated.',
-                                          status: :see_other
+        if @resource_permission.update(resource_permission_params)
+          redirect_to [:host, @resource_permission], only_path: true, notice: 'Resource permission was successfully updated.',
+                                            status: :see_other
       else
         render :edit, status: :unprocessable_entity
       end
@@ -54,9 +54,9 @@ module BetterTogether
     # DELETE /resource_permissions/1
     def destroy
       authorize @resource_permission
-      @resource_permission.destroy
-      redirect_to resource_permissions_url, notice: 'Resource permission was successfully destroyed.',
-                                            status: :see_other
+        @resource_permission.destroy
+        redirect_to host_resource_permissions_url, notice: 'Resource permission was successfully destroyed.',
+                                              status: :see_other
     end
 
     private

--- a/app/controllers/better_together/roles_controller.rb
+++ b/app/controllers/better_together/roles_controller.rb
@@ -33,8 +33,8 @@ module BetterTogether
       @role = resource_class.new(role_params)
       authorize @role # Add authorization check
 
-      if @role.save
-        redirect_to @role, only_path: true, notice: 'Role was successfully created.'
+        if @role.save
+          redirect_to [:host, @role], only_path: true, notice: 'Role was successfully created.'
       else
         render :new, status: :unprocessable_entity
       end
@@ -44,8 +44,8 @@ module BetterTogether
     def update
       authorize @role # Add authorization check
 
-      if @role.update(role_params)
-        redirect_to @role, only_path: true, notice: 'Role was successfully updated.', status: :see_other
+        if @role.update(role_params)
+          redirect_to [:host, @role], only_path: true, notice: 'Role was successfully updated.', status: :see_other
       else
         render :edit, status: :unprocessable_entity
       end
@@ -54,8 +54,8 @@ module BetterTogether
     # DELETE /roles/1
     def destroy
       authorize @role # Add authorization check
-      @role.destroy
-      redirect_to roles_url, notice: 'Role was successfully destroyed.', status: :see_other
+        @role.destroy
+        redirect_to host_roles_url, notice: 'Role was successfully destroyed.', status: :see_other
     end
 
     private

--- a/app/controllers/better_together/users_controller.rb
+++ b/app/controllers/better_together/users_controller.rb
@@ -26,8 +26,8 @@ module BetterTogether
       @user = resource_class.new(user_params)
       authorize_user
 
-      if @user.save
-        redirect_to @user, only_path: true, notice: 'User was successfully created.', status: :see_other
+        if @user.save
+          redirect_to [:host, @user], only_path: true, notice: 'User was successfully created.', status: :see_other
       else
         render :new, status: :unprocessable_entity
       end
@@ -39,8 +39,8 @@ module BetterTogether
     # PATCH/PUT /users/1
     def update
       ActiveRecord::Base.transaction do
-        if @user.update(user_params)
-          redirect_to @user, only_path: true, notice: 'Profile was successfully updated.', status: :see_other
+          if @user.update(user_params)
+            redirect_to [:host, @user], only_path: true, notice: 'Profile was successfully updated.', status: :see_other
         else
           flash.now[:alert] = 'Please address the errors below.'
           render :edit, status: :unprocessable_entity
@@ -50,8 +50,8 @@ module BetterTogether
 
     # DELETE /users/1
     def destroy
-      @user.destroy
-      redirect_to users_url, notice: 'User was successfully deleted.', status: :see_other
+        @user.destroy
+        redirect_to host_users_url, notice: 'User was successfully deleted.', status: :see_other
     end
 
     private

--- a/app/models/better_together/navigation_item.rb
+++ b/app/models/better_together/navigation_item.rb
@@ -8,28 +8,28 @@ module BetterTogether
     include Protected
 
     class_attribute :route_names, default: {
-      calls_for_interest: 'calls_for_interest_url',
-      calendars: 'calendars_url',
-      content_blocks: 'content_blocks_url',
-      communities: 'communities_url',
-      events: 'events_url',
-      geography_continents: 'geography_continents_url',
-      geography_countries: 'geography_countries_url',
-      geography_maps: 'geography_maps_url',
-      geography_states: 'geography_states_url',
-      geography_regions: 'geography_regions_url',
-      geography_settlements: 'geography_settlements_url',
-      host_dashboard: 'host_dashboard_url',
-      hub: 'hub_url',
-      metrics_reports: 'metrics_reports_url',
-      navigation_areas: 'navigation_areas_url',
-      pages: 'pages_url',
-      people: 'people_url',
-      platforms: 'platforms_url',
-      resource_permissions: 'resource_permissions_url',
-      roles: 'roles_url',
-      users: 'users_url'
-    }
+        calls_for_interest: 'calls_for_interest_url',
+        calendars: 'calendars_url',
+        content_blocks: 'host_content_blocks_url',
+        communities: 'host_communities_url',
+        events: 'events_url',
+        geography_continents: 'host_geography_continents_url',
+        geography_countries: 'host_geography_countries_url',
+        geography_maps: 'geography_maps_url',
+        geography_states: 'host_geography_states_url',
+        geography_regions: 'host_geography_regions_url',
+        geography_settlements: 'host_geography_settlements_url',
+        host_dashboard: 'host_root_url',
+        hub: 'hub_url',
+        metrics_reports: 'host_metrics_reports_url',
+        navigation_areas: 'host_navigation_areas_url',
+        pages: 'host_pages_url',
+        people: 'host_people_url',
+        platforms: 'host_platforms_url',
+        resource_permissions: 'host_resource_permissions_url',
+        roles: 'host_roles_url',
+        users: 'host_users_url'
+      }
 
     belongs_to :navigation_area, touch: true
     belongs_to :linkable, polymorphic: true, optional: true, autosave: true

--- a/app/views/better_together/categories/_form.html.erb
+++ b/app/views/better_together/categories/_form.html.erb
@@ -1,15 +1,15 @@
-<%= form_with(model: category.as_category, class: 'form', data: { controller: "better_together--form-validation better_together--tabs" }) do |form| %>
+<%= form_with(model: [:host, category.as_category], class: 'form', data: { controller: "better_together--form-validation better_together--tabs" }) do |form| %>
   <% content_for :resource_toolbar do %>
     <div class="btn-toolbar mb-3" role="toolbar" aria-label="<%= t('helpers.toolbar.aria_label') %>">
       <div class="btn-group me-2" role="group">
-        <%= link_to t('better_together.categories.back_to_categories'), categories_path, class: 'btn btn-secondary' %>
+          <%= link_to t('better_together.categories.back_to_categories'), host_categories_path, class: 'btn btn-secondary' %>
       </div>
       <div class="btn-group me-2" role="group">
         <%= form.submit t('better_together.categories.save_category'), class: 'btn btn-primary' %>
       </div>
       <% if category.persisted? %>
         <div class="btn-group me-2" role="group">
-          <%= link_to t('better_together.categories.view_category'), category.as_category, class: 'btn btn-info' %>
+            <%= link_to t('better_together.categories.view_category'), [:host, category.as_category], class: 'btn btn-info' %>
         </div>
       <% end %>
     </div>

--- a/app/views/better_together/categories/index.html.erb
+++ b/app/views/better_together/categories/index.html.erb
@@ -5,11 +5,11 @@
 <div class="container my-3">
   <div class="d-flex justify-content-between align-items-center">
     <h1><%= resource_class.model_name.human.pluralize %></h1>
-    <% if policy(resource_class).create? %> <!-- Policy check for create permission -->
-      <%= link_to new_category_path, class: 'btn btn-primary', 'aria-label' => 'Add Category' do %>
-        <i class="fas fa-plus"></i> <%= t('.new_btn_text', default: 'New Category') %>
+      <% if policy(resource_class).create? %> <!-- Policy check for create permission -->
+        <%= link_to new_host_category_path, class: 'btn btn-primary', 'aria-label' => 'Add Category' do %>
+          <i class="fas fa-plus"></i> <%= t('.new_btn_text', default: 'New Category') %>
+        <% end %>
       <% end %>
-    <% end %>
   </div>
 
   <div id="categories" class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 row-cols-xl-4">

--- a/app/views/better_together/categories/show.html.erb
+++ b/app/views/better_together/categories/show.html.erb
@@ -9,16 +9,16 @@
   <%= render partial: 'better_together/categories/category', object: @category %>
 
   <div class="mt-3">
-    <% if policy(resource_class).index? %>
-      <%= link_to t('better_together.categories.back_to_categories'), categories_path, class: 'btn btn-sm btn-outline-secondary' %>
-    <% end %>
-    <% if policy(@resource).edit? %>
-      <%= link_to edit_category_path(@resource), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Partner' do %>
+      <% if policy(resource_class).index? %>
+        <%= link_to t('better_together.categories.back_to_categories'), host_categories_path, class: 'btn btn-sm btn-outline-secondary' %>
+      <% end %>
+      <% if policy(@resource).edit? %>
+        <%= link_to edit_host_category_path(@resource), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Partner' do %>
         <i class="fas fa-edit"></i> <%= t('globals.edit') %>
       <% end %>
     <% end %>
-    <% if policy(@resource).destroy? %>
-      <%= link_to category_path(@resource), data: { turbo_method: :delete, turbo_confirm: t('globals.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Record' do %>
+      <% if policy(@resource).destroy? %>
+        <%= link_to host_category_path(@resource), data: { turbo_method: :delete, turbo_confirm: t('globals.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Record' do %>
         <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
       <% end %>
     <% end %>

--- a/app/views/better_together/host_dashboard/_resource_card.html.erb
+++ b/app/views/better_together/host_dashboard/_resource_card.html.erb
@@ -1,14 +1,14 @@
 <!-- app/views/better_together/host_dashboard/_resource_card.html.erb -->
 
-<%# locals: (collection:, model_class: collection.model, model_name: model_class.model_name, count:, url_helper: :url_for) -%>
+<%# locals: (collection:, model_class: collection.model, model_name: model_class.model_name, count:, url_helper: :url_for, index_url_helper: :url_for) -%>
 
 <div class="col mb-4">
   <div class="card hover-effect shadow-sm h-100">
     <div class="card-header d-flex justify-content-between align-items-center">
-      <% if policy(model_class).index? %>
-        <%= link_to model_class, class: "h6 text-decoration-none" do %>
-          <i class="fas fa-folder-open me-2"></i><%= model_name.human.pluralize(2, I18n.locale) %>
-        <% end %>
+        <% if policy(model_class).index? %>
+          <%= link_to public_send(index_url_helper), class: "h6 text-decoration-none" do %>
+            <i class="fas fa-folder-open me-2"></i><%= model_name.human.pluralize(2, I18n.locale) %>
+          <% end %>
       <% else %>
         <span class="h6"><i class="fas fa-folder-open me-2"></i><%= model_name.human.pluralize(2, I18n.locale) %></span>
       <% end %>
@@ -38,10 +38,10 @@
         </div>
       <% end %>
     </div>
-    <% if policy(model_class).index? %>
-      <div class="card-footer text-end">
-        <%= link_to t('host_dashboard.resource_card.view_all'), model_class, class: "btn btn-sm btn-outline-info" %>
-      </div>
-    <% end %>
+      <% if policy(model_class).index? %>
+        <div class="card-footer text-end">
+          <%= link_to t('host_dashboard.resource_card.view_all'), public_send(index_url_helper), class: "btn btn-sm btn-outline-info" %>
+        </div>
+      <% end %>
   </div>
 </div>

--- a/app/views/better_together/host_dashboard/index.html.erb
+++ b/app/views/better_together/host_dashboard/index.html.erb
@@ -13,49 +13,49 @@
     <h2><%= t('.better_together') %></h2>
     <div class="row mt-3 row-cols-1 row-cols-sm-2 row-cols-md-3">
       <!-- Communities -->
-      <%= render partial: 'resource_card', locals: { collection: @communities, count: @community_count, url_helper: :community_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @communities, count: @community_count, url_helper: :host_community_path, index_url_helper: :host_communities_path } %>
 
       <!-- Navigation Areas -->
-      <%= render partial: 'resource_card', locals: { collection: @navigation_areas, count: @navigation_area_count, url_helper: :navigation_area_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @navigation_areas, count: @navigation_area_count, url_helper: :host_navigation_area_path, index_url_helper: :host_navigation_areas_path } %>
 
       <!-- Pages -->
-      <%= render partial: 'resource_card', locals: { collection: @pages, count: @page_count, url_helper: :page_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @pages, count: @page_count, url_helper: :host_page_path, index_url_helper: :host_pages_path } %>
 
       <!-- Platforms -->
-      <%= render partial: 'resource_card', locals: { collection: @platforms, count: @platform_count, url_helper: :platform_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @platforms, count: @platform_count, url_helper: :host_platform_path, index_url_helper: :host_platforms_path } %>
 
       <!-- People -->
-      <%= render partial: 'resource_card', locals: { collection: @people, count: @person_count, url_helper: :person_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @people, count: @person_count, url_helper: :host_person_path, index_url_helper: :host_people_path } %>
 
       <!-- Roles -->
-      <%= render partial: 'resource_card', locals: { collection: @roles, count: @role_count, url_helper: :role_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @roles, count: @role_count, url_helper: :host_role_path, index_url_helper: :host_roles_path } %>
 
       <!-- Resource Permissions -->
-      <%= render partial: 'resource_card', locals: { collection: @resource_permissions, count: @resource_permission_count, url_helper: :resource_permission_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @resource_permissions, count: @resource_permission_count, url_helper: :host_resource_permission_path, index_url_helper: :host_resource_permissions_path } %>
 
       <!-- Users -->
-      <%= render partial: 'resource_card', locals: { collection: @users, count: @user_count, url_helper: :user_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @users, count: @user_count, url_helper: :host_user_path, index_url_helper: :host_users_path } %>
       <%= render partial: 'resource_card', locals: { collection: @conversations, count: @conversation_count, url_helper: :conversation_path } %>
       <%= render partial: 'resource_card', locals: { collection: @messages, count: @message_count, url_helper: :message_path } %>
-      <%= render partial: 'resource_card', locals: { collection: @categories, count: @category_count, url_helper: :category_path } %>
+      <%= render partial: 'resource_card', locals: { collection: @categories, count: @category_count, url_helper: :host_category_path, index_url_helper: :host_categories_path } %>
     </div>
 
     <div id="content-section" class="row mt-3">
       <div class="col-12">
         <h3><%= t('.content') %></h3>
       </div>
-      <%= render partial: 'resource_card', locals: { model_class: ::BetterTogether::Content::Block, collection: @content_blocks, count: @content_block_count, url_helper: :content_block_path } %>
+      <%= render partial: 'resource_card', locals: { model_class: ::BetterTogether::Content::Block, collection: @content_blocks, count: @content_block_count, url_helper: :host_content_block_path, index_url_helper: :host_content_blocks_path } %>
     </div>
 
     <div id="geography-section" class="row mt-3">
       <div class="col-12">
         <h3><%= t('.geography') %></h3>
       </div>
-      <%= render partial: 'resource_card', locals: {collection: @geography_continents, count: @geography_continent_count, url_helper: :geography_continent_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_countries, count: @geography_country_count, url_helper: :geography_country_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_states, count: @geography_state_count, url_helper: :geography_state_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_regions, count: @geography_region_count, url_helper: :geography_region_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_settlements, count: @geography_settlement_count, url_helper: :geography_settlement_path } %>
+      <%= render partial: 'resource_card', locals: {collection: @geography_continents, count: @geography_continent_count, url_helper: :host_geography_continent_path, index_url_helper: :host_geography_continents_path } %>
+      <%= render partial: 'resource_card', locals: {collection: @geography_countries, count: @geography_country_count, url_helper: :host_geography_country_path, index_url_helper: :host_geography_countries_path } %>
+      <%= render partial: 'resource_card', locals: {collection: @geography_states, count: @geography_state_count, url_helper: :host_geography_state_path, index_url_helper: :host_geography_states_path } %>
+      <%= render partial: 'resource_card', locals: {collection: @geography_regions, count: @geography_region_count, url_helper: :host_geography_region_path, index_url_helper: :host_geography_regions_path } %>
+      <%= render partial: 'resource_card', locals: {collection: @geography_settlements, count: @geography_settlement_count, url_helper: :host_geography_settlement_path, index_url_helper: :host_geography_settlements_path } %>
     </div>
   </div>
 </div>

--- a/app/views/better_together/navigation_areas/edit.html.erb
+++ b/app/views/better_together/navigation_areas/edit.html.erb
@@ -3,5 +3,5 @@
 <div class="container">
   <h1><%= t('better_together.navigation_areas.edit.title') %></h1>
   <%= render 'form', navigation_area: @navigation_area %>
-  <%= link_to t('shared.links.back'), navigation_areas_path, class: 'btn btn-secondary' %>
+    <%= link_to t('shared.links.back'), host_navigation_areas_path, class: 'btn btn-secondary' %>
 </div>

--- a/app/views/better_together/navigation_areas/index.html.erb
+++ b/app/views/better_together/navigation_areas/index.html.erb
@@ -4,8 +4,8 @@
 
 <div class="container my-3">
   <div class="d-flex justify-content-between align-items-center mb-3">
-    <h1><%= resource_class.model_name.human.pluralize %></h1>
-    <%= link_to new_navigation_area_path, class: 'btn btn-primary d-flex align-items-center' do %>
+      <h1><%= resource_class.model_name.human.pluralize %></h1>
+      <%= link_to new_host_navigation_area_path, class: 'btn btn-primary d-flex align-items-center' do %>
       <i class="fas fa-plus me-2"></i> <%= t('.new_navigation_area') %>
     <% end %>
   </div>
@@ -26,18 +26,18 @@
           <td><%= navigation_area.slug %></td>
           <td><%= navigation_area.visible ? t('globals.visible') : t('globals.hidden') %></td>
           <td class="text-end"> <!-- Right-align buttons -->
-            <% if policy(navigation_area).show? %>
-              <%= link_to navigation_area_path(navigation_area), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => t('.items') do %>
+              <% if policy(navigation_area).show? %>
+                <%= link_to host_navigation_area_path(navigation_area), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => t('.items') do %>
                 <i class="fas fa-list"></i> <%= t('.items') %>
               <% end %>
             <% end %>
-            <% if policy(navigation_area).edit? %>
-              <%= link_to edit_navigation_area_path(navigation_area), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
+              <% if policy(navigation_area).edit? %>
+                <%= link_to edit_host_navigation_area_path(navigation_area), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
                 <i class="fas fa-edit"></i> <%= t('globals.edit') %>
               <% end %>
             <% end %>
-            <% if policy(navigation_area).destroy? %>
-              <%= link_to navigation_area_path(navigation_area), method: :delete, data: { turbo_confirm: t('globals.confirm_delete'), turbo_method: :delete }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => t('globals.delete') do %>
+              <% if policy(navigation_area).destroy? %>
+                <%= link_to host_navigation_area_path(navigation_area), method: :delete, data: { turbo_confirm: t('globals.confirm_delete'), turbo_method: :delete }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => t('globals.delete') do %>
                 <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
               <% end %>
             <% end %>

--- a/app/views/better_together/navigation_areas/new.html.erb
+++ b/app/views/better_together/navigation_areas/new.html.erb
@@ -3,5 +3,5 @@
 <div class="container">
   <h1><%= t('better_together.navigation_areas.new.title') %></h1>
   <%= render 'form', navigation_area: @navigation_area %>
-  <%= link_to t('shared.links.back'), navigation_areas_path, class: 'btn btn-secondary' %>
+    <%= link_to t('shared.links.back'), host_navigation_areas_path, class: 'btn btn-secondary' %>
 </div>

--- a/app/views/better_together/navigation_areas/show.html.erb
+++ b/app/views/better_together/navigation_areas/show.html.erb
@@ -5,15 +5,15 @@
 <div class="container my-3">
   <div class="d-flex justify-content-between align-items-center">
     <h1><%= @navigation_area.name %></h1>
-    <% if policy(BetterTogether::NavigationItem).create? %>
-      <%= link_to new_navigation_area_navigation_item_path(@navigation_area), class: 'btn btn-primary', 'aria-label' => 'Add Navigation Item' do %>
-        <i class="fas fa-plus"></i> <%= t('.new_navigation_item') %>
+      <% if policy(BetterTogether::NavigationItem).create? %>
+        <%= link_to new_host_navigation_area_navigation_item_path(@navigation_area), class: 'btn btn-primary', 'aria-label' => 'Add Navigation Item' do %>
+          <i class="fas fa-plus"></i> <%= t('.new_navigation_item') %>
+        <% end %>
       <% end %>
-    <% end %>
   </div>
 
-  <% if policy(@navigation_area).edit? %>
-    <%= link_to edit_navigation_area_path(@navigation_area), class: 'btn btn-outline-secondary btn-sm me-1 mb-2', 'aria-label' => t('globals.edit') do %>
+    <% if policy(@navigation_area).edit? %>
+      <%= link_to edit_host_navigation_area_path(@navigation_area), class: 'btn btn-outline-secondary btn-sm me-1 mb-2', 'aria-label' => t('globals.edit') do %>
       <i class="fas fa-edit"></i> <%= t('globals.edit') %>
     <% end %>
   <% end %>
@@ -21,9 +21,9 @@
   <p><strong><%= resource_class.human_attribute_name(:visible) %>:</strong> <%= @navigation_area.visible ? 'Yes' : 'No' %></p>
   <p><strong><%= resource_class.human_attribute_name(:slug) %>:</strong> <%= @navigation_area.slug %></p>
 
-  <% if @navigation_item&.child? %>
-  <p><strong><%= resource_class.human_attribute_name(:parent) %>:</strong> <%= link_to @navigation_item.parent, [@navigation_area, @navigation_item.parent] %></p>
-  <% end %>
+    <% if @navigation_item&.child? %>
+    <p><strong><%= resource_class.human_attribute_name(:parent) %>:</strong> <%= link_to @navigation_item.parent, [:host, @navigation_area, @navigation_item.parent] %></p>
+    <% end %>
   <h2><%= BetterTogether::NavigationItem.model_name.human.pluralize %></h2>
   <%= render partial: 'better_together/navigation_items/navigation_items_table', locals: { navigation_items: @navigation_items } %>
 </div>

--- a/app/views/better_together/navigation_items/_form.html.erb
+++ b/app/views/better_together/navigation_items/_form.html.erb
@@ -1,11 +1,11 @@
 <!-- app/views/better_together/navigation_items/_form.html.erb -->
 
-<%= content_tag :div, id: 'navigation_item_form' do %>
-  <%= form_with(model: [@navigation_area, @navigation_item], local: false, class: 'form', data: { turbo: false, controller: "better_together--form-validation better_together--dependent-fields" }) do |form| %>
+  <%= content_tag :div, id: 'navigation_item_form' do %>
+    <%= form_with(model: [:host, @navigation_area, @navigation_item], local: false, class: 'form', data: { turbo: false, controller: "better_together--form-validation better_together--dependent-fields" }) do |form| %>
     <% content_for :action_toolbar do %>
       <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
         <div class="btn-group me-2" role="group" aria-label="First group">
-          <%= link_to t('globals.back_to_list'), navigation_area_navigation_items_path(navigation_area), class: 'btn btn-secondary' %>
+            <%= link_to t('globals.back_to_list'), host_navigation_area_navigation_items_path(navigation_area), class: 'btn btn-secondary' %>
         </div>
         <div class="btn-group me-2" role="group" aria-label="Third group">
           <%= form.submit class: 'btn btn-primary' %>

--- a/app/views/better_together/navigation_items/_navigation_item_row.html.erb
+++ b/app/views/better_together/navigation_items/_navigation_item_row.html.erb
@@ -6,22 +6,22 @@
     <% if item.child? %>
       <i class="fas fa-arrow-turn-up fa-rotate-90 me-2"></i>
     <% end %>
-    <%= link_to item.title, navigation_area_navigation_item_path(navigation_area.slug, item.slug), class: 'text-decoration-none' %>
+      <%= link_to item.title, host_navigation_area_navigation_item_path(navigation_area.slug, item.slug), class: 'text-decoration-none' %>
   </td>
   <td><%= item.item_type %></td>
   <td class="overflow-hidden"><%= link_to item.url, item.url %></td>
   <td><%= item.linkable ? link_to(item.linkable) : t('globals.none') %></td>
   <td><%= item.visible ? t('globals.yes') : t('globals.no') %></td>
   <td class="text-end">
-    <% if item.dropdown? %>
-      <%= link_to new_navigation_area_navigation_item_path(navigation_area.slug, parent_id: item.slug), class: 'btn btn-outline-primary btn-sm me-1', 'aria-label' => t('globals.add_child_item') do %>
+      <% if item.dropdown? %>
+        <%= link_to new_host_navigation_area_navigation_item_path(navigation_area.slug, parent_id: item.slug), class: 'btn btn-outline-primary btn-sm me-1', 'aria-label' => t('globals.add_child_item') do %>
         <i class="fas fa-plus"></i> <%= t('globals.add_child_item') %>
       <% end %>
     <% end %>
-    <%= link_to edit_navigation_area_navigation_item_path(navigation_area.slug, item.slug), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
+      <%= link_to edit_host_navigation_area_navigation_item_path(navigation_area.slug, item.slug), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
       <i class="fas fa-edit"></i> <%= t('globals.edit') %>
     <% end %>
-    <%= link_to navigation_area_navigation_item_path(navigation_area.slug, item.slug), data: { turbo_confirm: t('globals.confirm_delete'), turbo_method: :delete }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => t('globals.destroy') do %>
+      <%= link_to host_navigation_area_navigation_item_path(navigation_area.slug, item.slug), data: { turbo_confirm: t('globals.confirm_delete'), turbo_method: :delete }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => t('globals.destroy') do %>
       <i class="fas fa-trash-alt"></i> <%= t('globals.destroy') %>
     <% end %>
   </td>

--- a/app/views/better_together/navigation_items/index.html.erb
+++ b/app/views/better_together/navigation_items/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="container my-3">
   <h1><%= t('better_together.navigation_items.index.title', name: @navigation_area.name) %></h1>
-  <%= link_to t('better_together.navigation_items.index.new_navigation_item'), new_navigation_area_navigation_item_path(@navigation_area), class: 'btn btn-primary' %>
+    <%= link_to t('better_together.navigation_items.index.new_navigation_item'), new_host_navigation_area_navigation_item_path(@navigation_area), class: 'btn btn-primary' %>
 
   <%= render partial: 'navigation_items_table', locals: { navigation_items: @navigation_items } %>
 </div>

--- a/app/views/better_together/pages/_form.html.erb
+++ b/app/views/better_together/pages/_form.html.erb
@@ -1,8 +1,8 @@
-<%= form_with(model: page, class: 'form', multipart: true, id: dom_id(page, 'form'), data: { controller: "better_together--form-validation" }) do |form| %>
+<%= form_with(model: [:host, page], class: 'form', multipart: true, id: dom_id(page, 'form'), data: { controller: "better_together--form-validation" }) do |form| %>
   <% content_for :resource_toolbar do %>
     <div class="btn-toolbar mb-3" role="toolbar" aria-label="Toolbar with button groups">
       <div class="btn-group me-2" role="group" aria-label="First group">
-        <%= link_to t('globals.back_to_list'), pages_path, class: 'btn btn-secondary' %>
+          <%= link_to t('globals.back_to_list'), host_pages_path, class: 'btn btn-secondary' %>
       </div>
       <div class="btn-group me-2" role="group" aria-label="Third group">
         <%= form.submit class: 'btn btn-primary' %>

--- a/app/views/better_together/pages/_page_row.html.erb
+++ b/app/views/better_together/pages/_page_row.html.erb
@@ -9,13 +9,13 @@
         <i class="fas fa-eye"></i> <%= t('globals.show') %>
       <% end %>
     <% end %>
-    <% if policy(page).update? %>
-      <%= link_to edit_page_path(page), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => 'Edit Page' do %>
+      <% if policy(page).update? %>
+        <%= link_to edit_host_page_path(page), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => 'Edit Page' do %>
         <i class="fas fa-edit"></i> <%= t('globals.edit') %>
       <% end %>
     <% end %>
-    <% if policy(page).destroy? %>
-      <%= link_to page_path(page), method: :delete, data: { 'turbo-method': 'delete', turbo_confirm: t('pages.confirm_destroy') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Destroy Page' do %>
+      <% if policy(page).destroy? %>
+        <%= link_to host_page_path(page), method: :delete, data: { 'turbo-method': 'delete', turbo_confirm: t('pages.confirm_destroy') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Destroy Page' do %>
         <i class="fas fa-trash-alt"></i> <%= t('globals.destroy') %>
       <% end %>
     <% end %>

--- a/app/views/better_together/pages/edit.html.erb
+++ b/app/views/better_together/pages/edit.html.erb
@@ -7,14 +7,14 @@
   <% if permitted_to?('manage_platform') %>
     <% if policy(@page).index? %>
       <li class="nav-item record-list" data-bs-toggle="tooltip" data-bs-placement="bottom" title="<%= t('globals.back_to_list') %>">
-        <%= link_to pages_path, class: 'nav-link' do %>
+          <%= link_to host_pages_path, class: 'nav-link' do %>
           <i class="fas fa-list"></i>
         <% end %>
       </li>
     <% end %>
     <% if policy(@page).update? %>
       <li class="nav-item edit" data-bs-toggle="tooltip" data-bs-placement="bottom" title="<%= t('globals.edit') %>">
-        <%= link_to edit_page_path(@page, locale: I18n.locale), class: 'nav-link active' do %>
+          <%= link_to edit_host_page_path(@page, locale: I18n.locale), class: 'nav-link active' do %>
           <i class="fas fa-pencil"></i>
         <% end %>
       </li>

--- a/app/views/better_together/pages/index.html.erb
+++ b/app/views/better_together/pages/index.html.erb
@@ -6,7 +6,7 @@
   <% if permitted_to?('manage_platform') %>
     <% if policy(BetterTogether::Page).index? %>
       <li class="nav-item record-list" data-bs-toggle="tooltip" data-bs-placement="bottom" title="<%= t('globals.back_to_list') %>">
-        <%= link_to pages_path, class: 'nav-link active' do %>
+          <%= link_to host_pages_path, class: 'nav-link active' do %>
           <i class="fas fa-list"></i>
         <% end %>
       </li>
@@ -17,8 +17,8 @@
 <div class="container-fluid my-3">
   <div class="d-flex justify-content-between align-items-center">
     <h1><%= resource_class.model_name.human.pluralize %></h1>
-    <% if policy(resource_class).create? %>
-      <%= link_to new_page_path, class: 'btn btn-primary', 'aria-label' => t('.new_page') do %>
+      <% if policy(resource_class).create? %>
+        <%= link_to new_host_page_path, class: 'btn btn-primary', 'aria-label' => t('.new_page') do %>
         <i class="fas fa-plus"></i> <%= t('.new_page') %>
       <% end %>
     <% end %>

--- a/app/views/better_together/pages/show.html.erb
+++ b/app/views/better_together/pages/show.html.erb
@@ -36,14 +36,14 @@
   <% if permitted_to?('manage_platform') %>
     <% if policy(@page).index? %>
       <li class="nav-item record-list" data-bs-toggle="tooltip" data-bs-placement="bottom" title="<%= t('globals.back_to_list') %>">
-        <%= link_to pages_path, class: 'nav-link' do %>
+          <%= link_to host_pages_path, class: 'nav-link' do %>
           <i class="fas fa-list"></i>
         <% end %>
       </li>
     <% end %>
     <% if policy(@page).update? %>
       <li class="nav-item edit" data-bs-toggle="tooltip" data-bs-placement="bottom" title="<%= t('globals.edit') %>">
-        <%= link_to edit_page_path(@page, locale: I18n.locale), class: 'nav-link', target: "_#{dom_id(@page, 'edit')}" do %>
+          <%= link_to edit_host_page_path(@page, locale: I18n.locale), class: 'nav-link', target: "_#{dom_id(@page, 'edit')}" do %>
           <i class="fas fa-pencil"></i>
         <% end %>
       </li>

--- a/app/views/better_together/people/_person.html.erb
+++ b/app/views/better_together/people/_person.html.erb
@@ -4,20 +4,20 @@
   <td><%= person.description %></td>
   <td><%= person.slug %></td>
   <td class="text-end">
-    <% if policy(person).show? %>
-      <%= link_to person_path(person), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => 'Show Person' do %>
-        <i class="fas fa-eye"></i> <%= t('globals.show') %>
+      <% if policy(person).show? %>
+        <%= link_to host_person_path(person), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => 'Show Person' do %>
+          <i class="fas fa-eye"></i> <%= t('globals.show') %>
+        <% end %>
       <% end %>
-    <% end %>
-    <% if policy(person).edit? %>
-      <%= link_to edit_person_path(person), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => 'Edit Person' do %>
-        <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+      <% if policy(person).edit? %>
+        <%= link_to edit_host_person_path(person), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => 'Edit Person' do %>
+          <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+        <% end %>
       <% end %>
-    <% end %>
-    <% if policy(person).destroy? %>
-      <%= link_to person_path(person), method: :delete, data: { turbo_confirm: 'delete', turbo_confirm: t('people.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Person' do %>
-        <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+      <% if policy(person).destroy? %>
+        <%= link_to host_person_path(person), method: :delete, data: { turbo_confirm: 'delete', turbo_confirm: t('people.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Person' do %>
+          <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+        <% end %>
       <% end %>
-    <% end %>
   </td>
 </tr>

--- a/app/views/better_together/people/index.html.erb
+++ b/app/views/better_together/people/index.html.erb
@@ -5,11 +5,11 @@
 <div class="container my-3">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h1><%= resource_class.model_name.human.pluralize %></h1>
-    <% if policy(resource_class).create? %> <!-- Policy check using resource_class -->
-      <%= link_to new_person_path, class: 'btn btn-primary' do %>
-        <i class="fas fa-plus"></i> <%= t('.new_person') %>
+      <% if policy(resource_class).create? %> <!-- Policy check using resource_class -->
+        <%= link_to new_host_person_path, class: 'btn btn-primary' do %>
+          <i class="fas fa-plus"></i> <%= t('.new_person') %>
+        <% end %>
       <% end %>
-    <% end %>
   </div>
 
   <div class="row">

--- a/app/views/better_together/people/new.html.erb
+++ b/app/views/better_together/people/new.html.erb
@@ -8,8 +8,8 @@
   <%= render "form", person: @person %>
 
   <div class="mt-3">
-    <% if policy(::BetterTogether::Person.new).index? %>
-      <%= link_to "Back to People", people_path, class: "btn btn-secondary" %>
-    <% end %>
+      <% if policy(::BetterTogether::Person.new).index? %>
+        <%= link_to "Back to People", host_people_path, class: "btn btn-secondary" %>
+      <% end %>
   </div>
 </div>

--- a/app/views/better_together/people/show.html.erb
+++ b/app/views/better_together/people/show.html.erb
@@ -26,16 +26,16 @@
         <%= privacy_badge(@person) %>
       </div>
       <div class="col-auto">
-        <% if policy(@person).edit? %>
-          <%= link_to edit_person_path(@person), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Profile' do %>
-            <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+          <% if policy(@person).edit? %>
+            <%= link_to (current_person == @person ? edit_person_path(@person) : edit_host_person_path(@person)), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Profile' do %>
+              <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+            <% end %>
           <% end %>
-        <% end %>
-        <% if policy(@person).destroy? %>
-          <%= link_to person_path(@person), method: :delete, data: { turbo_method: :delete, confirm: t('people.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Profile' do %>
-            <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+          <% if policy(@person).destroy? %>
+            <%= link_to (current_person == @person ? person_path(@person) : host_person_path(@person)), method: :delete, data: { turbo_method: :delete, confirm: t('people.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Profile' do %>
+              <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+            <% end %>
           <% end %>
-        <% end %>
       </div>
     </div>
   </div>

--- a/app/views/better_together/platforms/_platform.html.erb
+++ b/app/views/better_together/platforms/_platform.html.erb
@@ -9,20 +9,20 @@
   <td><%= platform.protected ? t('globals.yes') : t('globals.no') %></td>
   <td><%= platform.host ? t('globals.yes') : t('globals.no') %></td>
   <td class="text-end">
-    <% if policy(platform).show? %>
-      <%= link_to platform_path(platform), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => 'Show Platform' do %>
-        <i class="fas fa-eye"></i> <%= t('globals.show') %>
+      <% if policy(platform).show? %>
+        <%= link_to host_platform_path(platform), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => 'Show Platform' do %>
+          <i class="fas fa-eye"></i> <%= t('globals.show') %>
+        <% end %>
       <% end %>
-    <% end %>
-    <% if policy(platform).edit? %>
-      <%= link_to edit_platform_path(platform), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => 'Edit Platform' do %>
-        <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+      <% if policy(platform).edit? %>
+        <%= link_to edit_host_platform_path(platform), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => 'Edit Platform' do %>
+          <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+        <% end %>
       <% end %>
-    <% end %>
-    <% if policy(platform).destroy? %>
-      <%= link_to platform_path(platform), method: :delete, data: { turbo_method: 'delete', turbo_confirm: t('platforms.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Platform' do %>
-        <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+      <% if policy(platform).destroy? %>
+        <%= link_to host_platform_path(platform), method: :delete, data: { turbo_method: 'delete', turbo_confirm: t('platforms.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Platform' do %>
+          <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
+        <% end %>
       <% end %>
-    <% end %>
   </td>
 </tr>

--- a/app/views/better_together/platforms/edit.html.erb
+++ b/app/views/better_together/platforms/edit.html.erb
@@ -4,11 +4,11 @@
   <%= render "form", platform: @platform %>
 
   <div class="mt-3">
-    <% if policy(@platform).show? %>
-      <%= link_to "Show this Platform", @platform, class: "btn btn-secondary me-2" %>
-    <% end %>
-    <% if policy(::BetterTogether::Platform).index? %>
-      <%= link_to "Back to Platforms", platforms_path, class: "btn btn-secondary" %>
-    <% end %>
+      <% if policy(@platform).show? %>
+        <%= link_to "Show this Platform", [:host, @platform], class: "btn btn-secondary me-2" %>
+      <% end %>
+      <% if policy(::BetterTogether::Platform).index? %>
+        <%= link_to "Back to Platforms", host_platforms_path, class: "btn btn-secondary" %>
+      <% end %>
   </div>
 </div>

--- a/app/views/better_together/platforms/new.html.erb
+++ b/app/views/better_together/platforms/new.html.erb
@@ -3,5 +3,5 @@
 
   <%= render "form", platform: @platform %>
 
-  <%= link_to t('globals.back_to_list'), platforms_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
+    <%= link_to t('globals.back_to_list'), host_platforms_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>
 </div>

--- a/app/views/better_together/platforms/show.html.erb
+++ b/app/views/better_together/platforms/show.html.erb
@@ -25,12 +25,12 @@
       </div>
       <div class="col-auto">
         <% if policy(@platform).edit? %>
-          <%= link_to edit_platform_path(@platform), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Platform' do %>
+          <%= link_to edit_host_platform_path(@platform), class: 'btn btn-outline-primary btn-sm me-2', 'aria-label' => 'Edit Platform' do %>
             <i class="fas fa-edit"></i> <%= t('globals.edit') %>
           <% end %>
         <% end %>
         <% if policy(@platform).destroy? %>
-          <%= link_to platform_path(@platform), method: :delete, data: { turbo_method: :delete, confirm: t('platforms.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Platform' do %>
+          <%= link_to host_platform_path(@platform), method: :delete, data: { turbo_method: :delete, confirm: t('platforms.confirm_delete') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => 'Delete Platform' do %>
             <i class="fas fa-trash-alt"></i> <%= t('globals.delete') %>
           <% end %>
         <% end %>

--- a/app/views/better_together/resource_permissions/_resource_permission.html.erb
+++ b/app/views/better_together/resource_permissions/_resource_permission.html.erb
@@ -6,18 +6,18 @@
   <td><%= resource_permission.position %></td>
   <td><%= resource_permission.protected ? t('globals.yes') : t('globals.no') %></td>
   <td class="text-end">
-    <% if policy(resource_permission).show? %>
-      <%= link_to resource_permission_path(resource_permission), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => t('globals.show') do %>
+      <% if policy(resource_permission).show? %>
+        <%= link_to host_resource_permission_path(resource_permission), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => t('globals.show') do %>
         <i class="fas fa-eye"></i> <%= t('globals.show') %>
       <% end %>
     <% end %>
-    <% if policy(resource_permission).edit? %>
-      <%= link_to edit_resource_permission_path(resource_permission), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
+      <% if policy(resource_permission).edit? %>
+        <%= link_to edit_host_resource_permission_path(resource_permission), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
         <i class="fas fa-edit"></i> <%= t('globals.edit') %>
       <% end %>
     <% end %>
-    <% if policy(resource_permission).destroy? %>
-      <%= link_to resource_permission_path(resource_permission), method: :delete, data: { turbo_method: :delete, turbo_confirm: t('resource_permissions.confirm_destroy') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => t('globals.destroy') do %>
+      <% if policy(resource_permission).destroy? %>
+        <%= link_to host_resource_permission_path(resource_permission), method: :delete, data: { turbo_method: :delete, turbo_confirm: t('resource_permissions.confirm_destroy') }, class: 'btn btn-outline-danger btn-sm', 'aria-label' => t('globals.destroy') do %>
         <i class="fas fa-trash-alt"></i> <%= t('globals.destroy') %>
       <% end %>
     <% end %>

--- a/app/views/better_together/resource_permissions/edit.html.erb
+++ b/app/views/better_together/resource_permissions/edit.html.erb
@@ -4,7 +4,7 @@
   <%= render "form", resource_permission: @resource_permission %>
 
   <div class="mt-3">
-    <%= link_to "Show this Resource Permission", @resource_permission, class: "btn btn-secondary me-2" %>
-    <%= link_to "Back to Resource Permissions", resource_permissions_path, class: "btn btn-secondary" %>
+      <%= link_to "Show this Resource Permission", [:host, @resource_permission], class: "btn btn-secondary me-2" %>
+      <%= link_to "Back to Resource Permissions", host_resource_permissions_path, class: "btn btn-secondary" %>
   </div>
 </div>

--- a/app/views/better_together/resource_permissions/index.html.erb
+++ b/app/views/better_together/resource_permissions/index.html.erb
@@ -5,11 +5,11 @@
 <div class="container my-3">
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h1><%= resource_class.model_name.human.pluralize %></h1>
-    <% if policy(resource_class).create? %>
-      <%= link_to new_resource_permission_path, class: 'btn btn-primary', 'aria-label' => t('.new_resource_permission') do %>
-        <i class="fas fa-plus"></i> <%= t('.new_resource_permission') %>
+      <% if policy(resource_class).create? %>
+        <%= link_to new_host_resource_permission_path, class: 'btn btn-primary', 'aria-label' => t('.new_resource_permission') do %>
+          <i class="fas fa-plus"></i> <%= t('.new_resource_permission') %>
+        <% end %>
       <% end %>
-    <% end %>
   </div>
 
   <div class="row">

--- a/app/views/better_together/resource_permissions/new.html.erb
+++ b/app/views/better_together/resource_permissions/new.html.erb
@@ -4,6 +4,6 @@
   <%= render "form", resource_permission: @resource_permission %>
 
   <div class="mt-3">
-    <%= link_to "Back to Resource Permissions", resource_permissions_path, class: "btn btn-secondary" %>
+      <%= link_to "Back to Resource Permissions", host_resource_permissions_path, class: "btn btn-secondary" %>
   </div>
 </div>

--- a/app/views/better_together/resource_permissions/show.html.erb
+++ b/app/views/better_together/resource_permissions/show.html.erb
@@ -30,12 +30,12 @@
   </div>
 
   <div class="mt-3">
-    <% if policy(@resource_permission).edit? %>
-      <%= link_to "Edit this Resource Permission", edit_resource_permission_path(@resource_permission), class: "btn btn-primary me-2" %>
-    <% end %>
-    <%= link_to "Back to Resource Permissions", resource_permissions_path, class: "btn btn-secondary me-2" %>
-    <% if policy(@resource_permission).destroy? %>
-      <%= button_to "Destroy this Resource Permission", @resource_permission, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger", style: "margin-right: 10px;" %>
-    <% end %>
+      <% if policy(@resource_permission).edit? %>
+        <%= link_to "Edit this Resource Permission", edit_host_resource_permission_path(@resource_permission), class: "btn btn-primary me-2" %>
+      <% end %>
+      <%= link_to "Back to Resource Permissions", host_resource_permissions_path, class: "btn btn-secondary me-2" %>
+      <% if policy(@resource_permission).destroy? %>
+        <%= button_to "Destroy this Resource Permission", [:host, @resource_permission], method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger", style: "margin-right: 10px;" %>
+      <% end %>
   </div>
 </div>

--- a/app/views/better_together/roles/_role.html.erb
+++ b/app/views/better_together/roles/_role.html.erb
@@ -6,22 +6,22 @@
   <td><%= role.position %></td>
   <td><%= role.protected ? t('globals.yes') : t('globals.no') %></td>
   <td class="text-end">
-    <%= link_to role_path(role), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => t('globals.show') do %>
+      <%= link_to host_role_path(role), class: 'btn btn-outline-info btn-sm me-1', 'aria-label' => t('globals.show') do %>
       <i class="fas fa-eye"></i> <%= t('globals.show') %>
     <% end %>
 
-    <% if policy(role).edit? %>
-      <%= link_to edit_role_path(role), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
+      <% if policy(role).edit? %>
+        <%= link_to edit_host_role_path(role), class: 'btn btn-outline-secondary btn-sm me-1', 'aria-label' => t('globals.edit') do %>
         <i class="fas fa-edit"></i> <%= t('globals.edit') %>
       <% end %>
     <% end %>
 
-    <% if policy(role).destroy? %>
-      <%= link_to role_path(role),
-                  method: :delete,
-                  data: { turbo_method: :delete, turbo_confirm: t('roles.confirm_destroy') },
-                  class: 'btn btn-outline-danger btn-sm',
-                  'aria-label' => t('globals.destroy') do %>
+      <% if policy(role).destroy? %>
+        <%= link_to host_role_path(role),
+                    method: :delete,
+                    data: { turbo_method: :delete, turbo_confirm: t('roles.confirm_destroy') },
+                    class: 'btn btn-outline-danger btn-sm',
+                    'aria-label' => t('globals.destroy') do %>
         <i class="fas fa-trash-alt"></i> <%= t('globals.destroy') %>
       <% end %>
     <% end %>

--- a/app/views/better_together/roles/edit.html.erb
+++ b/app/views/better_together/roles/edit.html.erb
@@ -4,11 +4,11 @@
   <%= render "form", role: @role %>
 
   <div class="mt-3">
-    <% if policy(@role).show? %>
-      <%= link_to "Show this Role", @role, class: "btn btn-secondary me-2" %>
-    <% end %>
-    <% if policy(::BetterTogether::Role).index? %>
-      <%= link_to "Back to Roles", roles_path, class: "btn btn-secondary" %>
-    <% end %>
+      <% if policy(@role).show? %>
+        <%= link_to "Show this Role", [:host, @role], class: "btn btn-secondary me-2" %>
+      <% end %>
+      <% if policy(::BetterTogether::Role).index? %>
+        <%= link_to "Back to Roles", host_roles_path, class: "btn btn-secondary" %>
+      <% end %>
   </div>
 </div>

--- a/app/views/better_together/roles/index.html.erb
+++ b/app/views/better_together/roles/index.html.erb
@@ -6,11 +6,11 @@
   <div class="d-flex justify-content-between align-items-center mb-3">
     <h1><%= resource_class.model_name.human.pluralize %></h1>
 
-    <% if policy(resource_class).create? %>
-      <%= link_to new_role_path, class: 'btn btn-primary' do %>
-        <i class="fas fa-plus"></i> <%= t('.new_role') %>
+      <% if policy(resource_class).create? %>
+        <%= link_to new_host_role_path, class: 'btn btn-primary' do %>
+          <i class="fas fa-plus"></i> <%= t('.new_role') %>
+        <% end %>
       <% end %>
-    <% end %>
   </div>
 
   <div class="row">

--- a/app/views/better_together/roles/new.html.erb
+++ b/app/views/better_together/roles/new.html.erb
@@ -4,6 +4,6 @@
   <%= render "form", role: @role %>
 
   <div class="mt-3">
-    <%= link_to "Back to Roles", roles_path, class: "btn btn-secondary" %>
+      <%= link_to "Back to Roles", host_roles_path, class: "btn btn-secondary" %>
   </div>
 </div>

--- a/app/views/better_together/roles/show.html.erb
+++ b/app/views/better_together/roles/show.html.erb
@@ -36,20 +36,20 @@
   </div>
 
   <div class="mt-3">
-    <% if policy(@role).edit? %>
-      <%= link_to edit_role_path(@role), class: "btn btn-outline-secondary me-2", 'aria-label' => t('globals.edit') do %>
-        <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+      <% if policy(@role).edit? %>
+        <%= link_to edit_host_role_path(@role), class: "btn btn-outline-secondary me-2", 'aria-label' => t('globals.edit') do %>
+          <i class="fas fa-edit"></i> <%= t('globals.edit') %>
+        <% end %>
       <% end %>
-    <% end %>
-    
-    <%= link_to roles_path, class: "btn btn-outline-info me-2", 'aria-label' => t('globals.back_to_list') do %>
-      <i class="fas fa-arrow-left"></i> <%= t('globals.back_to_list') %>
-    <% end %>
-    
-    <% if policy(@role).destroy? %>
-      <%= button_to @role, data: { turbo_method: :delete, turbo_confirm: t('roles.confirm_destroy') }, class: "btn btn-outline-danger", 'aria-label' => t('globals.destroy') do %>
-        <i class="fas fa-trash-alt"></i> <%= t('globals.destroy') %>
+
+      <%= link_to host_roles_path, class: "btn btn-outline-info me-2", 'aria-label' => t('globals.back_to_list') do %>
+        <i class="fas fa-arrow-left"></i> <%= t('globals.back_to_list') %>
       <% end %>
-    <% end %>
+
+      <% if policy(@role).destroy? %>
+        <%= button_to [:host, @role], data: { turbo_method: :delete, turbo_confirm: t('roles.confirm_destroy') }, class: "btn btn-outline-danger", 'aria-label' => t('globals.destroy') do %>
+          <i class="fas fa-trash-alt"></i> <%= t('globals.destroy') %>
+        <% end %>
+      <% end %>
   </div>
 </div>

--- a/app/views/better_together/users/_user.html.erb
+++ b/app/views/better_together/users/_user.html.erb
@@ -1,12 +1,12 @@
 <tr id="<%= dom_id(user) %>">
   <td><%= user.email %></td>
   <td>
-    <%= link_to 'Show', user_path(user), class: 'btn btn-primary btn-sm' %>
+      <%= link_to 'Show', host_user_path(user), class: 'btn btn-primary btn-sm' %>
     <% if policy(user).edit? %>
-      <%= link_to 'Edit', edit_user_path(user), class: 'btn btn-secondary btn-sm' %>
+        <%= link_to 'Edit', edit_host_user_path(user), class: 'btn btn-secondary btn-sm' %>
     <% end %>
     <% if policy(user).destroy? %>
-      <%= link_to 'Destroy', user_path(user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' %>
+        <%= link_to 'Destroy', host_user_path(user), method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger btn-sm' %>
     <% end %>
   </td>
 </tr>

--- a/app/views/better_together/users/edit.html.erb
+++ b/app/views/better_together/users/edit.html.erb
@@ -4,11 +4,11 @@
   <%= render "form", user: @user %>
 
   <div class="mt-3">
-    <% if policy(@user).show? %>
-      <%= link_to "Show this User", @user, class: "btn btn-secondary me-2" %>
-    <% end %>
-    <% if policy(::BetterTogether::User).index? %>
-      <%= link_to "Back to Users", users_path, class: "btn btn-secondary" %>
-    <% end %>
+      <% if policy(@user).show? %>
+        <%= link_to "Show this User", [:host, @user], class: "btn btn-secondary me-2" %>
+      <% end %>
+      <% if policy(::BetterTogether::User).index? %>
+        <%= link_to "Back to Users", host_users_path, class: "btn btn-secondary" %>
+      <% end %>
   </div>
 </div>

--- a/app/views/better_together/users/index.html.erb
+++ b/app/views/better_together/users/index.html.erb
@@ -4,9 +4,9 @@
 
 <div class="container my-3">
   <h1><%= ::BetterTogether::User.model_name.human.pluralize(2, I18n.locale) %></h1>
-  <% if policy(::BetterTogether::User.new).create? %>
-    <%= link_to 'New User', new_user_path, class: 'btn btn-success' %>
-  <% end %>
+    <% if policy(::BetterTogether::User.new).create? %>
+      <%= link_to 'New User', new_host_user_path, class: 'btn btn-success' %>
+    <% end %>
   <div class="row">
     <div class="col">
       <table class="table">

--- a/app/views/better_together/users/new.html.erb
+++ b/app/views/better_together/users/new.html.erb
@@ -4,6 +4,6 @@
   <%= render "form", user: @user %>
 
   <div class="mt-3">
-    <%= link_to "Back to Users", users_path, class: "btn btn-secondary" %>
+      <%= link_to "Back to Users", host_users_path, class: "btn btn-secondary" %>
   </div>
 </div>

--- a/app/views/better_together/users/show.html.erb
+++ b/app/views/better_together/users/show.html.erb
@@ -6,14 +6,14 @@
   </div>
 
   <div class="mt-3">
-    <% if policy(@user).edit? %>
-      <%= link_to "Edit this user", edit_user_path(@user), class: "btn btn-primary me-2" %>
-    <% end %>
+      <% if policy(@user).edit? %>
+        <%= link_to "Edit this user", edit_host_user_path(@user), class: "btn btn-primary me-2" %>
+      <% end %>
 
-    <%= link_to "Back to users", users_path, class: "btn btn-secondary me-2" %>
+      <%= link_to "Back to users", host_users_path, class: "btn btn-secondary me-2" %>
 
-    <% if policy(@user).destroy? %>
-      <%= button_to "Destroy this user", @user, method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger", style: "margin-right: 10px;" %>
-    <% end %>
+      <% if policy(@user).destroy? %>
+        <%= button_to "Destroy this user", [:host, @user], method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger", style: "margin-right: 10px;" %>
+      <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,18 +74,9 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
           get 'me/edit', to: 'people#edit', as: 'edit_my_profile'
         end
 
-        resources :platforms, only: %i[index show edit update] do
-          resources :platform_invitations, only: %i[create destroy] do
-            member do
-              put :resend
-            end
-          end
-        end
-
         authenticated :user, ->(u) { u.permitted_to?('manage_platform') } do # rubocop:todo Metrics/BlockLength
-          scope path: 'host' do # rubocop:todo Metrics/BlockLength
-            # Add route for the host dashboard
-            get '/', to: 'host_dashboard#index', as: 'host_dashboard'
+          namespace :host, module: nil do # rubocop:todo Metrics/BlockLength
+            root to: 'host_dashboard#index'
 
             resources :categories
 

--- a/spec/features/invitations/platform_invitation_create_spec.rb
+++ b/spec/features/invitations/platform_invitation_create_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'creating a platform invitation', type: :feature do
   end
 
   scenario 'with valid inputs' do
-    visit platform_path(host_platform, locale: I18n.default_locale)
+    visit host_platform_path(host_platform, locale: I18n.default_locale)
     within '#newInvitationModal' do
       select 'Platform Invitation', from: 'platform_invitation[type]'
       select 'Community Facilitator', from: 'platform_invitation[community_role_id]'


### PR DESCRIPTION
## Summary
- namespace host admin routes and root dashboard
- update navigation helpers, controllers, and views to use `host_*` paths
- adjust specs for new namespaced routes

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a591b086c832184c2ed282a10aace