### PR TITLE
Scope Joatu matches to request target

### DIFF
--- a/app/services/better_together/joatu/matchmaker.rb
+++ b/app/services/better_together/joatu/matchmaker.rb
@@ -6,6 +6,8 @@ module BetterTogether
     class Matchmaker
       def self.match(request)
         BetterTogether::Joatu::Offer.status_open
+                                    .where(target_type: request.target_type,
+                                           target_id: request.target_id)
                                     .joins(:categories)
                                     .where(BetterTogether::Joatu::Category.table_name => { id: request.category_ids })
                                     .where.not(creator_id: request.creator_id)

--- a/spec/services/better_together/joatu/matchmaker_spec.rb
+++ b/spec/services/better_together/joatu/matchmaker_spec.rb
@@ -23,6 +23,32 @@ module BetterTogether
 
         expect(matches).to contain_exactly(matching_offer)
       end
+
+      it 'only matches offers with the same target' do
+        requestor = create(:better_together_person)
+        offeror = create(:better_together_person)
+        category = create(:better_together_joatu_category)
+
+        target = create(:better_together_platform_invitation)
+        other_target = create(:better_together_platform_invitation)
+
+        matching_offer = create(:better_together_joatu_offer,
+                                creator: offeror,
+                                target: target)
+        matching_offer.categories << category
+
+        non_matching_offer = create(:better_together_joatu_offer, target: other_target)
+        non_matching_offer.categories << category
+
+        request = create(:better_together_joatu_request,
+                          creator: requestor,
+                          target: target)
+        request.categories << category
+
+        matches = described_class.match(request)
+
+        expect(matches).to contain_exactly(matching_offer)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- ensure Joatu matchmaker restricts offers to those sharing a request's target
- test matching on PlatformInvitation targets

## Testing
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689a5cf37dec8321956ad79dcb292077