### PR TITLE
Add target association to Joatu offers and requests

### DIFF
--- a/app/models/better_together/joatu/offer.rb
+++ b/app/models/better_together/joatu/offer.rb
@@ -16,6 +16,8 @@ module BetterTogether
       has_many :agreements, class_name: 'BetterTogether::Joatu::Agreement', dependent: :destroy
       has_many :requests, class_name: 'BetterTogether::Joatu::Request', through: :agreements
 
+      belongs_to :target, polymorphic: true, optional: true
+
       categorizable class_name: '::BetterTogether::Joatu::Category'
 
       translates :name, type: :string
@@ -23,6 +25,7 @@ module BetterTogether
 
       validates :name, :description, :creator, presence: true
       validates :status, presence: true, inclusion: { in: STATUS_VALUES.values }
+      validates :target_type, presence: true, if: :target_id?
 
       enum status: STATUS_VALUES, _prefix: :status
     end

--- a/app/models/better_together/joatu/request.rb
+++ b/app/models/better_together/joatu/request.rb
@@ -16,6 +16,8 @@ module BetterTogether
       has_many :agreements, class_name: 'BetterTogether::Joatu::Agreement', dependent: :destroy
       has_many :offers, class_name: 'BetterTogether::Joatu::Offer', through: :agreements
 
+      belongs_to :target, polymorphic: true, optional: true
+
       categorizable class_name: '::BetterTogether::Joatu::Category'
 
       translates :name, type: :string
@@ -23,6 +25,7 @@ module BetterTogether
 
       validates :name, :description, :creator, presence: true
       validates :status, presence: true, inclusion: { in: STATUS_VALUES.values }
+      validates :target_type, presence: true, if: :target_id?
 
       enum status: STATUS_VALUES, _prefix: :status
 

--- a/db/migrate/20250704000001_add_target_to_better_together_joatu_offers_requests.rb
+++ b/db/migrate/20250704000001_add_target_to_better_together_joatu_offers_requests.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Adds polymorphic target references to Joatu offers and requests
+class AddTargetToBetterTogetherJoatuOffersRequests < ActiveRecord::Migration[7.1]
+  def change
+    change_table :better_together_joatu_offers do |t|
+      t.bt_references :target, polymorphic: true, index: { name: 'bt_joatu_offers_on_target' }
+    end
+
+    change_table :better_together_joatu_requests do |t|
+      t.bt_references :target, polymorphic: true, index: { name: 'bt_joatu_requests_on_target' }
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -656,7 +656,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_04_172724) do
     t.datetime "updated_at", null: false
     t.uuid "creator_id"
     t.string "status", default: "open", null: false
+    t.string "target_type"
+    t.uuid "target_id"
     t.index ["creator_id"], name: "by_better_together_joatu_offers_creator"
+    t.index ["target_type", "target_id"], name: "bt_joatu_offers_on_target"
   end
 
   create_table "better_together_joatu_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
@@ -665,7 +668,10 @@ ActiveRecord::Schema[7.1].define(version: 2025_08_04_172724) do
     t.datetime "updated_at", null: false
     t.uuid "creator_id"
     t.string "status", default: "open", null: false
+    t.string "target_type"
+    t.uuid "target_id"
     t.index ["creator_id"], name: "by_better_together_joatu_requests_creator"
+    t.index ["target_type", "target_id"], name: "bt_joatu_requests_on_target"
   end
 
   create_table "better_together_jwt_denylists", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/factories/better_together/joatu/offers.rb
+++ b/spec/factories/better_together/joatu/offers.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     trait :with_target do
       target { association :better_together_person }
     end
+
+    trait :with_target_type do
+      target_type { 'BetterTogether::Invitation' }
+    end
   end
 end

--- a/spec/factories/better_together/joatu/offers.rb
+++ b/spec/factories/better_together/joatu/offers.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     name { Faker::Commerce.product_name }
     description { Faker::Lorem.paragraph }
     creator { association :better_together_person }
+
+    trait :with_target do
+      target { association :better_together_person }
+    end
   end
 end

--- a/spec/factories/better_together/joatu/requests.rb
+++ b/spec/factories/better_together/joatu/requests.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     trait :with_target do
       target { association :better_together_person }
     end
+
+    trait :with_target_type do
+      target_type { 'BetterTogether::Invitation' }
+    end
   end
 end

--- a/spec/factories/better_together/joatu/requests.rb
+++ b/spec/factories/better_together/joatu/requests.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     name { Faker::Commerce.material }
     description { Faker::Lorem.paragraph }
     creator { association :better_together_person }
+
+    trait :with_target do
+      target { association :better_together_person }
+    end
   end
 end

--- a/spec/models/better_together/joatu/offer_spec.rb
+++ b/spec/models/better_together/joatu/offer_spec.rb
@@ -16,6 +16,11 @@ module BetterTogether
         expect(offer_with_target).to be_valid
       end
 
+      it 'is valid with only a target_type' do
+        offer_with_type = build(:better_together_joatu_offer, :with_target_type)
+        expect(offer_with_type).to be_valid
+      end
+
       it 'is invalid without a creator' do
         offer.creator = nil
         expect(offer).not_to be_valid

--- a/spec/models/better_together/joatu/offer_spec.rb
+++ b/spec/models/better_together/joatu/offer_spec.rb
@@ -7,12 +7,23 @@ module BetterTogether
     RSpec.describe Offer, type: :model do
       subject(:offer) { build(:better_together_joatu_offer) }
 
-      it 'is valid with valid attributes' do
+      it 'is valid without a target' do
         expect(offer).to be_valid
+      end
+
+      it 'is valid with a target' do
+        offer_with_target = build(:better_together_joatu_offer, :with_target)
+        expect(offer_with_target).to be_valid
       end
 
       it 'is invalid without a creator' do
         offer.creator = nil
+        expect(offer).not_to be_valid
+      end
+
+      it 'is invalid without target_type when target_id is set' do
+        offer.target_id = SecureRandom.uuid
+        offer.target_type = nil
         expect(offer).not_to be_valid
       end
     end

--- a/spec/models/better_together/joatu/request_spec.rb
+++ b/spec/models/better_together/joatu/request_spec.rb
@@ -16,6 +16,11 @@ module BetterTogether
         expect(request_with_target).to be_valid
       end
 
+      it 'is valid with only a target_type' do
+        request_with_type = build(:better_together_joatu_request, :with_target_type)
+        expect(request_with_type).to be_valid
+      end
+
       it 'is invalid without a creator' do
         request_model.creator = nil
         expect(request_model).not_to be_valid

--- a/spec/models/better_together/joatu/request_spec.rb
+++ b/spec/models/better_together/joatu/request_spec.rb
@@ -7,12 +7,23 @@ module BetterTogether
     RSpec.describe Request, type: :model do
       subject(:request_model) { build(:better_together_joatu_request) }
 
-      it 'is valid with valid attributes' do
+      it 'is valid without a target' do
         expect(request_model).to be_valid
+      end
+
+      it 'is valid with a target' do
+        request_with_target = build(:better_together_joatu_request, :with_target)
+        expect(request_with_target).to be_valid
       end
 
       it 'is invalid without a creator' do
         request_model.creator = nil
+        expect(request_model).not_to be_valid
+      end
+
+      it 'is invalid without target_type when target_id is set' do
+        request_model.target_id = SecureRandom.uuid
+        request_model.target_type = nil
         expect(request_model).not_to be_valid
       end
     end


### PR DESCRIPTION
## Summary
- add polymorphic target columns to Joatu offers/requests
- associate Offer and Request models with optional target
- support building offers/requests with or without targets in factories and specs

## Testing
- `bin/ci` *(fails: could not translate host name "community-engine-db" to address)*
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bin/codex_style_guard`


------
https://chatgpt.com/codex/tasks/task_e_689a5cea3920832193df145b2b881bf3