### PR TITLE
Notify Joatu agreement participants on creation

### DIFF
--- a/app/mailers/better_together/joatu_mailer.rb
+++ b/app/mailers/better_together/joatu_mailer.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  # Sends Joatu related emails
+  class JoatuMailer < ApplicationMailer
+    def agreement_created
+      @agreement = params[:agreement]
+      @offer = @agreement.offer
+      @request = @agreement.request
+      @recipient = params[:recipient]
+      @platform = BetterTogether::Platform.find_by(host: true)
+
+      self.locale = @recipient.locale
+      self.time_zone = @recipient.time_zone
+
+      mail(to: @recipient.email, subject: t('.subject'))
+    end
+  end
+end

--- a/app/models/better_together/joatu/agreement.rb
+++ b/app/models/better_together/joatu/agreement.rb
@@ -18,6 +18,8 @@ module BetterTogether
 
       enum status: STATUS_VALUES, _prefix: :status
 
+      after_create_commit :notify_creators
+
       def accept!
         transaction do
           update!(status: :accepted)
@@ -28,6 +30,12 @@ module BetterTogether
 
       def reject!
         update!(status: :rejected)
+      end
+
+      private
+
+      def notify_creators
+        AgreementNotifier.with(record: self).deliver_later(offer.creator, request.creator)
       end
     end
   end

--- a/app/notifiers/better_together/joatu/agreement_notifier.rb
+++ b/app/notifiers/better_together/joatu/agreement_notifier.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Joatu
+    # Sends notifications when a new agreement is created
+    class AgreementNotifier < ApplicationNotifier
+      deliver_by :action_cable, channel: 'BetterTogether::NotificationsChannel', message: :build_message
+      deliver_by :email, mailer: 'BetterTogether::JoatuMailer', method: :agreement_created, params: :email_params do |config|
+        config.if = -> { recipient.email.present? && recipient.notification_preferences['notify_by_email'] }
+      end
+
+      validates :record, presence: true
+
+      # Helper method to access the agreement
+      def agreement
+        record
+      end
+
+      def offer
+        agreement.offer
+      end
+
+      def request
+        agreement.request
+      end
+
+      def identifier
+        agreement.id
+      end
+
+      def url
+        ::BetterTogether::Engine.routes.url_helpers.root_url(locale: I18n.locale)
+      end
+
+      def title
+        I18n.t('better_together.notifications.joatu.agreement_created.title')
+      end
+
+      def body
+        I18n.t('better_together.notifications.joatu.agreement_created.content',
+               offer: offer.name,
+               request: request.name)
+      end
+
+      def build_message(notification)
+        {
+          title:,
+          body:,
+          identifier:,
+          url:,
+          unread_count: notification.recipient.notifications.unread.count
+        }
+      end
+
+      def email_params(_notification)
+        { agreement: agreement }
+      end
+    end
+  end
+end

--- a/app/views/better_together/joatu_mailer/agreement_created.html.erb
+++ b/app/views/better_together/joatu_mailer/agreement_created.html.erb
@@ -1,0 +1,7 @@
+<!-- app/views/better_together/joatu_mailer/agreement_created.html.erb -->
+
+<p><%= t('.greeting', recipient_name: @recipient.name) %></p>
+
+<p><%= t('.message_intro', offer_name: @offer.name, request_name: @request.name) %></p>
+
+<p><%= t('.signature_html', platform: @platform.name) %></p>

--- a/app/views/better_together/joatu_mailer/agreement_created.text.erb
+++ b/app/views/better_together/joatu_mailer/agreement_created.text.erb
@@ -1,0 +1,7 @@
+<!-- app/views/better_together/joatu_mailer/agreement_created.text.erb -->
+
+<%= t('.greeting', recipient_name: @recipient.name) %>
+
+<%= t('.message_intro', offer_name: @offer.name, request_name: @request.name) %>
+
+<%= t('.signature', platform: @platform.name) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -640,6 +640,17 @@ en:
         view_conversation: 'You can view and reply to this message by clicking the
           link below:'
         view_conversation_link: 'Go to conversation'
+    joatu_mailer:
+      agreement_created:
+        subject: 'A new agreement was created'
+        greeting: Hello %{recipient_name},
+        message_intro: 'An agreement has been created between "%{offer_name}" and "%{request_name}".'
+        signature: |-
+          Best regards,
+          The %{platform} Team
+        signature_html: |-
+          Best regards,<br />
+          The %{platform} Team
     conversations:
       communicator:
         active_conversations: Active Conversations
@@ -819,6 +830,10 @@ en:
       new_message:
         content: "%{content}"
         title: "%{sender}: %{conversation}"
+      joatu:
+        agreement_created:
+          title: Agreement created
+          content: 'An agreement between "%{offer}" and "%{request}" has been created.'
       time_ago: "%{time} ago"
     pages:
       form:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -643,6 +643,17 @@ es:
         view_conversation: 'Puedes ver y responder a este mensaje haciendo clic en
           el enlace a continuación:'
         view_conversation_link: 'Ir a la conversación'
+    joatu_mailer:
+      agreement_created:
+        subject: 'Se ha creado un nuevo acuerdo'
+        greeting: Hola %{recipient_name},
+        message_intro: 'Se ha creado un acuerdo entre "%{offer_name}" y "%{request_name}".'
+        signature: |-
+          Saludos cordiales,
+          El equipo de %{platform}
+        signature_html: |-
+          Saludos cordiales,<br />
+          El equipo de %{platform}
     conversations:
       communicator:
         active_conversations: Active Conversations
@@ -822,6 +833,10 @@ es:
       new_message:
         content: "%{content}"
         title: "%{sender}: %{conversation}"
+      joatu:
+        agreement_created:
+          title: Acuerdo creado
+          content: 'Se ha creado un acuerdo entre "%{offer}" y "%{request}".'
       time_ago: hace %{time}
     pages:
       form:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -645,6 +645,17 @@ fr:
         view_conversation: 'Vous pouvez voir et répondre à ce message en cliquant
           sur le lien ci-dessous :'
         view_conversation_link: 'Aller à la conversation'
+    joatu_mailer:
+      agreement_created:
+        subject: 'Un nouvel accord a été créé'
+        greeting: Bonjour %{recipient_name},
+        message_intro: 'Un accord a été créé entre "%{offer_name}" et "%{request_name}".'
+        signature: |-
+          Cordialement,
+          L'équipe de %{platform}
+        signature_html: |-
+          Cordialement,<br />
+          L'équipe de %{platform}
     conversations:
       communicator:
         active_conversations: Active Conversations
@@ -825,6 +836,10 @@ fr:
       new_message:
         content: "%{content}"
         title: "%{sender}: %{conversation}"
+      joatu:
+        agreement_created:
+          title: Accord créé
+          content: 'Un accord entre "%{offer}" et "%{request}" a été créé.'
       time_ago: il y a %{time}
     pages:
       form:

--- a/spec/mailers/better_together/joatu_mailer_spec.rb
+++ b/spec/mailers/better_together/joatu_mailer_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module BetterTogether
+  RSpec.describe JoatuMailer, type: :mailer do
+    describe 'agreement_created' do
+      let!(:host_platform) { create(:platform, :host) }
+      let(:offer_user) { create(:user) }
+      let(:request_user) { create(:user) }
+      let(:offer) { create(:joatu_offer, creator: offer_user.person) }
+      let(:request) { create(:joatu_request, creator: request_user.person) }
+      let(:agreement) { create(:joatu_agreement, offer:, request:) }
+      let(:recipient) { offer_user.person }
+
+      let(:mail) do
+        JoatuMailer.with(agreement: agreement, recipient: recipient).agreement_created
+      end
+
+      it 'renders the headers' do
+        expect(mail.subject).to have_content('agreement was created')
+        expect(mail.to).to include(offer_user.email)
+        expect(mail.from).to include('community@bettertogethersolutions.com')
+      end
+
+      it 'renders the body' do
+        expect(mail.body.encoded).to have_content("Hello #{recipient.name}")
+        expect(mail.body.encoded).to have_content(
+          "An agreement has been created between \"#{offer.name}\" and \"#{request.name}\""
+        )
+      end
+
+      it 'sends the agreement created email to the recipient' do
+        expect { mail.deliver_now }.to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect(ActionMailer::Base.deliveries.last.to).to include(offer_user.email)
+      end
+    end
+  end
+end

--- a/spec/notifiers/better_together/joatu/agreement_notifier_spec.rb
+++ b/spec/notifiers/better_together/joatu/agreement_notifier_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module BetterTogether
+  module Joatu
+    RSpec.describe AgreementNotifier do
+      let(:offer_user) { create(:user) }
+      let(:request_user) { create(:user) }
+      let(:offer) { create(:joatu_offer, creator: offer_user.person) }
+      let(:request) { create(:joatu_request, creator: request_user.person) }
+
+      it 'notifies both offer and request creators when agreement is created' do
+        expect do
+          create(:joatu_agreement, offer:, request:)
+        end.to change(Noticed::Notification, :count).by(2)
+
+        recipients = Noticed::Notification.last(2).map(&:recipient)
+        expect(recipients).to contain_exactly(offer_user.person, request_user.person)
+      end
+
+      it 'builds message with offer and request names' do
+        agreement = build(:joatu_agreement, offer:, request:)
+        notifier = described_class.new(record: agreement)
+
+        expect(notifier.title).to eq(
+          I18n.t('better_together.notifications.joatu.agreement_created.title')
+        )
+        expect(notifier.body).to eq(
+          I18n.t('better_together.notifications.joatu.agreement_created.content',
+                 offer: offer.name,
+                 request: request.name)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add AgreementNotifier for Joatu agreements delivering via NotificationsChannel and JoatuMailer
- implement JoatuMailer#agreement_created with HTML/text templates
- notify offer and request creators after agreement creation
- cover notifier and mailer with specs

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop; install missing gem executables with `bundle install`)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman; install missing gem executables with `bundle install`)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit; install missing gem executables with `bundle install`)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop; install missing gem executables with `bundle install`)*
- `bin/ci` *(fails: bundler: command not found: rails; install missing gem executables with `bundle install`)*

------
https://chatgpt.com/codex/tasks/task_e_689a5e5556bc8321b6efede11b3eb8f9