### PR TITLE
Handle nil expiration in PlatformInvitation scopes

### DIFF
--- a/app/models/better_together/platform_invitation.rb
+++ b/app/models/better_together/platform_invitation.rb
@@ -46,10 +46,8 @@ module BetterTogether
 
     scope :pending, -> { where(status: STATUS_VALUES[:pending]) }
     scope :accepted, -> { where(status: STATUS_VALUES[:accepted]) }
-    # TODO: Check expired scope to ensure that it includes those wit no value for valid_until
-    scope :expired, -> { where('valid_until < ?', Time.current) }
-
-    # TODO: add 'not expired' scope to find only invitations that are available
+    scope :expired, -> { where('valid_until IS NOT NULL AND valid_until < ?', Time.current) }
+    scope :not_expired, -> { where('valid_until IS NULL OR valid_until >= ?', Time.current) }
 
     def self.load_all_subclasses
       Rails.application.eager_load! # Ensure all models are loaded

--- a/spec/models/better_together/platform_invitation_spec.rb
+++ b/spec/models/better_together/platform_invitation_spec.rb
@@ -94,6 +94,19 @@ module BetterTogether # rubocop:todo Metrics/ModuleLength
           expect(BetterTogether::PlatformInvitation.expired.count).to eq(1)
         end
       end
+
+      describe '.not_expired' do
+        it 'returns invitations that are not expired or have no expiration' do
+          future_invitation = create(:better_together_platform_invitation, valid_until: 1.day.from_now)
+          nil_invitation = create(:better_together_platform_invitation, valid_until: nil)
+          create(:better_together_platform_invitation, valid_until: 1.day.ago)
+
+          result = BetterTogether::PlatformInvitation.not_expired
+
+          expect(result).to include(future_invitation, nil_invitation)
+          expect(result.count).to eq(2)
+        end
+      end
     end
 
     describe 'Methods' do


### PR DESCRIPTION
## Summary
- refine expired and not_expired scopes on PlatformInvitation to handle NULL expiration
- cover not_expired scope with test including nil valid_until

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a64f887e48321ac28d7b9f1a46923