### PR TITLE
Refactor host dashboard resource definitions for customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,17 @@ Run the RSpec tests:
 ```bash
 bin/dc-run app rspec
 ```
+
+## Host Dashboard Customization
+
+Host applications can modify which resources appear on the host dashboard by adjusting the resource definition arrays in an initializer. Each resource hash accepts a `:model` and `:url_helper` with optional `:collection` and `:count` lambdas.
+
+```ruby
+# config/initializers/host_dashboard_resources.rb
+BetterTogether::HostDashboardController::ROOT_RESOURCE_DEFINITIONS << {
+  model: -> { MyResource },
+  url_helper: -> { :my_resource_path }
+}
+```
+
+See `docs/host_dashboard_extensions.md` for more customization examples.

--- a/app/views/better_together/host_dashboard/index.html.erb
+++ b/app/views/better_together/host_dashboard/index.html.erb
@@ -12,50 +12,27 @@
   <div class="better-together-resources mt-4">
     <h2><%= t('host_dashboard.index.better_together') %></h2>
     <div class="row mt-3 row-cols-1 row-cols-sm-2 row-cols-md-3">
-      <!-- Communities -->
-      <%= render partial: 'resource_card', locals: { collection: @communities, count: @community_count, url_helper: :community_path } %>
-
-      <!-- Navigation Areas -->
-      <%= render partial: 'resource_card', locals: { collection: @navigation_areas, count: @navigation_area_count, url_helper: :navigation_area_path } %>
-
-      <!-- Pages -->
-      <%= render partial: 'resource_card', locals: { collection: @pages, count: @page_count, url_helper: :page_path } %>
-
-      <!-- Platforms -->
-      <%= render partial: 'resource_card', locals: { collection: @platforms, count: @platform_count, url_helper: :platform_path } %>
-
-      <!-- People -->
-      <%= render partial: 'resource_card', locals: { collection: @people, count: @person_count, url_helper: :person_path } %>
-
-      <!-- Roles -->
-      <%= render partial: 'resource_card', locals: { collection: @roles, count: @role_count, url_helper: :role_path } %>
-
-      <!-- Resource Permissions -->
-      <%= render partial: 'resource_card', locals: { collection: @resource_permissions, count: @resource_permission_count, url_helper: :resource_permission_path } %>
-
-      <!-- Users -->
-      <%= render partial: 'resource_card', locals: { collection: @users, count: @user_count, url_helper: :user_path } %>
-      <%= render partial: 'resource_card', locals: { collection: @conversations, count: @conversation_count, url_helper: :conversation_path } %>
-      <%= render partial: 'resource_card', locals: { collection: @messages, count: @message_count, url_helper: :message_path } %>
-      <%= render partial: 'resource_card', locals: { collection: @categories, count: @category_count, url_helper: :category_path } %>
+      <% @root_resources.each do |resource| %>
+        <%= render partial: 'resource_card', locals: resource %>
+      <% end %>
     </div>
 
     <div id="content-section" class="row mt-3">
       <div class="col-12">
         <h3><%= t('host_dashboard.index.content') %></h3>
       </div>
-      <%= render partial: 'resource_card', locals: { model_class: ::BetterTogether::Content::Block, collection: @content_blocks, count: @content_block_count, url_helper: :content_block_path } %>
+      <% @content_resources.each do |resource| %>
+        <%= render partial: 'resource_card', locals: resource %>
+      <% end %>
     </div>
 
     <div id="geography-section" class="row mt-3">
       <div class="col-12">
         <h3><%= t('host_dashboard.index.geography') %></h3>
       </div>
-      <%= render partial: 'resource_card', locals: {collection: @geography_continents, count: @geography_continent_count, url_helper: :geography_continent_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_countries, count: @geography_country_count, url_helper: :geography_country_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_states, count: @geography_state_count, url_helper: :geography_state_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_regions, count: @geography_region_count, url_helper: :geography_region_path } %>
-      <%= render partial: 'resource_card', locals: {collection: @geography_settlements, count: @geography_settlement_count, url_helper: :geography_settlement_path } %>
+      <% @geography_resources.each do |resource| %>
+        <%= render partial: 'resource_card', locals: resource %>
+      <% end %>
     </div>
   </div>
 </div>

--- a/docs/host_dashboard_extensions.md
+++ b/docs/host_dashboard_extensions.md
@@ -22,3 +22,29 @@ Example:
 ```
 
 If the partial is absent, the dashboard simply skips this section.
+
+## Customizing Resource Listings
+
+Host applications can also adjust the resources displayed on the dashboard by modifying the resource definition arrays exposed by the controller. Each definition hash expects a `:model` and `:url_helper` with optional `:collection` and `:count` lambdas.
+
+Append a new resource:
+
+```ruby
+# config/initializers/host_dashboard_resources.rb
+BetterTogether::HostDashboardController::ROOT_RESOURCE_DEFINITIONS << {
+  model: -> { MyResource },
+  url_helper: -> { :my_resource_path },
+  collection: -> { MyResource.limit(5) }, # optional
+  count: -> { MyResource.count }          # optional
+}
+```
+
+Or replace the entire list:
+
+```ruby
+BetterTogether::HostDashboardController::CONTENT_RESOURCE_DEFINITIONS = [
+  { model: -> { MyOtherResource }, url_helper: -> { :my_other_resource_path } }
+]
+```
+
+When `:collection` or `:count` are omitted, the dashboard falls back to the model's latest three records and total count.


### PR DESCRIPTION
## Summary
- move host dashboard resource listings into configurable definition arrays
- build resources dynamically with optional lambdas for model, collection, and count
- document how host apps can append or replace resources via initializers

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.4)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a65210a9c83218f2b00025a97b721