### PR TITLE
Validate Joatu agreement target alignment

### DIFF
--- a/app/models/better_together/joatu/agreement.rb
+++ b/app/models/better_together/joatu/agreement.rb
@@ -15,6 +15,7 @@ module BetterTogether
 
       validates :offer, :request, presence: true
       validates :status, presence: true, inclusion: { in: STATUS_VALUES.values }
+      validate :offer_matches_request_target
 
       enum status: STATUS_VALUES, _prefix: :status
 
@@ -28,6 +29,21 @@ module BetterTogether
 
       def reject!
         update!(status: :rejected)
+      end
+
+      private
+
+      # Ensures the offer targets the same record as the request
+      def offer_matches_request_target
+        return unless targets_present?
+        return if offer.target_type == request.target_type && offer.target_id == request.target_id
+
+        errors.add(:offer, 'target does not match request target')
+      end
+
+      def targets_present?
+        offer && request &&
+          [offer, request].all? { |r| r.respond_to?(:target_type) && r.respond_to?(:target_id) }
       end
     end
   end

--- a/spec/models/better_together/joatu/agreement_spec.rb
+++ b/spec/models/better_together/joatu/agreement_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 module BetterTogether
   module Joatu
-    RSpec.describe Agreement, type: :model do
+    RSpec.describe Agreement, type: :model do # rubocop:disable Metrics/BlockLength
       it 'accept! closes offer and request' do
         agreement = create(:better_together_joatu_agreement)
         agreement.accept!
@@ -12,6 +12,37 @@ module BetterTogether
         expect(agreement.status_accepted?).to be(true)
         expect(agreement.offer.status_closed?).to be(true)
         expect(agreement.request.status_closed?).to be(true)
+      end
+
+      describe 'validation' do
+        it 'rejects mismatched targets' do
+          request = create(:better_together_joatu_request)
+          offer = create(:better_together_joatu_offer)
+
+          allow(request).to receive(:target_type).and_return('Foo')
+          allow(request).to receive(:target_id).and_return('1')
+          allow(offer).to receive(:target_type).and_return('Foo')
+          allow(offer).to receive(:target_id).and_return('2')
+
+          agreement = described_class.new(offer:, request:)
+
+          expect(agreement).not_to be_valid
+          expect(agreement.errors[:offer]).to include('target does not match request target')
+        end
+
+        it 'allows matching targets' do
+          request = create(:better_together_joatu_request)
+          offer = create(:better_together_joatu_offer)
+
+          allow(request).to receive(:target_type).and_return('Foo')
+          allow(request).to receive(:target_id).and_return('1')
+          allow(offer).to receive(:target_type).and_return('Foo')
+          allow(offer).to receive(:target_id).and_return('1')
+
+          agreement = described_class.new(offer:, request:)
+
+          expect(agreement).to be_valid
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary
- ensure `BetterTogether::Joatu::Agreement` requires offer and request to target the same record
- add model specs for target mismatch validation

## Testing
- `bundle exec rubocop`
- `bin/codex_style_guard`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bin/ci` *(fails: connection to server at "::1", port 5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_689a5cf034588321aabb45a45be8eb16