### PR TITLE
Show total upload size

### DIFF
--- a/app/controllers/better_together/uploads_controller.rb
+++ b/app/controllers/better_together/uploads_controller.rb
@@ -6,6 +6,10 @@ module BetterTogether
     before_action :set_resource_instance, only: %i[show edit update destroy download]
     before_action :authorize_resource, only: %i[new show edit update destroy download]
 
+    def index
+      @total_size = policy_scope(Upload).sum(&:byte_size)
+    end
+
     def download # rubocop:todo Metrics/AbcSize, Metrics/MethodLength
       if resource_instance.attached?
         # Trigger the background job to log the download

--- a/app/helpers/better_together/uploads_helper.rb
+++ b/app/helpers/better_together/uploads_helper.rb
@@ -3,5 +3,8 @@
 module BetterTogether
   # helper methods for file uploads
   module UploadsHelper
+    def total_upload_size(uploads)
+      number_to_human_size(uploads.sum(&:byte_size))
+    end
   end
 end

--- a/app/views/better_together/uploads/index.html.erb
+++ b/app/views/better_together/uploads/index.html.erb
@@ -1,2 +1,8 @@
-<h1>Files#index</h1>
-<p>Find me in app/views/better_together/files/index.html.erb</p>
+<% content_for :page_title do %>
+  <%= resource_class.model_name.human.pluralize %>
+<% end %>
+
+<div class="container my-3">
+  <h1><%= resource_class.model_name.human.pluralize %></h1>
+  <p><%= t('.storage_usage', size: number_to_human_size(@total_size)) %></p>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -613,6 +613,9 @@ en:
         contact_details: Contact details
         details: Details
         images: Images
+    uploads:
+      index:
+        storage_usage: "You're using %{size} of storage"
     contact_details:
       contact_information: Contact information
       title: Contact Details

--- a/spec/helpers/better_together/uploads_helper_spec.rb
+++ b/spec/helpers/better_together/uploads_helper_spec.rb
@@ -2,20 +2,13 @@
 
 require 'rails_helper'
 
-# Specs in this file have access to a helper object that includes
-# the UploadsHelper. For example:
-#
-# describe UploadsHelper do
-#   describe "string concat" do
-#     it "concats two strings with spaces" do
-#       expect(helper.concat_strings("this","that")).to eq("this that")
-#     end
-#   end
-# end
 module BetterTogether
   RSpec.describe UploadsHelper, type: :helper do
-    it 'exists' do
-      expect(described_class).to be
+    describe '#total_upload_size' do
+      it 'returns human readable total size' do
+        uploads = [double(byte_size: 2.megabytes), double(byte_size: 3.megabytes)]
+        expect(helper.total_upload_size(uploads)).to eq '5 MB'
+      end
     end
   end
 end

--- a/spec/views/better_together/files/index.html.erb_spec.rb
+++ b/spec/views/better_together/files/index.html.erb_spec.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-require 'rails_helper'
-
-RSpec.describe 'files/index.html.erb', type: :view do
-  it 'works' do
-    expect(true).to be(true)
-  end
-end

--- a/spec/views/better_together/uploads/index.html.erb_spec.rb
+++ b/spec/views/better_together/uploads/index.html.erb_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'better_together/uploads/index.html.erb', type: :view do
+  it 'renders total storage usage' do
+    allow(view).to receive(:resource_class).and_return(BetterTogether::Upload)
+    assign(:uploads, [])
+    assign(:total_size, 3.megabytes)
+
+    render
+
+    expect(rendered).to include("You're using 3 MB of storage")
+  end
+end


### PR DESCRIPTION
## Summary
- add `total_upload_size` helper to present upload totals
- compute and expose total upload size in uploads#index
- show storage usage message on uploads index page

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689a6fe1934883219cf1b240d8f49854