### PR TITLE
Fix Rails matrix versions to avoid Bundler hang

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -14,10 +14,10 @@ jobs:
             rails: '7.1.5.1'
             allowed_failure: false   # ✅ required
           - ruby: '3.4.4'
-            rails: '7.2'
-            allowed_failure: false    # ⚠️ allowed to fail
+            rails: '7.2.2.1'
+            allowed_failure: false   # ⚠️ allowed to fail
           - ruby: '3.4.4'
-            rails: '8.0'
+            rails: '8.0.2'
             allowed_failure: true    # ⚠️ allowed to fail
 
     env:


### PR DESCRIPTION
## Summary
- use full Rails gem versions in CI matrix so bundler can resolve dependencies

## Testing
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.4)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689b611271308321a014d72d3828c666