### PR TITLE
Handle conversation form errors via Turbo Stream

### DIFF
--- a/app/controllers/better_together/conversations_controller.rb
+++ b/app/controllers/better_together/conversations_controller.rb
@@ -20,7 +20,7 @@ module BetterTogether
       authorize @conversation
     end
 
-    def create # rubocop:todo Metrics/MethodLength
+    def create # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
       @conversation = Conversation.new(conversation_params.merge(creator: helpers.current_person))
 
       authorize @conversation

--- a/app/controllers/better_together/conversations_controller.rb
+++ b/app/controllers/better_together/conversations_controller.rb
@@ -33,7 +33,12 @@ module BetterTogether
           format.html { redirect_to @conversation }
         end
       else
-        render :new
+        respond_to do |format|
+          format.turbo_stream do
+            render :create_error, status: :unprocessable_entity
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 

--- a/app/views/better_together/conversations/create_error.turbo_stream.erb
+++ b/app/views/better_together/conversations/create_error.turbo_stream.erb
@@ -1,0 +1,1 @@
+<%= turbo_stream.update 'form_errors', partial: 'layouts/better_together/errors', locals: { object: @conversation } %>

--- a/app/views/better_together/conversations/new.html.erb
+++ b/app/views/better_together/conversations/new.html.erb
@@ -4,9 +4,10 @@
       <h6 class="mb-0"><%= t('.new_conversation') %></h6>
     </div>
 
-    <div class="card-body">
-      <%= form_with(model: @conversation, local: true, data: { turbo: false, controller: 'better_together--form-validation'}) do |form| %>
-        <div class="mb-3">
+      <div class="card-body">
+        <%= form_with(model: @conversation, data: { controller: 'better_together--form-validation' }) do |form| %>
+          <%= turbo_frame_tag 'form_errors' %>
+          <div class="mb-3">
           <%= form.label :participant_ids, t('.add_participants') %>
           <%= form.collection_select :participant_ids, available_participants, :id, :select_option_title, { }, { multiple: true, class: 'form-select', required: true, data: { controller: "better_together--slim-select" } } %>
         </div>


### PR DESCRIPTION
## Summary
- Add Turbo Stream error handling to conversation creation failures
- Show validation messages in `form_errors` frame
- Enhance Stimulus form validation controller to render server-side errors on 422 responses

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec brakeman -q -w2` *(fails: command not found)*
- `bundle exec bundler-audit --update` *(fails: command not found)*
- `bin/codex_style_guard` *(fails: command not found)*
- `bin/ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b64c801a483219d5c496b53f5584f