### PR TITLE
Add Turbo Stream validation handling

### DIFF
--- a/app/controllers/better_together/conversations_controller.rb
+++ b/app/controllers/better_together/conversations_controller.rb
@@ -33,7 +33,16 @@ module BetterTogether
           format.html { redirect_to @conversation }
         end
       else
-        render :new
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @conversation }
+            )
+          end
+          format.html { render :new }
+        end
       end
     end
 

--- a/app/controllers/better_together/geography/continents_controller.rb
+++ b/app/controllers/better_together/geography/continents_controller.rb
@@ -28,7 +28,16 @@ module BetterTogether
         if @geography_continent.save
           redirect_to @geography_continent, notice: 'Continent was successfully created.'
         else
-          render :new, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_continent }
+              )
+            end
+            format.html { render :new, status: :unprocessable_entity }
+          end
         end
       end
 
@@ -37,7 +46,16 @@ module BetterTogether
         if @geography_continent.update(geography_continent_params)
           redirect_to @geography_continent, notice: 'Continent was successfully updated.', status: :see_other
         else
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_continent }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
 

--- a/app/controllers/better_together/geography/countries_controller.rb
+++ b/app/controllers/better_together/geography/countries_controller.rb
@@ -35,7 +35,16 @@ module BetterTogether
         if @geography_country.save
           redirect_to @geography_country, notice: 'Country was successfully created.', status: :see_other
         else
-          render :new, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_country }
+              )
+            end
+            format.html { render :new, status: :unprocessable_entity }
+          end
         end
       end
 
@@ -44,7 +53,16 @@ module BetterTogether
         if @geography_country.update(geography_country_params)
           redirect_to @geography_country, notice: 'Country was successfully updated.', status: :see_other
         else
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_country }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
 

--- a/app/controllers/better_together/geography/region_settlements_controller.rb
+++ b/app/controllers/better_together/geography/region_settlements_controller.rb
@@ -28,7 +28,16 @@ module BetterTogether
         if @geography_region_settlement.save
           redirect_to @geography_region_settlement, notice: 'Region settlement was successfully created.'
         else
-          render :new, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_region_settlement }
+              )
+            end
+            format.html { render :new, status: :unprocessable_entity }
+          end
         end
       end
 
@@ -38,7 +47,16 @@ module BetterTogether
           redirect_to @geography_region_settlement, notice: 'Region settlement was successfully updated.',
                                                     status: :see_other
         else
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_region_settlement }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
 

--- a/app/controllers/better_together/geography/regions_controller.rb
+++ b/app/controllers/better_together/geography/regions_controller.rb
@@ -35,7 +35,16 @@ module BetterTogether
         if @geography_region.save
           redirect_to @geography_region, notice: 'Region was successfully created.'
         else
-          render :new, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_region }
+              )
+            end
+            format.html { render :new, status: :unprocessable_entity }
+          end
         end
       end
 
@@ -44,7 +53,16 @@ module BetterTogether
         if @geography_region.update(geography_region_params)
           redirect_to @geography_region, notice: 'Region was successfully updated.', status: :see_other
         else
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_region }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
 

--- a/app/controllers/better_together/geography/settlements_controller.rb
+++ b/app/controllers/better_together/geography/settlements_controller.rb
@@ -35,7 +35,16 @@ module BetterTogether
         if @geography_settlement.save
           redirect_to @geography_settlement, notice: 'Settlement was successfully created.'
         else
-          render :new, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_settlement }
+              )
+            end
+            format.html { render :new, status: :unprocessable_entity }
+          end
         end
       end
 
@@ -44,7 +53,16 @@ module BetterTogether
         if @geography_settlement.update(geography_settlement_params)
           redirect_to @geography_settlement, notice: 'Settlement was successfully updated.', status: :see_other
         else
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_settlement }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
 

--- a/app/controllers/better_together/geography/states_controller.rb
+++ b/app/controllers/better_together/geography/states_controller.rb
@@ -33,7 +33,16 @@ module BetterTogether
         if @geography_state.save
           redirect_to @geography_state, notice: 'State was successfully created.', status: :see_other
         else
-          render :new, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_state }
+              )
+            end
+            format.html { render :new, status: :unprocessable_entity }
+          end
         end
       end
 
@@ -42,7 +51,16 @@ module BetterTogether
         if @geography_state.update(geography_state_params)
           redirect_to @geography_state, notice: 'State was successfully updated.', status: :see_other
         else
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @geography_state }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
 

--- a/app/controllers/better_together/navigation_areas_controller.rb
+++ b/app/controllers/better_together/navigation_areas_controller.rb
@@ -52,7 +52,16 @@ module BetterTogether
       if @navigation_area.save
         redirect_to @navigation_area, only_path: true, notice: 'Navigation area was successfully created.'
       else
-        render :new
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @navigation_area }
+            )
+          end
+          format.html { render :new }
+        end
       end
     end
 
@@ -62,7 +71,16 @@ module BetterTogether
       if @navigation_area.update(navigation_area_params)
         redirect_to @navigation_area, only_path: true, notice: 'Navigation area was successfully updated.'
       else
-        render :edit
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @navigation_area }
+            )
+          end
+          format.html { render :edit }
+        end
       end
     end
 

--- a/app/controllers/better_together/navigation_items_controller.rb
+++ b/app/controllers/better_together/navigation_items_controller.rb
@@ -40,7 +40,16 @@ module BetterTogether
       if @navigation_item.save
         redirect_to @navigation_area, only_path: true, notice: 'Navigation item was successfully created.'
       else
-        render :new
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @navigation_item }
+            )
+          end
+          format.html { render :new }
+        end
       end
     end
 

--- a/app/controllers/better_together/pages_controller.rb
+++ b/app/controllers/better_together/pages_controller.rb
@@ -36,12 +36,21 @@ module BetterTogether
       @page = resource_class.new(page_params)
       authorize @page
 
-      if @page.save
-        redirect_to edit_page_path(@page), notice: t('flash.generic.created', resource: t('resources.page'))
-      else
-        render :new
+        if @page.save
+          redirect_to edit_page_path(@page), notice: t('flash.generic.created', resource: t('resources.page'))
+        else
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @page }
+              )
+            end
+            format.html { render :new }
+          end
+        end
       end
-    end
 
     def edit
       authorize @page

--- a/app/controllers/better_together/people_controller.rb
+++ b/app/controllers/better_together/people_controller.rb
@@ -26,7 +26,16 @@ module BetterTogether
       if @person.save
         redirect_to @person, only_path: true, notice: 'Person was successfully created.', status: :see_other
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @person }
+            )
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -40,7 +49,16 @@ module BetterTogether
           redirect_to @person, only_path: true, notice: 'Profile was successfully updated.', status: :see_other
         else
           flash.now[:alert] = 'Please address the errors below.'
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @person }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
     end

--- a/app/controllers/better_together/person_platform_memberships_controller.rb
+++ b/app/controllers/better_together/person_platform_memberships_controller.rb
@@ -29,7 +29,16 @@ module BetterTogether
         redirect_to @person_platform_membership, only_path: true,
                                                  notice: 'Person platform membership was successfully created.'
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @person_platform_membership }
+            )
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -39,7 +48,16 @@ module BetterTogether
         redirect_to @person_platform_membership, notice: 'Person platform membership was successfully updated.',
                                                  status: :see_other
       else
-        render :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @person_platform_membership }
+            )
+          end
+          format.html { render :edit, status: :unprocessable_entity }
+        end
       end
     end
 

--- a/app/controllers/better_together/platforms_controller.rb
+++ b/app/controllers/better_together/platforms_controller.rb
@@ -43,7 +43,16 @@ module BetterTogether
       if @platform.save
         redirect_to @platform, notice: 'Platform was successfully created.'
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @platform }
+            )
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -53,7 +62,16 @@ module BetterTogether
       if @platform.update(platform_params)
         redirect_to @platform, notice: 'Platform was successfully updated.', status: :see_other
       else
-        render :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @platform }
+            )
+          end
+          format.html { render :edit, status: :unprocessable_entity }
+        end
       end
     end
 

--- a/app/controllers/better_together/resource_controller.rb
+++ b/app/controllers/better_together/resource_controller.rb
@@ -29,7 +29,16 @@ module BetterTogether
         redirect_to @resource.becomes(resource_class),
                     notice: "#{resource_class.model_name.human} was successfully created."
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @resource }
+            )
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -40,7 +49,16 @@ module BetterTogether
         redirect_to url_for([:edit, @resource.becomes(resource_class)]),
                     notice: "#{resource_class.model_name.human} was successfully updated."
       else
-        render :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @resource }
+            )
+          end
+          format.html { render :edit, status: :unprocessable_entity }
+        end
       end
     end
 

--- a/app/controllers/better_together/resource_permissions_controller.rb
+++ b/app/controllers/better_together/resource_permissions_controller.rb
@@ -35,7 +35,16 @@ module BetterTogether
       if @resource_permission.save
         redirect_to @resource_permission, only_path: true, notice: 'Resource permission was successfully created.'
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @resource_permission }
+            )
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -47,7 +56,16 @@ module BetterTogether
         redirect_to @resource_permission, only_path: true, notice: 'Resource permission was successfully updated.',
                                           status: :see_other
       else
-        render :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @resource_permission }
+            )
+          end
+          format.html { render :edit, status: :unprocessable_entity }
+        end
       end
     end
 

--- a/app/controllers/better_together/roles_controller.rb
+++ b/app/controllers/better_together/roles_controller.rb
@@ -36,7 +36,16 @@ module BetterTogether
       if @role.save
         redirect_to @role, only_path: true, notice: 'Role was successfully created.'
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @role }
+            )
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -47,7 +56,16 @@ module BetterTogether
       if @role.update(role_params)
         redirect_to @role, only_path: true, notice: 'Role was successfully updated.', status: :see_other
       else
-        render :edit, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @role }
+            )
+          end
+          format.html { render :edit, status: :unprocessable_entity }
+        end
       end
     end
 

--- a/app/controllers/better_together/users_controller.rb
+++ b/app/controllers/better_together/users_controller.rb
@@ -29,7 +29,16 @@ module BetterTogether
       if @user.save
         redirect_to @user, only_path: true, notice: 'User was successfully created.', status: :see_other
       else
-        render :new, status: :unprocessable_entity
+        respond_to do |format|
+          format.turbo_stream do
+            render turbo_stream: turbo_stream.update(
+              'form_errors',
+              partial: 'layouts/better_together/errors',
+              locals: { object: @user }
+            )
+          end
+          format.html { render :new, status: :unprocessable_entity }
+        end
       end
     end
 
@@ -43,7 +52,16 @@ module BetterTogether
           redirect_to @user, only_path: true, notice: 'Profile was successfully updated.', status: :see_other
         else
           flash.now[:alert] = 'Please address the errors below.'
-          render :edit, status: :unprocessable_entity
+          respond_to do |format|
+            format.turbo_stream do
+              render turbo_stream: turbo_stream.update(
+                'form_errors',
+                partial: 'layouts/better_together/errors',
+                locals: { object: @user }
+              )
+            end
+            format.html { render :edit, status: :unprocessable_entity }
+          end
         end
       end
     end

--- a/app/views/better_together/conversations/new.html.erb
+++ b/app/views/better_together/conversations/new.html.erb
@@ -5,6 +5,7 @@
     </div>
 
     <div class="card-body">
+      <div id="form_errors"></div>
       <%= form_with(model: @conversation, local: true, data: { turbo: false, controller: 'better_together--form-validation'}) do |form| %>
         <div class="mb-3">
           <%= form.label :participant_ids, t('.add_participants') %>

--- a/app/views/better_together/geography/continents/edit.html.erb
+++ b/app/views/better_together/geography/continents/edit.html.erb
@@ -1,5 +1,6 @@
 <h1>Editing continent</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_continent: @geography_continent %>
 
 <br>

--- a/app/views/better_together/geography/continents/new.html.erb
+++ b/app/views/better_together/geography/continents/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New continent</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_continent: @geography_continent %>
 
 <br>

--- a/app/views/better_together/geography/countries/edit.html.erb
+++ b/app/views/better_together/geography/countries/edit.html.erb
@@ -1,5 +1,6 @@
 <h1>Editing country</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_country: @geography_country %>
 
 <br>

--- a/app/views/better_together/geography/countries/new.html.erb
+++ b/app/views/better_together/geography/countries/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New country</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_country: @geography_country %>
 
 <br>

--- a/app/views/better_together/geography/region_settlements/edit.html.erb
+++ b/app/views/better_together/geography/region_settlements/edit.html.erb
@@ -1,5 +1,6 @@
 <h1>Editing region settlement</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_region_settlement: @geography_region_settlement %>
 
 <br>

--- a/app/views/better_together/geography/region_settlements/new.html.erb
+++ b/app/views/better_together/geography/region_settlements/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New region settlement</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_region_settlement: @geography_region_settlement %>
 
 <br>

--- a/app/views/better_together/geography/regions/edit.html.erb
+++ b/app/views/better_together/geography/regions/edit.html.erb
@@ -1,5 +1,6 @@
 <h1>Editing region</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_region: @geography_region %>
 
 <br>

--- a/app/views/better_together/geography/regions/new.html.erb
+++ b/app/views/better_together/geography/regions/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New region</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_region: @geography_region %>
 
 <br>

--- a/app/views/better_together/geography/settlements/edit.html.erb
+++ b/app/views/better_together/geography/settlements/edit.html.erb
@@ -1,5 +1,6 @@
 <h1>Editing settlement</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_settlement: @geography_settlement %>
 
 <br>

--- a/app/views/better_together/geography/settlements/new.html.erb
+++ b/app/views/better_together/geography/settlements/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New settlement</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_settlement: @geography_settlement %>
 
 <br>

--- a/app/views/better_together/geography/states/edit.html.erb
+++ b/app/views/better_together/geography/states/edit.html.erb
@@ -1,5 +1,6 @@
 <h1>Editing state</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_state: @geography_state %>
 
 <br>

--- a/app/views/better_together/geography/states/new.html.erb
+++ b/app/views/better_together/geography/states/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New state</h1>
 
+<div id="form_errors"></div>
 <%= render "form", geography_state: @geography_state %>
 
 <br>

--- a/app/views/better_together/navigation_areas/edit.html.erb
+++ b/app/views/better_together/navigation_areas/edit.html.erb
@@ -2,6 +2,7 @@
 
 <div class="container">
   <h1><%= t('better_together.navigation_areas.edit.title') %></h1>
+  <div id="form_errors"></div>
   <%= render 'form', navigation_area: @navigation_area %>
   <%= link_to t('shared.links.back'), navigation_areas_path, class: 'btn btn-secondary' %>
 </div>

--- a/app/views/better_together/navigation_areas/new.html.erb
+++ b/app/views/better_together/navigation_areas/new.html.erb
@@ -2,6 +2,7 @@
 
 <div class="container">
   <h1><%= t('better_together.navigation_areas.new.title') %></h1>
+  <div id="form_errors"></div>
   <%= render 'form', navigation_area: @navigation_area %>
   <%= link_to t('shared.links.back'), navigation_areas_path, class: 'btn btn-secondary' %>
 </div>

--- a/app/views/better_together/pages/edit.html.erb
+++ b/app/views/better_together/pages/edit.html.erb
@@ -26,6 +26,7 @@
   <div class="row">
     <div class="col">
       <h1>Edit Page</h1>
+      <div id="form_errors"></div>
       <%= render 'form', page: @page %>
     </div>
   </div>

--- a/app/views/better_together/pages/new.html.erb
+++ b/app/views/better_together/pages/new.html.erb
@@ -7,6 +7,7 @@
   <div class="row">
     <div class="col">
       <h1>New Page</h1>
+      <div id="form_errors"></div>
       <%= render 'form', page: @page %>
     </div>
   </div>

--- a/app/views/better_together/people/edit.html.erb
+++ b/app/views/better_together/people/edit.html.erb
@@ -7,5 +7,6 @@
 <div class="container my-3">
   <h1>Edit Profile</h1>
 
+  <div id="form_errors"></div>
   <%= render 'form', person: @person %>
 </div>

--- a/app/views/better_together/people/new.html.erb
+++ b/app/views/better_together/people/new.html.erb
@@ -5,6 +5,7 @@
 <div class="container my-3">
   <h1 class="mb-4">New Person</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", person: @person %>
 
   <div class="mt-3">

--- a/app/views/better_together/person_platform_memberships/edit.html.erb
+++ b/app/views/better_together/person_platform_memberships/edit.html.erb
@@ -1,5 +1,6 @@
 <h1>Editing person platform membership</h1>
 
+<div id="form_errors"></div>
 <%= render "form", person_platform_membership: @person_platform_membership %>
 
 <br>

--- a/app/views/better_together/person_platform_memberships/new.html.erb
+++ b/app/views/better_together/person_platform_memberships/new.html.erb
@@ -1,5 +1,6 @@
 <h1>New person platform membership</h1>
 
+<div id="form_errors"></div>
 <%= render "form", person_platform_membership: @person_platform_membership %>
 
 <br>

--- a/app/views/better_together/platforms/edit.html.erb
+++ b/app/views/better_together/platforms/edit.html.erb
@@ -1,6 +1,7 @@
 <div class="container my-3">
   <h1 class="mb-4">Editing Platform</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", platform: @platform %>
 
   <div class="mt-3">

--- a/app/views/better_together/platforms/new.html.erb
+++ b/app/views/better_together/platforms/new.html.erb
@@ -1,6 +1,7 @@
 <div class="mx-auto md:w-2/3 w-full">
   <h1 class="font-bold text-4xl">New platform</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", platform: @platform %>
 
   <%= link_to t('globals.back_to_list'), platforms_path, class: "ml-2 rounded-lg py-3 px-5 bg-gray-100 inline-block font-medium" %>

--- a/app/views/better_together/resource_permissions/edit.html.erb
+++ b/app/views/better_together/resource_permissions/edit.html.erb
@@ -1,6 +1,7 @@
 <div class="container">
   <h1 class="mb-4">Editing Resource Permission</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", resource_permission: @resource_permission %>
 
   <div class="mt-3">

--- a/app/views/better_together/resource_permissions/new.html.erb
+++ b/app/views/better_together/resource_permissions/new.html.erb
@@ -1,6 +1,7 @@
 <div class="container my-3">
   <h1 class="mb-4">New Resource Permission</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", resource_permission: @resource_permission %>
 
   <div class="mt-3">

--- a/app/views/better_together/roles/edit.html.erb
+++ b/app/views/better_together/roles/edit.html.erb
@@ -1,6 +1,7 @@
 <div class="container my-3">
   <h1 class="mb-4">Editing Role</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", role: @role %>
 
   <div class="mt-3">

--- a/app/views/better_together/roles/new.html.erb
+++ b/app/views/better_together/roles/new.html.erb
@@ -1,6 +1,7 @@
 <div class="container my-3">
   <h1 class="mb-4">New Role</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", role: @role %>
 
   <div class="mt-3">

--- a/app/views/better_together/users/edit.html.erb
+++ b/app/views/better_together/users/edit.html.erb
@@ -1,6 +1,7 @@
 <div class="container my-3">
   <h1 class="mb-4">Editing User</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", user: @user %>
 
   <div class="mt-3">

--- a/app/views/better_together/users/new.html.erb
+++ b/app/views/better_together/users/new.html.erb
@@ -1,6 +1,7 @@
 <div class="container my-3">
   <h1 class="mb-4">New User</h1>
 
+  <div id="form_errors"></div>
   <%= render "form", user: @user %>
 
   <div class="mt-3">


### PR DESCRIPTION
## Summary
- return Turbo Stream validation errors across controllers
- provide placeholders in forms for error updates

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec brakeman -q -w2` *(fails: command not found)*
- `bundle exec bundler-audit --update` *(fails: command not found)*
- `bin/codex_style_guard` *(fails: command not found)*
- `bin/ci` *(fails: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689b64ccac4483218114fa7ee4d9d596