### PR TITLE
Detect Turbo Native clients for mobile layout tweaks

### DIFF
--- a/app/controllers/better_together/application_controller.rb
+++ b/app/controllers/better_together/application_controller.rb
@@ -9,6 +9,8 @@ module BetterTogether
 
     protect_from_forgery with: :exception
 
+    layout :determine_layout
+
     before_action :check_platform_setup
     before_action :set_locale
     before_action :store_user_location!, if: :storable_location?
@@ -28,7 +30,8 @@ module BetterTogether
     rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
     rescue_from StandardError, with: :handle_error
 
-    helper_method :current_invitation, :default_url_options, :valid_platform_invitation_token_present?
+    helper_method :current_invitation, :default_url_options, :valid_platform_invitation_token_present?,
+                  :turbo_native_app?
 
     def self.default_url_options
       super.merge(locale: I18n.locale)
@@ -253,6 +256,14 @@ module BetterTogether
 
     def metric_viewable_id
       metric_viewable&.id
+    end
+
+    def determine_layout
+      turbo_native_app? ? 'better_together/turbo_native' : 'better_together/application'
+    end
+
+    def turbo_native_app?
+      request.user_agent.to_s.include?('Turbo Native')
     end
   end
 end

--- a/app/views/layouts/better_together/turbo_native.html.erb
+++ b/app/views/layouts/better_together/turbo_native.html.erb
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="<%= I18n.locale %>">
+  <head>
+    <% if ENV["SENTRY_CLIENT_KEY"] %>
+      <script src="https://js-de.sentry-cdn.com/<%= ENV["SENTRY_CLIENT_KEY"] %>.min.js" crossorigin="anonymous"></script>
+    <% end %>
+
+    <!-- Custom Head Javascript from Host App -->
+    <%= render 'layouts/better_together/custom_head_javascript' %>
+
+    <title><%= (yield(:page_title) + ' | ') if content_for?(:page_title) %><%= host_platform.name %></title>
+    <%= open_graph_meta_tags %>
+    <%= seo_meta_tags %>
+    <meta name="color-scheme" content="light dark">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+
+    <!-- Default Stylesheets -->
+    <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.8/dist/trix.css">
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/slim-select/2.9.2/slimselect.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+     integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+     crossorigin=""/>
+    <%= stylesheet_link_tag 'better_together/application', media: 'all', 'data-turbo-track': 'reload' %>
+
+    <!-- Custom Stylesheets from Host App -->
+    <%= render 'layouts/better_together/custom_stylesheets' %>
+
+    <%= cache ['host_css_block', host_platform.cache_key_with_version] do %>
+      <%= render host_platform.css_block if host_platform.css_block %>
+    <% end %>
+
+    <!-- Embed I18n Translations -->
+    <script id="i18n-js" type="text/javascript">
+      window.I18n = {
+        locale: "<%= I18n.locale %>",
+        translations: <%= raw javascript_i18n[:translations].to_json %>,
+        t: function(key, options = {}) {
+          const keys = key.split('.');
+          let translation = this.translations;
+          for (let k of keys) {
+            if (translation[k] === undefined) {
+              return key; // Fallback to key if translation not found
+            }
+            translation = translation[k];
+          }
+          if (typeof translation === 'string') {
+            // Simple interpolation
+            return translation.replace(/\%\{(\w+)\}/g, (match, p1) => options[p1] || match);
+          }
+          return key;
+        }
+      };
+    </script>
+
+    <%= javascript_importmap_tags %>
+  </head>
+  <%= metrics_body_tag(body_class: content_for?(:body_class) ? yield(:body_class) : '') do %>
+    <div class="wrapper">
+      <!-- Custom Header from Host App -->
+      <%= content_for?(:custom_header) ? yield(:custom_header) : render('layouts/better_together/header') %>
+
+      <%= render 'layouts/better_together/flash_messages' %>
+
+      <!-- Main Section -->
+      <main class="content">
+        <%= yield %>
+      </main>
+
+      <%= render partial: 'layouts/better_together/extra_page_content_bottom' %>
+
+      <!-- Custom Footer from Host App -->
+      <%= content_for?(:custom_footer) ? yield(:custom_footer) : render('layouts/better_together/footer') %>
+
+      <!-- Custom Scripts from Host App -->
+      <%= render 'layouts/better_together/custom_body_javascript' %>
+    </div>
+  <% end %>
+</html>


### PR DESCRIPTION
## Summary
- add `turbo_native_app?` helper and expose to views
- switch to simplified layout when Turbo Native app detected
- provide native-specific layout without mobile bar

## Testing
- `DATABASE_URL=postgis://postgres:postgres@localhost BUNDLE_GEMFILE=$(pwd)/Gemfile.local bin/ci`
- `BUNDLE_GEMFILE=$(pwd)/Gemfile.local bundle exec rubocop`
- `BUNDLE_GEMFILE=$(pwd)/Gemfile.local bundle exec brakeman -q -w2`
- `BUNDLE_GEMFILE=$(pwd)/Gemfile.local bundle exec bundler-audit --update`
- `BUNDLE_GEMFILE=$(pwd)/Gemfile.local bin/codex_style_guard`


------
https://chatgpt.com/codex/tasks/task_e_689b64996ea083219245488e8965ab1b