### PR TITLE
Fix Joatu specs and resolve Rubocop warnings

### DIFF
--- a/app/controllers/better_together/joatu/agreements_controller.rb
+++ b/app/controllers/better_together/joatu/agreements_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 module BetterTogether
   module Joatu
@@ -9,7 +10,12 @@ module BetterTogether
       def create
         request = BetterTogether::Joatu::Request.find(params[:request_id])
         offer = BetterTogether::Joatu::Offer.find(params[:offer_id])
-        @agreement = BetterTogether::Joatu::Agreement.create!(request:, offer:, terms: params[:terms], value: params[:value])
+        @agreement = BetterTogether::Joatu::Agreement.create!(
+          request:,
+          offer:,
+          terms: params[:terms],
+          value: params[:value]
+        )
         redirect_to joatu_agreement_path(@agreement)
       end
 

--- a/app/controllers/better_together/joatu/requests_controller.rb
+++ b/app/controllers/better_together/joatu/requests_controller.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 module BetterTogether

--- a/app/mailers/better_together/joatu_mailer.rb
+++ b/app/mailers/better_together/joatu_mailer.rb
@@ -23,7 +23,7 @@ module BetterTogether
 
       mail(to: @recipient.email, subject: t('.subject'))
     end
- 
+
     def agreement_status_changed
       @platform = BetterTogether::Platform.find_by(host: true)
       @agreement = params[:agreement]

--- a/app/models/better_together/joatu/agreement.rb
+++ b/app/models/better_together/joatu/agreement.rb
@@ -23,7 +23,6 @@ module BetterTogether
 
       after_update_commit :notify_status_change, if: -> { saved_change_to_status? }
 
-
       def accept!
         transaction do
           update!(status: :accepted)

--- a/app/notifiers/better_together/joatu/agreement_notifier.rb
+++ b/app/notifiers/better_together/joatu/agreement_notifier.rb
@@ -5,7 +5,10 @@ module BetterTogether
     # Sends notifications when a new agreement is created
     class AgreementNotifier < ApplicationNotifier
       deliver_by :action_cable, channel: 'BetterTogether::NotificationsChannel', message: :build_message
-      deliver_by :email, mailer: 'BetterTogether::JoatuMailer', method: :agreement_created, params: :email_params do |config|
+      deliver_by :email,
+                 mailer: 'BetterTogether::JoatuMailer',
+                 method: :agreement_created,
+                 params: :email_params do |config|
         config.if = -> { recipient.email.present? && recipient.notification_preferences['notify_by_email'] }
       end
 

--- a/app/services/better_together/joatu/matchmaker.rb
+++ b/app/services/better_together/joatu/matchmaker.rb
@@ -17,8 +17,6 @@ module BetterTogether
 
         offers.where.not(creator_id: request.creator_id).distinct
       end
-      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
-      # rubocop:enable Layout/MultilineMethodCallIndentation
     end
   end
 end

--- a/db/migrate/20240918000000_add_target_to_joatu_requests_and_offers.rb
+++ b/db/migrate/20240918000000_add_target_to_joatu_requests_and_offers.rb
@@ -1,6 +1,6 @@
-# Adds polymorphic target references to Joatu requests and offers
 # frozen_string_literal: true
 
+# Adds polymorphic target references to Joatu requests and offers
 class AddTargetToJoatuRequestsAndOffers < ActiveRecord::Migration[7.1]
   def change
     change_table :better_together_joatu_requests, bulk: true do |t|

--- a/spec/mailers/better_together/joatu_mailer_spec.rb
+++ b/spec/mailers/better_together/joatu_mailer_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 module BetterTogether
   RSpec.describe JoatuMailer, type: :mailer do
     describe 'new_match' do
@@ -18,6 +19,7 @@ module BetterTogether
         expect(mail.subject).to eq('New Joatu match')
         expect(mail.to).to include(recipient_user.email)
       end
+    end
 
     describe 'agreement_created' do
       let!(:host_platform) { create(:platform, :host) }
@@ -59,3 +61,4 @@ module BetterTogether
     end
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/notifiers/better_together/joatu/agreement_status_notifier_spec.rb
+++ b/spec/notifiers/better_together/joatu/agreement_status_notifier_spec.rb
@@ -27,7 +27,7 @@ module BetterTogether
           end
 
           def _read_attribute(attr)
-            instance_variable_get('@' + attr.to_s)
+            instance_variable_get("@#{attr}")
           end
         end
       end

--- a/spec/requests/better_together/joatu/agreements_spec.rb
+++ b/spec/requests/better_together/joatu/agreements_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'BetterTogether::Joatu::Agreements', type: :request do
   routes { BetterTogether::Engine.routes }
 
@@ -15,7 +16,10 @@ RSpec.describe 'BetterTogether::Joatu::Agreements', type: :request do
 
   describe 'routing' do
     it 'routes to #index' do
-      expect(get: "/#{I18n.locale}/joatu/agreements").to route_to('better_together/joatu/agreements#index', locale: I18n.locale.to_s)
+      expect(get: "/#{I18n.locale}/joatu/agreements").to route_to(
+        'better_together/joatu/agreements#index',
+        locale: I18n.locale.to_s
+      )
     end
   end
 
@@ -43,8 +47,11 @@ RSpec.describe 'BetterTogether::Joatu::Agreements', type: :request do
 
   describe 'PATCH /update' do
     it 'updates the agreement' do
-      patch better_together.joatu_agreement_path(agreement, locale: I18n.locale), params: { agreement: { status: 'accepted' } }
-      expect(response).to redirect_to(better_together.joatu_agreement_path(agreement, locale: I18n.locale))
+      patch better_together.joatu_agreement_path(agreement, locale: I18n.locale),
+            params: { agreement: { status: 'accepted' } }
+      expect(response).to redirect_to(
+        better_together.joatu_agreement_path(agreement, locale: I18n.locale)
+      )
       expect(agreement.reload.status).to eq('accepted')
     end
   end
@@ -57,4 +64,5 @@ RSpec.describe 'BetterTogether::Joatu::Agreements', type: :request do
       end.to change(BetterTogether::Joatu::Agreement, :count).by(-1)
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/requests/better_together/joatu/matchmaking_spec.rb
+++ b/spec/requests/better_together/joatu/matchmaking_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'Joatu matchmaking', type: :request do
   let(:requestor) { create(:better_together_person) }
   let(:offeror) { create(:better_together_person) }
@@ -41,4 +42,5 @@ RSpec.describe 'Joatu matchmaking', type: :request do
       expect(agreement.reload.status_rejected?).to be true
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/requests/better_together/joatu/offers_spec.rb
+++ b/spec/requests/better_together/joatu/offers_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'BetterTogether::Joatu::Offers', type: :request do
   routes { BetterTogether::Engine.routes }
 
@@ -14,7 +15,10 @@ RSpec.describe 'BetterTogether::Joatu::Offers', type: :request do
 
   describe 'routing' do
     it 'routes to #index' do
-      expect(get: "/#{I18n.locale}/joatu/offers").to route_to('better_together/joatu/offers#index', locale: I18n.locale.to_s)
+      expect(get: "/#{I18n.locale}/joatu/offers").to route_to(
+        'better_together/joatu/offers#index',
+        locale: I18n.locale.to_s
+      )
     end
   end
 
@@ -42,8 +46,11 @@ RSpec.describe 'BetterTogether::Joatu::Offers', type: :request do
 
   describe 'PATCH /update' do
     it 'updates the offer' do
-      patch better_together.joatu_offer_path(offer, locale: I18n.locale), params: { offer: { status: 'closed' } }
-      expect(response).to redirect_to(better_together.joatu_offer_path(offer, locale: I18n.locale))
+      patch better_together.joatu_offer_path(offer, locale: I18n.locale),
+            params: { offer: { status: 'closed' } }
+      expect(response).to redirect_to(
+        better_together.joatu_offer_path(offer, locale: I18n.locale)
+      )
       expect(offer.reload.status).to eq('closed')
     end
   end
@@ -56,4 +63,5 @@ RSpec.describe 'BetterTogether::Joatu::Offers', type: :request do
       end.to change(BetterTogether::Joatu::Offer, :count).by(-1)
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/requests/better_together/joatu/requests_spec.rb
+++ b/spec/requests/better_together/joatu/requests_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 
+# rubocop:disable Metrics/BlockLength
 RSpec.describe 'BetterTogether::Joatu::Requests', type: :request do
   routes { BetterTogether::Engine.routes }
 
@@ -14,7 +15,10 @@ RSpec.describe 'BetterTogether::Joatu::Requests', type: :request do
 
   describe 'routing' do
     it 'routes to #index' do
-      expect(get: "/#{I18n.locale}/joatu/requests").to route_to('better_together/joatu/requests#index', locale: I18n.locale.to_s)
+      expect(get: "/#{I18n.locale}/joatu/requests").to route_to(
+        'better_together/joatu/requests#index',
+        locale: I18n.locale.to_s
+      )
     end
   end
 
@@ -42,8 +46,11 @@ RSpec.describe 'BetterTogether::Joatu::Requests', type: :request do
 
   describe 'PATCH /update' do
     it 'updates the request' do
-      patch better_together.joatu_request_path(request_record, locale: I18n.locale), params: { request: { status: 'closed' } }
-      expect(response).to redirect_to(better_together.joatu_request_path(request_record, locale: I18n.locale))
+      patch better_together.joatu_request_path(request_record, locale: I18n.locale),
+            params: { request: { status: 'closed' } }
+      expect(response).to redirect_to(
+        better_together.joatu_request_path(request_record, locale: I18n.locale)
+      )
       expect(request_record.reload.status).to eq('closed')
     end
   end
@@ -56,4 +63,5 @@ RSpec.describe 'BetterTogether::Joatu::Requests', type: :request do
       end.to change(BetterTogether::Joatu::Request, :count).by(-1)
     end
   end
+  # rubocop:enable Metrics/BlockLength
 end

--- a/spec/services/better_together/joatu/matchmaker_spec.rb
+++ b/spec/services/better_together/joatu/matchmaker_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 module BetterTogether
   module Joatu
+    # rubocop:disable Metrics/BlockLength
     RSpec.describe Matchmaker do
       it 'matches offers by category and excludes same creator' do
         requestor = create(:better_together_person)
@@ -32,17 +33,21 @@ module BetterTogether
         target = create(:better_together_platform_invitation)
         other_target = create(:better_together_platform_invitation)
 
-        matching_offer = create(:better_together_joatu_offer,
-                                creator: offeror,
-                                target: target)
+        matching_offer = create(
+          :better_together_joatu_offer,
+          creator: offeror,
+          target: target
+        )
         matching_offer.categories << category
 
         non_matching_offer = create(:better_together_joatu_offer, target: other_target)
         non_matching_offer.categories << category
 
-        request = create(:better_together_joatu_request,
-                          creator: requestor,
-                          target: target)
+        request = create(
+          :better_together_joatu_request,
+          creator: requestor,
+          target: target
+        )
         request.categories << category
 
         matches = described_class.match(request)
@@ -50,5 +55,6 @@ module BetterTogether
         expect(matches).to contain_exactly(matching_offer)
       end
     end
+    # rubocop:enable Metrics/BlockLength
   end
 end


### PR DESCRIPTION
## Summary
- tidy up Joatu controllers, models, and notifier to satisfy Rubocop
- clean up Joatu specs and add missing block terminators
- clarify migration documentation for target references

## Testing
- `bundle exec rubocop`
- `bin/ci` *(fails: There is an issue connecting with your hostname: community-engine-db)*

------
https://chatgpt.com/codex/tasks/task_e_689b60cbbbfc8321a41a22bb77655d38