### PR TITLE
Normalize PageView URLs and scrub sensitive query data

### DIFF
--- a/db/migrate/20250301000000_purge_query_strings_from_page_urls.rb
+++ b/db/migrate/20250301000000_purge_query_strings_from_page_urls.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Removes query strings from existing page_url entries
+class PurgeQueryStringsFromPageUrls < ActiveRecord::Migration[7.1]
+  class PageView < ApplicationRecord # rubocop:todo Style/Documentation
+    self.table_name = 'better_together_metrics_page_views'
+  end
+
+  def up
+    PageView.where("page_url LIKE '%?%'").find_each do |pv|
+      uri = URI.parse(pv.page_url)
+      PageView.where(id: pv.id).update_all(page_url: uri.path)
+    rescue URI::InvalidURIError
+      PageView.where(id: pv.id).update_all(page_url: nil)
+    end
+  end
+
+  def down
+    # irreversible
+  end
+end

--- a/spec/models/better_together/metrics/page_view_spec.rb
+++ b/spec/models/better_together/metrics/page_view_spec.rb
@@ -4,8 +4,29 @@ require 'rails_helper'
 
 module BetterTogether
   RSpec.describe Metrics::PageView, type: :model do
-    it 'exists' do
-      expect(described_class).to be
+    let(:viewed_at) { Time.zone.now }
+    let(:locale) { 'en' }
+
+    it 'normalizes page_url to exclude query strings' do
+      page_view = described_class.new(
+        page_url: 'https://example.com/path?foo=bar',
+        viewed_at: viewed_at,
+        locale: locale
+      )
+
+      expect(page_view).to be_valid
+      expect(page_view.page_url).to eq('/path')
+    end
+
+    it 'rejects URLs containing sensitive parameters' do
+      page_view = described_class.new(
+        page_url: 'https://example.com/path?token=abc',
+        viewed_at: viewed_at,
+        locale: locale
+      )
+
+      expect(page_view).not_to be_valid
+      expect(page_view.errors[:page_url]).to include('contains sensitive parameters')
     end
   end
 end


### PR DESCRIPTION
## Summary
- normalize `page_url` to drop query strings and reject sensitive parameters
- backfill existing `page_url` records to remove query components
- test PageView URL normalization and validation

## Testing
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bin/codex_style_guard`
- `DATABASE_URL=postgis://rails:password@localhost/community_engine_test bundle exec rspec` *(fails: 384 examples, 10 failures)*

------
https://chatgpt.com/codex/tasks/task_e_689b685aaa7083219fe0bcf03c4a17a5