### PR TITLE
Avoid modifying Rails 8 autoload paths in engine

### DIFF
--- a/lib/better_together/engine.rb
+++ b/lib/better_together/engine.rb
@@ -53,14 +53,16 @@ module BetterTogether
     end
 
     config.before_initialize do
-      require_dependency 'friendly_id'
-      require_dependency 'mobility'
-      require_dependency 'friendly_id/mobility'
-      require_dependency 'jsonapi-resources'
-      require_dependency 'importmap-rails'
-      require_dependency 'public_activity'
-      require_dependency 'pundit'
-      require_dependency 'rack/cors'
+      # Use `require` instead of `require_dependency` for external gems to avoid
+      # modifying Rails' frozen autoload paths (Rails 8 compatibility)
+      require 'friendly_id'
+      require 'mobility'
+      require 'friendly_id/mobility'
+      require 'jsonapi-resources'
+      require 'importmap-rails'
+      require 'public_activity'
+      require 'pundit'
+      require 'rack/cors'
     end
 
     default_url_options = {


### PR DESCRIPTION
## Summary
- replace `require_dependency` with plain `require` for external gems
- avoid Rails 8 FrozenError when loading engine

## Testing
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689b6ec3e1b88321a3410959ca87218a