### PR TITLE
Fix safe_html spec expectation

### DIFF
--- a/spec/helpers/better_together/content_helper_spec.rb
+++ b/spec/helpers/better_together/content_helper_spec.rb
@@ -13,10 +13,10 @@ module BetterTogether
       end
 
       it 'allows permitted markup' do
-        input = "<p><strong>Bold</strong> and <a href=\"https://example.com\">link</a></p>"
+        input = '<p><strong>Bold</strong> and <a href="https://example.com">link</a></p>'
         output = helper.safe_html(input)
         expect(output).to include('<strong>Bold</strong>')
-        expect(output).to include('<a href=\"https://example.com\">link</a>')
+        expect(output).to include('<a href="https://example.com">link</a>')
       end
 
       it 'allows youtube iframes' do


### PR DESCRIPTION
## Summary
- Correct ContentHelper spec to expect unescaped anchor tag attributes in safe_html

## Testing
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689b7397cf9083219a36487ec4f9b6dd