### PR TITLE
Remove routes override from Joatu request specs

### DIFF
--- a/spec/requests/better_together/joatu/agreements_spec.rb
+++ b/spec/requests/better_together/joatu/agreements_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe 'BetterTogether::Joatu::Agreements', type: :request do
-  routes { BetterTogether::Engine.routes }
 
   let(:user) { create(:user, :confirmed) }
   let(:offer) { create(:joatu_offer) }

--- a/spec/requests/better_together/joatu/offers_spec.rb
+++ b/spec/requests/better_together/joatu/offers_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe 'BetterTogether::Joatu::Offers', type: :request do
-  routes { BetterTogether::Engine.routes }
 
   let(:user) { create(:user, :confirmed) }
   let(:person) { user.person }

--- a/spec/requests/better_together/joatu/requests_spec.rb
+++ b/spec/requests/better_together/joatu/requests_spec.rb
@@ -4,7 +4,6 @@ require 'rails_helper'
 
 # rubocop:disable Metrics/BlockLength
 RSpec.describe 'BetterTogether::Joatu::Requests', type: :request do
-  routes { BetterTogether::Engine.routes }
 
   let(:user) { create(:user, :confirmed) }
   let(:person) { user.person }


### PR DESCRIPTION
## Summary
- avoid calling `routes` in Joatu request specs to prevent undefined method errors

## Testing
- `bin/ci` *(fails: ActiveRecord::ConnectionNotEstablished: connection to server at "::1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b7774e1348321bb43e991e3fa2c5f