### PR TITLE
chore: adjust autoload path for Rails 8

### DIFF
--- a/lib/better_together/engine.rb
+++ b/lib/better_together/engine.rb
@@ -44,7 +44,7 @@ module BetterTogether
     isolate_namespace BetterTogether
 
     # Avoid modifying frozen autoload path arrays (Rails 8 compatibility)
-    config.autoload_paths = Array(config.autoload_paths) + Dir["#{root}/lib/better_together/**/"]
+    paths.add 'lib', eager_load: true
 
     config.generators do |g|
       g.orm :active_record, primary_key_type: :uuid


### PR DESCRIPTION
## Summary
- avoid modifying frozen autoload paths by registering engine lib via `paths.add`

## Testing
- `bin/ci` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0 in locally installed gems)*
- `bundle exec rubocop` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0 in locally installed gems)*
- `bundle exec brakeman -q -w2` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0 in locally installed gems)*
- `bundle exec bundler-audit --update` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0 in locally installed gems)*
- `bin/codex_style_guard` *(fails: Could not find font-awesome-sass-6.7.2, sassc-2.4.0 in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_689b742c7474832197c577e8473f6bf1