### PR TITLE
Add meta descriptions and helper for standard pages

### DIFF
--- a/app/helpers/better_together/application_helper.rb
+++ b/app/helpers/better_together/application_helper.rb
@@ -80,6 +80,17 @@ module BetterTogether
       rails_storage_proxy_url(attachment)
     end
 
+    # Sets a translated meta description for the current view. Provide the
+    # translation scope without the `meta.descriptions` prefix.
+    #
+    #   set_meta_description('communities.show', community_name: @resource.name)
+    #
+    # @param scope [String] translation scope under meta.descriptions
+    # @param options [Hash] interpolation values for the translation
+    def set_meta_description(scope, **options)
+      content_for(:meta_description, t("meta.descriptions.#{scope}", **options))
+    end
+
     # Builds SEO-friendly meta tags for the current view. Defaults are derived
     # from translations and fall back to the Open Graph description when set.
     # rubocop:todo Metrics/MethodLength

--- a/app/views/better_together/communities/index.html.erb
+++ b/app/views/better_together/communities/index.html.erb
@@ -2,6 +2,8 @@
   <%= resource_class.model_name.human.pluralize %>
 <% end %>
 
+<% set_meta_description('communities.index', platform_name: host_platform.name) %>
+
 <div class="container my-3">
   <div class="d-flex justify-content-between align-items-center">
     <h1><%= resource_class.model_name.human.pluralize %></h1>

--- a/app/views/better_together/communities/show.html.erb
+++ b/app/views/better_together/communities/show.html.erb
@@ -2,6 +2,8 @@
   <%= @resource.name %> | <%= resource_class.model_name.human.pluralize %>
 <% end %>
 
+<% set_meta_description('communities.show', community_name: @resource.name, platform_name: host_platform.name) %>
+
 <div class="container-fluid mb-3 px-0">
 
   <div class="profile-header position-relative">

--- a/app/views/better_together/conversations/index.html.erb
+++ b/app/views/better_together/conversations/index.html.erb
@@ -2,6 +2,8 @@
   <%= BetterTogether::Conversation.model_name.human.pluralize %>
 <% end %>
 
+<% set_meta_description('conversations.index', platform_name: host_platform.name) %>
+
 <div id="conversations_index">
   <div class="p-2 bg-secondary rounded-0 text-white d-flex flex-row justify-content-between align-items-center">
     <h5 class="mb-0">

--- a/app/views/better_together/conversations/show.html.erb
+++ b/app/views/better_together/conversations/show.html.erb
@@ -4,6 +4,8 @@
   <%= "#{@conversation} | " if @conversation.to_s.present? %><%= @conversation.class.model_name.human.pluralize %>
 <% end %>
 
+<% set_meta_description('conversations.show', conversation_subject: @conversation.to_s, platform_name: host_platform.name) %>
+
 <%= render 'communicator' do %>
   <%= render partial: 'better_together/conversations/conversation_content', locals: { conversation: @conversation, messages: @messages, message: @message } %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1486,6 +1486,13 @@ en:
     default_description: "Welcome to %{platform_name}"
     page:
       description_fallback: "Read %{title} on %{platform_name}"
+    descriptions:
+      communities:
+        index: "Discover communities on %{platform_name}."
+        show: "Learn about %{community_name} on %{platform_name}."
+      conversations:
+        index: "Browse conversations on %{platform_name}."
+        show: "View conversation %{conversation_subject} on %{platform_name}."
   time:
     am: am
     formats:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1478,6 +1478,13 @@ es:
     default_description: "Bienvenido a %{platform_name}"
     page:
       description_fallback: "Lee %{title} en %{platform_name}"
+    descriptions:
+      communities:
+        index: "Descubre comunidades en %{platform_name}."
+        show: "Conoce %{community_name} en %{platform_name}."
+      conversations:
+        index: "Explora tus conversaciones en %{platform_name}."
+        show: "Ver conversación %{conversation_subject} en %{platform_name}."
   errors:
     not_found:
       title: "404 - Página no encontrada"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1500,6 +1500,13 @@ fr:
     default_description: "Bienvenue sur %{platform_name}"
     page:
       description_fallback: "Lire %{title} sur %{platform_name}"
+    descriptions:
+      communities:
+        index: "Découvrir les communautés sur %{platform_name}."
+        show: "En savoir plus sur %{community_name} sur %{platform_name}."
+      conversations:
+        index: "Parcourez vos conversations sur %{platform_name}."
+        show: "Voir la conversation %{conversation_subject} sur %{platform_name}."
   errors:
     not_found:
       title: "404 - Page non trouvée"

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,0 +1,18 @@
+# SEO
+
+## Meta Descriptions
+
+- Each high-traffic page should set a concise, unique `content_for :meta_description`.
+- Use the `set_meta_description` helper with translation keys under `meta.descriptions`.
+- Keep descriptions under 160 characters and include relevant keywords.
+- Example:
+
+```erb
+<% set_meta_description('communities.show', community_name: @community.name, platform_name: host_platform.name) %>
+```
+
+## Best Practices
+
+- Translate descriptions using `config/locales/*` to support internationalization.
+- Prefer dynamic values (e.g., community or conversation names) to ensure uniqueness.
+- Review descriptions regularly to avoid duplication and improve click-through rates.


### PR DESCRIPTION
## Summary
- add `set_meta_description` helper and meta description translations
- include meta descriptions for communities and conversations views
- document meta description usage in `docs/seo.md`

## Testing
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bin/ci` *(fails: command not found: rails)*
- `bundle exec brakeman -q -w2` *(fails: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689b7bc807f08321991c8c007f45eadc