### PR TITLE
Use Time.current in event scopes

### DIFF
--- a/app/models/better_together/event.rb
+++ b/app/models/better_together/event.rb
@@ -36,12 +36,12 @@ module BetterTogether
     }
 
     scope :upcoming, lambda {
-      start_query = arel_table[:starts_at].gteq(DateTime.now)
+      start_query = arel_table[:starts_at].gteq(Time.current)
       where(start_query)
     }
 
     scope :past, lambda {
-      start_query = arel_table[:starts_at].lt(DateTime.now)
+      start_query = arel_table[:starts_at].lt(Time.current)
       where(start_query)
     }
 


### PR DESCRIPTION
## Summary
- use `Time.current` for comparing event times

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c1631288321a53271dcc47dac9a