### PR TITLE
Add canonical URL and hreflang overrides to SEO helpers

### DIFF
--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,0 +1,27 @@
+# SEO
+
+The engine exposes helpers that output common search engine optimisation tags.
+
+## Canonical URL
+
+`seo_meta_tags` includes a canonical `<link>` tag pointing to the current request
+URL. You can override the URL by setting a `content_for` block:
+
+```erb
+<% content_for :canonical_url, article_url(@article, locale: :en) %>
+```
+
+## Hreflang links
+
+Alternate language links are generated for each available locale. Additional
+links can be appended using `content_for :hreflang_links` and are merged with the
+default set:
+
+```erb
+<% content_for :hreflang_links do %>
+  <%= tag.link rel: 'alternate', hreflang: 'x-default', href: root_url %>
+<% end %>
+```
+
+Links supplied via `content_for` are merged with the automatically generated
+links rather than replacing them.

--- a/spec/helpers/better_together/application_helper_spec.rb
+++ b/spec/helpers/better_together/application_helper_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module BetterTogether
+  RSpec.describe ApplicationHelper, type: :helper do
+    before do
+      allow(helper).to receive(:host_platform).and_return(double(name: 'Test Platform', cache_key_with_version: 'test-platform'))
+      allow(helper).to receive(:host_community_logo_url).and_return(nil)
+      allow(controller.request).to receive(:original_url).and_return('http://test.host/en/current')
+      allow(I18n).to receive(:available_locales).and_return(%i[en fr])
+      allow(helper).to receive(:url_for) do |opts|
+        "http://test.host/#{opts[:locale]}/current"
+      end
+    end
+
+    describe '#seo_meta_tags' do
+      it 'includes default canonical and hreflang links' do
+        html = helper.seo_meta_tags
+        expect(html).to include('<link rel="canonical" href="http://test.host/en/current"')
+        expect(html).to include('<link rel="alternate" hreflang="fr" href="http://test.host/fr/current"')
+      end
+
+      it 'merges content_for overrides' do
+        helper.content_for(:canonical_url, 'http://example.com/custom')
+        helper.content_for(:hreflang_links, tag.link(rel: 'alternate', hreflang: 'es', href: 'http://test.host/es/current'))
+
+        html = helper.seo_meta_tags
+        expect(html).to include('<link rel="canonical" href="http://example.com/custom"')
+        expect(html).to include('<link rel="alternate" hreflang="fr" href="http://test.host/fr/current"')
+        expect(html).to include('<link rel="alternate" hreflang="es" href="http://test.host/es/current"')
+      end
+    end
+
+    describe '#open_graph_meta_tags' do
+      it 'defaults og:url to canonical_url' do
+        allow(helper).to receive(:canonical_url).and_return('http://test.host/en/current')
+        html = helper.open_graph_meta_tags
+        expect(html).to include('<meta property="og:url" content="http://test.host/en/current"')
+      end
+
+      it 'allows og_url override' do
+        helper.content_for(:og_url, 'http://example.com/og')
+        allow(helper).to receive(:canonical_url).and_return('http://test.host/en/current')
+        html = helper.open_graph_meta_tags
+        expect(html).to include('<meta property="og:url" content="http://example.com/og"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Allow canonical URL override via `content_for(:canonical_url)`
- Merge `content_for(:hreflang_links)` with default locale alternates
- Document canonical and hreflang helpers

## Testing
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec brakeman -q -w2` *(fails: command not found)*
- `bundle exec bundler-audit --update` *(fails: command not found)*
- `bin/codex_style_guard` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b9fe1408321ad23c69db47aedcf