### PR TITLE
Add canonical link tag helper

### DIFF
--- a/app/helpers/better_together/application_helper.rb
+++ b/app/helpers/better_together/application_helper.rb
@@ -138,6 +138,25 @@ module BetterTogether
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
+    # Generates a canonical link tag for the current request.
+    # Defaults to request.original_url but can be overridden by setting
+    # `content_for(:canonical_url)` in views. When provided a relative path,
+    # the host and locale are ensured by prefixing with `base_url_with_locale`.
+    def canonical_link_tag
+      canonical_url = if content_for?(:canonical_url)
+                        content_for(:canonical_url)
+                      else
+                        request.original_url
+                      end
+
+      unless canonical_url.starts_with?('http://', 'https://')
+        path = canonical_url.sub(%r{^/#{I18n.locale}}, '')
+        canonical_url = "#{base_url_with_locale}#{path}"
+      end
+
+      tag.link(rel: 'canonical', href: canonical_url)
+    end
+
     # Retrieves the setup wizard for hosts or raises an error if not found.
     # This is crucial for initial setup processes and should be pre-configured.
     def host_setup_wizard

--- a/app/views/layouts/better_together/application.html.erb
+++ b/app/views/layouts/better_together/application.html.erb
@@ -11,6 +11,7 @@
     <title><%= (yield(:page_title) + ' | ') if content_for?(:page_title) %><%= host_platform.name %></title>
     <%= open_graph_meta_tags %>
     <%= seo_meta_tags %>
+    <%= canonical_link_tag %>
     <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/better_together/turbo_native.html.erb
+++ b/app/views/layouts/better_together/turbo_native.html.erb
@@ -11,6 +11,7 @@
     <title><%= (yield(:page_title) + ' | ') if content_for?(:page_title) %><%= host_platform.name %></title>
     <%= open_graph_meta_tags %>
     <%= seo_meta_tags %>
+    <%= canonical_link_tag %>
     <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= csrf_meta_tags %>

--- a/spec/helpers/better_together/application_helper_spec.rb
+++ b/spec/helpers/better_together/application_helper_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module BetterTogether
+  RSpec.describe ApplicationHelper, type: :helper do
+    describe '#canonical_link_tag' do
+      before do
+        allow(helper).to receive(:base_url_with_locale).and_return('https://example.com/en')
+      end
+
+      context 'when no canonical_url is provided' do
+        it 'defaults to request.original_url' do
+          allow(helper.request).to receive(:original_url).and_return('https://example.com/en/posts')
+          result = helper.canonical_link_tag
+          expect(result).to include('href="https://example.com/en/posts"')
+        end
+      end
+
+      context 'when canonical_url is a relative path with locale' do
+        it 'prefixes base_url_with_locale and removes duplicate locale' do
+          helper.content_for(:canonical_url, '/en/custom')
+          result = helper.canonical_link_tag
+          expect(result).to include('href="https://example.com/en/custom"')
+        end
+      end
+
+      context 'when canonical_url is a full URL' do
+        it 'uses the provided URL' do
+          helper.content_for(:canonical_url, 'https://external.test/path')
+          result = helper.canonical_link_tag
+          expect(result).to include('href="https://external.test/path"')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `canonical_link_tag` helper with optional override and proper host/locale
- render canonical links in BetterTogether layouts
- test canonical link behavior

## Testing
- `bundle exec rubocop` *(fails: command not found: rubocop)*
- `bin/ci` *(fails: command not found: rails)*
- `bundle exec brakeman -q -w2` *(fails: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b8a7b708321b7558711a31e5499