### PR TITLE
Add hreflang alternate links for locales

### DIFF
--- a/app/helpers/better_together/application_helper.rb
+++ b/app/helpers/better_together/application_helper.rb
@@ -138,6 +138,17 @@ module BetterTogether
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/PerceivedComplexity
 
+    # Generates `<link rel="alternate" hreflang="..." href="...">` tags for
+    # each locale supported by the application. These tags help search engines
+    # understand language-specific versions of a page.
+    def hreflang_links
+      tags = I18n.available_locales.map do |locale|
+        tag.link(rel: 'alternate', hreflang: locale, href: url_for(locale:, only_path: false))
+      end
+
+      safe_join(tags, "\n")
+    end
+
     # Retrieves the setup wizard for hosts or raises an error if not found.
     # This is crucial for initial setup processes and should be pre-configured.
     def host_setup_wizard

--- a/app/views/layouts/better_together/application.html.erb
+++ b/app/views/layouts/better_together/application.html.erb
@@ -15,6 +15,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <%= tag.link rel: 'canonical', href: url_for(only_path: false) %>
+    <%= content_for?(:hreflang_links) ? yield(:hreflang_links) : hreflang_links %>
 
     <!-- Default Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.8/dist/trix.css">

--- a/app/views/layouts/better_together/turbo_native.html.erb
+++ b/app/views/layouts/better_together/turbo_native.html.erb
@@ -13,8 +13,10 @@
     <%= seo_meta_tags %>
     <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
+   <%= csrf_meta_tags %>
+   <%= csp_meta_tag %>
+    <%= tag.link rel: 'canonical', href: url_for(only_path: false) %>
+    <%= content_for?(:hreflang_links) ? yield(:hreflang_links) : hreflang_links %>
 
     <!-- Default Stylesheets -->
     <link rel="stylesheet" type="text/css" href="https://unpkg.com/trix@2.0.8/dist/trix.css">


### PR DESCRIPTION
## Summary
- add helper to build hreflang alternate link tags for all locales
- render canonical and hreflang link tags in BetterTogether layouts with content_for override

## Testing
- `bundle exec bundler-audit --update`
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bin/codex_style_guard`
- `DATABASE_URL=postgis://postgres:postgres@localhost bin/ci`

------
https://chatgpt.com/codex/tasks/task_e_689b7b92a9948321b2c0d1109c758749