### PR TITLE
Add robots meta tag helper and flag private pages as noindex

### DIFF
--- a/app/controllers/better_together/application_controller.rb
+++ b/app/controllers/better_together/application_controller.rb
@@ -129,6 +129,10 @@ module BetterTogether
 
     private
 
+    def disallow_robots
+      view_context.content_for(:meta_robots, 'noindex,nofollow')
+    end
+
     def render_not_found
       render 'errors/404', status: :not_found
     end

--- a/app/controllers/better_together/content/blocks_controller.rb
+++ b/app/controllers/better_together/content/blocks_controller.rb
@@ -5,6 +5,7 @@ module BetterTogether
     # CRUD for content blocks independently of pages
     class BlocksController < ResourceController
       before_action :authenticate_user!
+      before_action :disallow_robots
       before_action :set_block, only: %i[show edit update destroy]
       before_action only: %i[index], if: -> { Rails.env.development? } do
         # Make sure that all BLock subclasses are loaded in dev to generate new block buttons

--- a/app/controllers/better_together/content/page_blocks_controller.rb
+++ b/app/controllers/better_together/content/page_blocks_controller.rb
@@ -5,6 +5,7 @@ module BetterTogether
     # CRUD for page blocks
     class PageBlocksController < ApplicationController
       before_action :authenticate_user!
+      before_action :disallow_robots
       before_action :set_page
 
       def new

--- a/app/controllers/better_together/conversations_controller.rb
+++ b/app/controllers/better_together/conversations_controller.rb
@@ -4,6 +4,7 @@ module BetterTogether
   # Handles managing conversations
   class ConversationsController < ApplicationController
     before_action :authenticate_user!
+    before_action :disallow_robots
     before_action :set_conversations, only: %i[index new show]
     before_action :set_conversation, only: %i[show]
 

--- a/app/controllers/better_together/messages_controller.rb
+++ b/app/controllers/better_together/messages_controller.rb
@@ -4,6 +4,7 @@ module BetterTogether
   # handles managing messages
   class MessagesController < ApplicationController
     before_action :authenticate_user!
+    before_action :disallow_robots
     before_action :set_conversation
 
     def create

--- a/app/controllers/better_together/notifications_controller.rb
+++ b/app/controllers/better_together/notifications_controller.rb
@@ -4,6 +4,7 @@ module BetterTogether
   # handles rendering and marking notifications as read
   class NotificationsController < ApplicationController
     before_action :authenticate_user!
+    before_action :disallow_robots
 
     def index
       @notifications = helpers.current_person.notifications.includes(:event).order(created_at: :desc)

--- a/app/helpers/better_together/application_helper.rb
+++ b/app/helpers/better_together/application_helper.rb
@@ -102,6 +102,11 @@ module BetterTogether
     end
     # rubocop:enable Metrics/MethodLength
 
+    def robots_meta_tag(content = 'index,follow')
+      meta_content = content_for?(:meta_robots) ? content_for(:meta_robots) : content
+      tag.meta(name: 'robots', content: meta_content)
+    end
+
     # Builds Open Graph meta tags for the current view using content blocks when
     # provided. Falls back to localized defaults and the host community logo.
     # rubocop:todo Metrics/PerceivedComplexity

--- a/app/views/layouts/better_together/application.html.erb
+++ b/app/views/layouts/better_together/application.html.erb
@@ -11,6 +11,7 @@
     <title><%= (yield(:page_title) + ' | ') if content_for?(:page_title) %><%= host_platform.name %></title>
     <%= open_graph_meta_tags %>
     <%= seo_meta_tags %>
+    <%= robots_meta_tag %>
     <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= csrf_meta_tags %>

--- a/app/views/layouts/better_together/turbo_native.html.erb
+++ b/app/views/layouts/better_together/turbo_native.html.erb
@@ -11,6 +11,7 @@
     <title><%= (yield(:page_title) + ' | ') if content_for?(:page_title) %><%= host_platform.name %></title>
     <%= open_graph_meta_tags %>
     <%= seo_meta_tags %>
+    <%= robots_meta_tag %>
     <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <%= csrf_meta_tags %>

--- a/spec/helpers/better_together/application_helper_spec.rb
+++ b/spec/helpers/better_together/application_helper_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module BetterTogether
+  RSpec.describe ApplicationHelper, type: :helper do
+    describe '#robots_meta_tag' do
+      it 'renders default robots meta tag' do
+        tag = helper.robots_meta_tag
+        expect(tag).to include('name="robots"')
+        expect(tag).to include('content="index,follow"')
+      end
+
+      it 'allows override via content_for' do
+        view.content_for(:meta_robots, 'noindex,nofollow')
+        tag = helper.robots_meta_tag
+        expect(tag).to include('content="noindex,nofollow"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add `robots_meta_tag` helper with `content_for` override
- include robots meta tag in standard layouts
- mark auth-only controllers as noindex via new helper and tests

## Testing
- `bundle exec rubocop`
- `bundle exec brakeman -q -w2`
- `bundle exec bundler-audit --update`
- `bin/codex_style_guard`
- `bin/ci`
- `DATABASE_URL=postgis://postgres:postgres@localhost/community_engine_test bundle exec rspec spec/helpers/better_together/application_helper_spec.rb`


------
https://chatgpt.com/codex/tasks/task_e_689b7bb862c8832193bc115a7923001c