### PR TITLE
Validate BetterTogether event times

### DIFF
--- a/app/models/better_together/event.rb
+++ b/app/models/better_together/event.rb
@@ -27,8 +27,10 @@ module BetterTogether
     translates :description, backend: :action_text
 
     validates :name, presence: true
+    validates :starts_at, presence: true
     validates :registration_url, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]) }, allow_blank: true,
                                  allow_nil: true
+    validate :ends_at_after_starts_at
 
     scope :draft, lambda {
       start_query = arel_table[:starts_at].eq(nil)
@@ -74,5 +76,14 @@ module BetterTogether
     end
 
     configure_attachment_cleanup
+
+    private
+
+    def ends_at_after_starts_at
+      return if ends_at.blank? || starts_at.blank?
+      return if ends_at > starts_at
+
+      errors.add(:ends_at, I18n.t('errors.models.ends_at_before_starts_at'))
+    end
   end
 end

--- a/app/views/better_together/events/_form.html.erb
+++ b/app/views/better_together/events/_form.html.erb
@@ -100,7 +100,7 @@
           <div class="row">
             <!-- Start Datetime Field -->
             <div class="col-6 mb-3 pb-3 border-bottom">
-              <%= form.label :starts_at, t('better_together.events.labels.starts_at') %>
+              <%= required_label form, :starts_at, class: 'form-label' %>
               <%= form.datetime_field :starts_at, include_seconds: false, class: 'form-control' %>
               <% if event.errors[:starts_at].any? %>
                 <div class="invalid-feedback">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1516,6 +1516,7 @@ en:
       protected_destroy: "This record is protected and cannot be destroyed."
       address_missing_type: "Address must be either physical, postal, or both."
       host_single: "can only be set for one record"
+      ends_at_before_starts_at: "must be after the start time"
     person_block:
       cannot_block_self: "cannot block yourself"
       cannot_block_manager: "cannot be a platform manager"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1515,6 +1515,7 @@ es:
       protected_destroy: "Este registro está protegido y no se puede eliminar."
       address_missing_type: "La dirección debe ser física, postal o ambas."
       host_single: "solo se puede establecer para un registro"
+      ends_at_before_starts_at: "debe ser después de la hora de inicio"
     person_block:
       cannot_block_self: "no puedes bloquearte a ti mismo"
       cannot_block_manager: "no puede ser un administrador de la plataforma"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1537,6 +1537,7 @@ fr:
       protected_destroy: "Cet enregistrement est protégé et ne peut pas être supprimé."
       address_missing_type: "L'adresse doit être physique, postale ou les deux."
       host_single: "ne peut être défini que pour un seul enregistrement"
+      ends_at_before_starts_at: "doit être après l'heure de début"
     person_block:
       cannot_block_self: "ne peut pas vous bloquer vous-même"
       cannot_block_manager: "ne peut pas être un gestionnaire de plateforme"

--- a/spec/models/better_together/event_spec.rb
+++ b/spec/models/better_together/event_spec.rb
@@ -4,8 +4,27 @@ require 'rails_helper'
 
 module BetterTogether
   RSpec.describe Event, type: :model do
+    subject(:event) { described_class.new(name: 'Event', starts_at: Time.current) }
+
     it 'exists' do
       expect(described_class).to be
+    end
+
+    it 'requires starts_at' do
+      event.starts_at = nil
+      expect(event).not_to be_valid
+      expect(event.errors[:starts_at]).to include("can't be blank")
+    end
+
+    it 'requires ends_at to be after starts_at' do
+      event.ends_at = event.starts_at - 1.hour
+      expect(event).not_to be_valid
+      expect(event.errors[:ends_at]).to include(I18n.t('errors.models.ends_at_before_starts_at'))
+    end
+
+    it 'is valid when ends_at is after starts_at' do
+      event.ends_at = event.starts_at + 1.hour
+      expect(event).to be_valid
     end
   end
 end


### PR DESCRIPTION
## Summary
- require event start time and ensure end time follows
- mark start time required in event form
- translate end-before-start validation message

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec brakeman -q -w2` *(fails: command not found)*
- `bundle exec bundler-audit --update` *(fails: command not found)*
- `bin/codex_style_guard` *(fails: command not found)*
- `bin/ci` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c1e48fc8321b2cd711f590678b1