### PR TITLE
ci: add coverage badge generation

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -89,12 +89,12 @@ jobs:
           bundle exec rspec
         continue-on-error: ${{ matrix.allowed_failure }}
 
-      - name: Create coverage badge
+      - name: Generate coverage badge
         if: ${{ github.ref == 'refs/heads/main' && success() }}
-        uses: tj-actions/coverage-badge@v2
-        with:
-          input-file: coverage/.resultset.json
-          output-file: coverage.svg
+        run: |
+          COVERAGE=$(jq -r '.result.covered_percent' coverage/.last_run.json)
+          COLOR=$(node -e "cov=parseFloat(process.argv[1]);console.log(cov>=90?'green':cov>=75?'orange':'red')" $COVERAGE)
+          npx badgen-cli coverage ${COVERAGE}% -c $COLOR > coverage.svg
 
       - name: Commit badge
         if: ${{ github.ref == 'refs/heads/main' && success() }}

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -89,6 +89,20 @@ jobs:
           bundle exec rspec
         continue-on-error: ${{ matrix.allowed_failure }}
 
+      - name: Create coverage badge
+        if: ${{ github.ref == 'refs/heads/main' && success() }}
+        uses: tj-actions/coverage-badge@v2
+        with:
+          input-file: coverage/.resultset.json
+          output-file: coverage.svg
+
+      - name: Commit badge
+        if: ${{ github.ref == 'refs/heads/main' && success() }}
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update coverage badge"
+          file_pattern: coverage.svg
+
   # ── style & security jobs (unchanged) ───────────────────────────────────────
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add coverage badge generation and auto-commit to rspec workflow

## Testing
- `bin/ci` *(fails: bundler not installed; Ruby 3.4.4 not available)*
- `bundle exec rubocop` *(fails: bundler not installed)*
- `bundle exec brakeman -q -w2` *(fails: bundler not installed)*
- `bundle exec bundler-audit --update` *(fails: bundler not installed)*
- `bin/codex_style_guard` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689b82b7a4708321abfc22c697909343