### PR TITLE
Preload event associations and add pagination

### DIFF
--- a/app/controllers/better_together/events_controller.rb
+++ b/app/controllers/better_together/events_controller.rb
@@ -9,9 +9,15 @@ module BetterTogether
     end
 
     def index
+      @events = @events
+                  .includes(:categories, cover_image_attachment: :blob)
+
       @draft_events = @events.draft
+                               .page(params[:draft_page]).per(params[:per])
       @upcoming_events = @events.upcoming
+                                 .page(params[:upcoming_page]).per(params[:per])
       @past_events = @events.past
+                              .page(params[:past_page]).per(params[:per])
     end
 
     protected

--- a/app/views/better_together/events/index.html.erb
+++ b/app/views/better_together/events/index.html.erb
@@ -15,6 +15,7 @@
     <div class="row">
       <%= render(@draft_events) || render('none') %>
     </div>
+    <%= paginate @draft_events %>
   <% end %>
 
   <% if @upcoming_events.any? || @past_events.any? %>
@@ -22,12 +23,14 @@
     <div class="row">
       <%= render(@upcoming_events) || render('none') %>
     </div>
+    <%= paginate @upcoming_events %>
 
     <% if @past_events.any? %>
       <h2>Past</h2>
       <div class="row">
         <%= render(@past_events) %>
       </div>
+      <%= paginate @past_events %>
     <% end %>
   <% else %>
     <div class="row">

--- a/spec/features/events/index_spec.rb
+++ b/spec/features/events/index_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'events index', type: :feature do
+  include BetterTogether::DeviseSessionHelpers
+
+  before do
+    configure_host_platform
+    login_as_platform_manager
+  end
+
+  let!(:draft_event) { BetterTogether::Event.create!(name: 'Draft Event') }
+  let!(:upcoming_event) { BetterTogether::Event.create!(name: 'Upcoming Event', starts_at: 1.day.from_now) }
+  let!(:past_event) { BetterTogether::Event.create!(name: 'Past Event', starts_at: 2.days.ago) }
+
+  scenario 'displays events grouped by status' do
+    visit events_path(locale: I18n.default_locale)
+
+    draft_section = find('h2', text: 'Draft').sibling('div')
+    within(draft_section) do
+      expect(page).to have_content(draft_event.name)
+    end
+
+    upcoming_section = find('h2', text: 'Upcoming').sibling('div')
+    within(upcoming_section) do
+      expect(page).to have_content(upcoming_event.name)
+    end
+
+    past_section = find('h2', text: 'Past').sibling('div')
+    within(past_section) do
+      expect(page).to have_content(past_event.name)
+    end
+  end
+end

--- a/spec/requests/better_together/events_spec.rb
+++ b/spec/requests/better_together/events_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Events', type: :request do
+  include BetterTogether::Engine.routes.url_helpers
+  include RequestSpecHelper
+
+  let(:locale) { I18n.default_locale }
+
+  describe 'GET /events' do
+    let!(:event) { BetterTogether::Event.create!(name: 'Sample Event') }
+
+    it 'returns http success' do
+      get events_path(locale: locale)
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe 'POST /events' do
+    let(:user) { create(:better_together_user, :confirmed, :platform_manager) }
+
+    before { login(user) }
+
+    it 'creates an event' do
+      expect do
+        post events_path(locale: locale), params: { event: { name: 'New Event' } }
+      end.to change(BetterTogether::Event, :count).by(1)
+      expect(response).to redirect_to(event_path(BetterTogether::Event.last, locale: locale))
+    end
+  end
+
+  describe 'PATCH /events/:id' do
+    let(:user) { create(:better_together_user, :confirmed, :platform_manager) }
+    let!(:event) { BetterTogether::Event.create!(name: 'Old Name', creator: user.person) }
+
+    before { login(user) }
+
+    it 'updates the event' do
+      patch event_path(event, locale: locale), params: { event: { name: 'Updated Name' } }
+      expect(response).to redirect_to(edit_event_path(event, locale: locale))
+      expect(event.reload.name).to eq('Updated Name')
+    end
+  end
+
+  describe 'DELETE /events/:id' do
+    let(:user) { create(:better_together_user, :confirmed, :platform_manager) }
+    let!(:event) { BetterTogether::Event.create!(name: 'Delete Me', creator: user.person) }
+
+    before { login(user) }
+
+    it 'destroys the event' do
+      expect do
+        delete event_path(event, locale: locale)
+      end.to change(BetterTogether::Event, :count).by(-1)
+      expect(response).to redirect_to(events_path(locale: locale))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- eager load event categories and cover image attachments in index
- paginate draft, upcoming, and past event groups individually in the grouped index view
- add feature spec to verify event grouping on the index page
- add request specs covering event CRUD actions

## Testing
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.4.4)*
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*

------
https://chatgpt.com/codex/tasks/task_e_689b7c3d13248321af2a78793a16fe70