### PR TITLE
ci: fix coverage badge command

### DIFF
--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           COVERAGE=$(jq -r '.result.covered_percent' coverage/.last_run.json)
           COLOR=$(node -e "cov=parseFloat(process.argv[1]);console.log(cov>=90?'green':cov>=75?'orange':'red')" $COVERAGE)
-          npx badgen-cli coverage ${COVERAGE}% -c $COLOR > coverage.svg
+          npx badgen-cli --subject coverage --status ${COVERAGE}% --color $COLOR > coverage.svg
 
       - name: Commit badge
         if: ${{ github.ref == 'refs/heads/main' && success() }}


### PR DESCRIPTION
## Summary
- fix coverage badge script in GitHub Actions to pass required flags

## Testing
- `bundle exec rubocop` *(fails: bundler: command not found: rubocop)*
- `bin/ci` *(fails: bundler: command not found: rails)*
- `bundle exec brakeman -q -w2` *(fails: bundler: command not found: brakeman)*
- `bundle exec bundler-audit --update` *(fails: bundler: command not found: bundler-audit)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*

------
https://chatgpt.com/codex/tasks/task_e_689c72c076548321a2b96c7431330f4e