### PR TITLE
fix: raise not-found for unauthorized conversations

### DIFF
--- a/app/controllers/better_together/conversations_controller.rb
+++ b/app/controllers/better_together/conversations_controller.rb
@@ -226,7 +226,7 @@ module BetterTogether
                                                               :contact_detail,
                                                               { profile_image_attachment: :blob }
                                                             ])
-      @conversation = scope.find_by(id: params[:id])
+      @conversation = scope.find(params[:id])
       @set_conversation ||= Conversation.includes(participants: [
                                                     :string_translations,
                                                     :contact_detail,

--- a/spec/requests/better_together/conversations_request_spec.rb
+++ b/spec/requests/better_together/conversations_request_spec.rb
@@ -80,6 +80,19 @@ RSpec.describe 'BetterTogether::Conversations', :as_user do
     end
   end
 
+  describe 'GET /conversations/:id' do
+    context 'as a non-participant', :as_user do # rubocop:todo RSpec/ContextWording
+      it 'returns not found' do
+        conversation = create('better_together/conversation', creator: manager_user.person).tap do |c|
+          c.participants << manager_user.person unless c.participants.exists?(manager_user.person.id)
+        end
+
+        get better_together.conversation_path(conversation, locale: I18n.default_locale)
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+
   describe 'PATCH /conversations/:id' do
     context 'as a regular member', :as_user do # rubocop:todo RSpec/ContextWording
       let!(:conversation) do


### PR DESCRIPTION
## Summary
- raise `ActiveRecord::RecordNotFound` when accessing conversations not belonging to the current user
- add request spec to ensure non-participants receive a 404 response

## Testing
- `bin/dc-run bundle exec rubocop` *(fails: docker: command not found)*
- `bin/codex_style_guard` *(fails: bundler: command not found: rubocop)*
- `bin/dc-run bundle exec brakeman --quiet --no-pager` *(fails: docker: command not found)*
- `bin/dc-run bundle exec bundler-audit --update` *(fails: docker: command not found)*
- `bin/dc-run bin/i18n` *(fails: docker: command not found)*
- `bin/dc-run bin/ci` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1f69223b88321bb27a78b2da20f6d