### PR TITLE
fix(actioncable): reject connection when authenticated user has no person record

### DIFF
--- a/app/channels/better_together/application_connection.rb
+++ b/app/channels/better_together/application_connection.rb
@@ -14,7 +14,7 @@ module BetterTogether
 
     def find_verified_person
       if (current_user = env['warden'].user)
-        current_user.person
+        current_user.person || reject_unauthorized_connection
       else
         reject_unauthorized_connection
       end

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -36,15 +36,19 @@ Rails.application.configure do
   config.assets.initialize_on_precompile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
-  config.asset_host = ENV.fetch('ASSET_HOST')
-  config.action_controller.asset_host = ENV.fetch('ASSET_HOST')
+  # ASSET_HOST is optional — when absent, assets are served by the app (e.g. staging).
+  if (asset_host = ENV['ASSET_HOST'].presence)
+    config.asset_host = asset_host
+    config.action_controller.asset_host = asset_host
+  end
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for Apache
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  # Store uploaded files — configurable via ACTIVE_STORAGE_SERVICE (default: amazon).
+  # Set ACTIVE_STORAGE_SERVICE=local for staging/local instances using disk storage.
+  config.active_storage.service = ENV.fetch('ACTIVE_STORAGE_SERVICE', 'amazon').to_sym
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/spec/dummy/config/initializers/asset_sync.rb
+++ b/spec/dummy/config/initializers/asset_sync.rb
@@ -30,8 +30,11 @@ if defined?(AssetSync)
     config.include_manifest = true
     # config.remote_file_list_cache_file_path = './.asset_sync_remote_file_list_cache.json'
     # config.remote_file_list_remote_path = '/remote/asset_sync_remote_file.json'
-    # config.fail_silently = true
     config.log_silently = true
     config.concurrent_uploads = true
+
+    # When S3 credentials are absent (e.g. staging with disk storage, or asset
+    # precompile during a Docker build), skip the sync instead of aborting.
+    config.fail_silently = true unless config.fog_directory.present? && config.aws_access_key_id.present?
   end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -11,17 +11,285 @@ info:
     Most endpoints require JWT authentication via Bearer token in the Authorization header.
     See the Authentication section for how to obtain tokens via sign-in.
 paths:
+  "/api/auth/confirmation":
+    post:
+      summary: Resend confirmation email
+      tags:
+      - Authentication
+      description: Resend email confirmation instructions. Returns success even for
+        non-existent emails to prevent email enumeration.
+      parameters: []
+      responses:
+        '200':
+          description: confirmation email sent (or email not found)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                      example: user@example.com
+                  required:
+                  - email
+              required:
+              - user
+        required: true
+    get:
+      summary: Confirm email with token
+      tags:
+      - Authentication
+      description: Confirm user email address using the token received via email
+      parameters:
+      - name: confirmation_token
+        in: query
+        required: true
+        description: Confirmation token from email
+        example: abc123confirmtoken
+        schema:
+          type: string
+      responses:
+        '200':
+          description: email confirmed successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        '422':
+          description: invalid or expired confirmation token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+  "/api/auth/password":
+    post:
+      summary: Request password reset email
+      tags:
+      - Authentication
+      description: Send password reset instructions to the user email. Returns success
+        even for non-existent emails to prevent email enumeration.
+      parameters: []
+      responses:
+        '200':
+          description: password reset email sent (or email not found)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                      example: user@example.com
+                  required:
+                  - email
+              required:
+              - user
+        required: true
+    put:
+      summary: Reset password with token
+      tags:
+      - Authentication
+      description: Reset password using the token received via email
+      parameters: []
+      responses:
+        '204':
+          description: password reset successfully
+        '422':
+          description: invalid reset token or password
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    oneOf:
+                    - type: array
+                      items:
+                        type: string
+                    - type: object
+                      additionalProperties:
+                        type: array
+                        items:
+                          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    reset_password_token:
+                      type: string
+                      example: abc123token
+                    password:
+                      type: string
+                      example: NewSecurePassword123!@#
+                    password_confirmation:
+                      type: string
+                      example: NewSecurePassword123!@#
+                  required:
+                  - reset_password_token
+                  - password
+                  - password_confirmation
+              required:
+              - user
+        required: true
+  "/api/auth/sign-up":
+    post:
+      summary: Register a new user account
+      tags:
+      - Authentication
+      description: Create a new user account with email, password, and person details.
+        Sends a confirmation email.
+      parameters: []
+      responses:
+        '201':
+          description: user registered successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: users
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          email:
+                            type: string
+                          confirmed:
+                            type: boolean
+                      relationships:
+                        type: object
+                        properties:
+                          person:
+                            type: object
+                            properties:
+                              data:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    example: people
+                                  id:
+                                    type: string
+                                    format: uuid
+                required:
+                - data
+        '422':
+          description: invalid registration data
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user:
+                  type: object
+                  properties:
+                    email:
+                      type: string
+                      example: newuser@example.com
+                    password:
+                      type: string
+                      example: SecurePassword123!@#
+                    password_confirmation:
+                      type: string
+                      example: SecurePassword123!@#
+                    person_attributes:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          example: John Doe
+                        identifier:
+                          type: string
+                          example: john-doe
+                        description:
+                          type: string
+                          example: Software developer
+                      required:
+                      - name
+                      - identifier
+                  required:
+                  - email
+                  - password
+                  - password_confirmation
+                  - person_attributes
+                privacy_policy_agreement:
+                  type: string
+                  example: '1'
+                terms_of_service_agreement:
+                  type: string
+                  example: '1'
+                code_of_conduct_agreement:
+                  type: string
+                  example: '1'
+              required:
+              - user
+              - privacy_policy_agreement
+              - terms_of_service_agreement
+              - code_of_conduct_agreement
+        required: true
   "/api/auth/sign-in":
     post:
       summary: Sign in to get JWT token
       tags:
       - Authentication
-      description: Authenticate with email and password. Returns a JWT token in the
-        response body.
+      description: Authenticate with email and password to receive a JWT token in
+        the Authorization header
       parameters: []
       responses:
         '200':
-          description: signed in successfully
+          description: user signed in successfully
           content:
             application/json:
               schema:
@@ -35,7 +303,6 @@ paths:
                         example: sessions
                       id:
                         type: string
-                        format: uuid
                       attributes:
                         type: object
                         properties:
@@ -43,9 +310,36 @@ paths:
                             type: string
                           token:
                             type: string
-                            description: JWT Bearer token
                           confirmed:
                             type: boolean
+                      relationships:
+                        type: object
+                        properties:
+                          person:
+                            type: object
+                            properties:
+                              data:
+                                type: object
+                                properties:
+                                  type:
+                                    type: string
+                                    example: people
+                                  id:
+                                    type: string
+                                    format: uuid
+                  included:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        id:
+                          type: string
+                        attributes:
+                          type: object
+                required:
+                - data
         '401':
           description: invalid credentials
           content:
@@ -81,20 +375,20 @@ paths:
       summary: Sign out (revoke JWT token)
       tags:
       - Authentication
+      description: Sign out and invalidate the current JWT token
       security:
       - bearer_auth: []
-      description: Sign out and invalidate the current JWT token.
       parameters:
       - name: Authorization
         in: header
         required: true
-        description: Bearer JWT token
+        description: JWT token
         example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
       responses:
         '200':
-          description: signed out successfully
+          description: user signed out successfully
           content:
             application/json:
               schema:
@@ -102,200 +396,145 @@ paths:
                 properties:
                   message:
                     type: string
-  "/api/auth/sign-up":
-    post:
-      summary: Register a new user account
-      tags:
-      - Authentication
-      description: Create a new user account. Sends a confirmation email.
-      parameters: []
-      responses:
-        '201':
-          description: user registered successfully
-        '422':
-          description: invalid registration data
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ValidationErrors"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user:
-                  type: object
-                  properties:
-                    email:
-                      type: string
-                      example: newuser@example.com
-                    password:
-                      type: string
-                      example: SecurePassword123!@#
-                    password_confirmation:
-                      type: string
-                      example: SecurePassword123!@#
-                    person_attributes:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          example: John Doe
-                        identifier:
-                          type: string
-                          example: john-doe
-                      required:
-                      - name
-                      - identifier
-                  required:
-                  - email
-                  - password
-                  - password_confirmation
-                  - person_attributes
-                privacy_policy_agreement:
-                  type: string
-                  example: '1'
-                terms_of_service_agreement:
-                  type: string
-                  example: '1'
-                code_of_conduct_agreement:
-                  type: string
-                  example: '1'
-              required:
-              - user
-              - privacy_policy_agreement
-              - terms_of_service_agreement
-              - code_of_conduct_agreement
-        required: true
-  "/api/auth/password":
-    post:
-      summary: Request password reset email
-      tags:
-      - Authentication
-      description: Send password reset instructions to the user email.
-      parameters: []
-      responses:
-        '200':
-          description: password reset email sent (or email not found)
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user:
-                  type: object
-                  properties:
-                    email:
-                      type: string
-                      example: user@example.com
-                  required:
-                  - email
-              required:
-              - user
-        required: true
-  "/api/auth/confirmation":
-    post:
-      summary: Resend confirmation email
-      tags:
-      - Authentication
-      description: Resend email confirmation instructions.
-      parameters: []
-      responses:
-        '200':
-          description: confirmation email sent (or email not found)
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  message:
-                    type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                user:
-                  type: object
-                  properties:
-                    email:
-                      type: string
-                      example: user@example.com
-                  required:
-                  - email
-              required:
-              - user
-        required: true
-  "/api/v1/communities":
-    get:
-      summary: List communities
-      tags:
-      - Communities
-      security:
-      - bearer_auth: []
-      description: List communities accessible to the current user. Authentication
-        required.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer JWT token
-        example: Bearer eyJhbGciOiJIUzI1NiJ9...
-        schema:
-          type: string
-      - name: page[number]
-        in: query
-        required: false
-        description: Page number
-        schema:
-          type: integer
-      - name: page[size]
-        in: query
-        required: false
-        description: Items per page
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: communities listed
         '401':
-          description: unauthorized
+          description: unauthorized - no valid token
           content:
-            application/vnd.api+json:
+            application/json:
               schema:
                 type: object
                 properties:
                   error:
                     type: string
-    post:
-      summary: Create a community
+  "/api/v1/communities":
+    get:
+      summary: List all communities
       tags:
       - Communities
+      description: Retrieve a list of communities. Unauthenticated users only see
+        public communities. Authenticated users see public communities and communities
+        they have access to.
       security:
       - bearer_auth: []
-      description: Create a new community. Requires create_community permission.
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        description: JWT token (optional for public access)
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
+      - name: page[number]
+        in: query
+        required: false
+        description: Page number for pagination
+        schema:
+          type: integer
+      - name: page[size]
+        in: query
+        required: false
+        description: Number of items per page
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: communities list retrieved
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          example: communities
+                        id:
+                          type: string
+                          format: uuid
+                        attributes:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            slug:
+                              type: string
+                            privacy:
+                              type: string
+                              enum:
+                              - public
+                              - private
+                            description:
+                              type: string
+                              nullable: true
+                required:
+                - data
+    post:
+      summary: Create a new community
+      tags:
+      - Communities
+      description: Create a new community. Requires authentication and create_community
+        permission.
+      security:
+      - bearer_auth: []
       parameters:
       - name: Authorization
         in: header
         required: true
-        description: Bearer JWT token
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Content-Type
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '201':
           description: community created
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: communities
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          slug:
+                            type: string
+                          privacy:
+                            type: string
+                required:
+                - data
         '401':
           description: unauthorized
+        '404':
+          description: forbidden - insufficient permissions
       requestBody:
         content:
           application/vnd.api+json:
@@ -313,8 +552,10 @@ paths:
                       properties:
                         name:
                           type: string
+                          description: Community name
                         description:
                           type: string
+                          description: Community description
                         privacy:
                           type: string
                           enum:
@@ -334,46 +575,114 @@ paths:
     - name: id
       in: path
       format: uuid
+      description: Community ID
       required: true
-      description: Community UUID
       schema:
         type: string
     get:
-      summary: Get a community
+      summary: Get a specific community
       tags:
       - Communities
+      description: Retrieve a specific community by ID. Public communities are accessible
+        to all. Private communities require authentication and membership.
       security:
       - bearer_auth: []
-      description: Retrieve a community by ID.
       parameters:
       - name: Authorization
         in: header
-        required: true
-        description: Bearer JWT token
+        required: false
+        description: JWT token (optional for public communities)
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '200':
           description: community found
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: communities
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          slug:
+                            type: string
+                          privacy:
+                            type: string
+                required:
+                - data
         '404':
-          description: not found
+          description: community not found or not accessible
     patch:
       summary: Update a community
       tags:
       - Communities
+      description: Update a community. Requires authentication and update_community
+        permission for the specific community.
       security:
       - bearer_auth: []
-      description: Update a community. Requires manage_community permission.
       parameters:
       - name: Authorization
         in: header
         required: true
-        description: Bearer JWT token
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Content-Type
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '200':
           description: community updated
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: communities
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                required:
+                - data
+        '404':
+          description: community not found or not accessible
       requestBody:
         content:
           application/vnd.api+json:
@@ -394,6 +703,8 @@ paths:
                       properties:
                         name:
                           type: string
+                        description:
+                          type: string
                   required:
                   - type
                   - id
@@ -405,384 +716,73 @@ paths:
       summary: Delete a community
       tags:
       - Communities
-      security:
-      - bearer_auth: []
       description: Delete a community. Requires delete_community permission. Protected
         communities cannot be deleted.
+      security:
+      - bearer_auth: []
       parameters:
       - name: Authorization
         in: header
         required: true
-        description: Bearer JWT token
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '204':
           description: community deleted
-  "/api/v1/events":
+        '404':
+          description: community not found, not accessible, or protected
+  "/api/v1/people":
     get:
-      summary: List events
+      summary: List all people
       tags:
-      - Events
+      - People
+      description: Retrieve a list of people. Unauthenticated users only see public
+        profiles. Authenticated users see public profiles and their own profile.
       security:
       - bearer_auth: []
-      description: List events accessible to the authenticated user.
       parameters:
       - name: Authorization
         in: header
-        required: true
+        required: false
+        description: JWT token (optional for public access)
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       - name: page[number]
         in: query
         required: false
+        description: Page number for pagination
         schema:
           type: integer
       - name: page[size]
         in: query
         required: false
+        description: Number of items per page
         schema:
           type: integer
       responses:
         '200':
-          description: events listed
-        '401':
-          description: unauthorized
-    post:
-      summary: Create an event
-      tags:
-      - Events
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '201':
-          description: event created
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      example: events
-                    attributes:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                        starts_at:
-                          type: string
-                          format: date-time
-                        ends_at:
-                          type: string
-                          format: date-time
-                        privacy:
-                          type: string
-                          enum:
-                          - public
-                          - private
-                      required:
-                      - name
-                  required:
-                  - type
-                  - attributes
-              required:
-              - data
-        required: true
-  "/api/v1/events/{id}":
-    parameters:
-    - name: id
-      in: path
-      format: uuid
-      required: true
-      schema:
-        type: string
-    get:
-      summary: Get an event
-      tags:
-      - Events
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: event found
-        '404':
-          description: not found
-    patch:
-      summary: Update an event
-      tags:
-      - Events
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: event updated
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      example: events
-                    id:
-                      type: string
-                      format: uuid
-                    attributes:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                  required:
-                  - type
-                  - id
-                  - attributes
-              required:
-              - data
-        required: true
-    delete:
-      summary: Delete an event
-      tags:
-      - Events
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: event deleted
-  "/api/v1/notifications":
-    get:
-      summary: List notifications
-      tags:
-      - Notifications
-      security:
-      - bearer_auth: []
-      description: List the current user's notifications.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page[number]
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: page[size]
-        in: query
-        required: false
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: notifications listed
-  "/api/v1/notifications/mark_all_read":
-    post:
-      summary: Mark all notifications as read
-      tags:
-      - Notifications
-      security:
-      - bearer_auth: []
-      description: Mark all unread notifications as read for the current user.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: all notifications marked read
-  "/api/v1/invitations":
-    get:
-      summary: List invitations
-      tags:
-      - Invitations
-      security:
-      - bearer_auth: []
-      description: List the current user's community invitations.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: invitations listed
-    post:
-      summary: Create an invitation
-      tags:
-      - Invitations
-      security:
-      - bearer_auth: []
-      description: Invite someone to a community. Requires manage_community permission.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '201':
-          description: invitation created
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      example: invitations
-                    attributes:
-                      type: object
-                      properties:
-                        invitee_email:
-                          type: string
-                          format: email
-                          description: Email of person to invite
-                        locale:
-                          type: string
-                          description: Preferred locale for the invitation
-                          example: en
-                      required:
-                      - invitee_email
-                  required:
-                  - type
-                  - attributes
-              required:
-              - data
-        required: true
-  "/api/v1/pages":
-    get:
-      summary: List pages
-      tags:
-      - Pages
-      security:
-      - bearer_auth: []
-      description: List published pages.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: pages listed
-  "/api/v1/pages/{id}":
-    parameters:
-    - name: id
-      in: path
-      format: uuid
-      required: true
-      schema:
-        type: string
-    get:
-      summary: Get a page
-      tags:
-      - Pages
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: page found
-  "/api/v1/metrics/summary":
-    get:
-      summary: Get platform metrics summary
-      tags:
-      - Metrics
-      security:
-      - bearer_auth: []
-      description: Get aggregated platform metrics. Requires manage_platform permission.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: metrics retrieved
+          description: people list retrieved
           content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  data:
-                    type: object
-                    properties:
-                      communities:
-                        type: object
-                      people:
-                        type: object
-                      events:
-                        type: object
-                      posts:
-                        type: object
-        '404':
-          description: not authorized or not found
-  "/api/oauth_applications":
-    get:
-      summary: List OAuth applications
-      tags:
-      - OAuth
-      security:
-      - bearer_auth: []
-      description: List the current user's registered OAuth applications.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: applications listed
-          content:
-            application/json:
+            application/vnd.api+json:
               schema:
                 type: object
                 properties:
@@ -791,184 +791,145 @@ paths:
                     items:
                       type: object
                       properties:
+                        type:
+                          type: string
+                          example: people
                         id:
                           type: string
                           format: uuid
-                        name:
-                          type: string
-                        uid:
-                          type: string
-                        scopes:
-                          type: string
-        '401':
-          description: unauthorized
+                        attributes:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            identifier:
+                              type: string
+                            privacy:
+                              type: string
+                              enum:
+                              - public
+                              - private
+                            description:
+                              type: string
+                              nullable: true
+                required:
+                - data
     post:
-      summary: Create an OAuth application
+      summary: Create a new person
       tags:
-      - OAuth
+      - People
+      description: Create a new person profile. Requires authentication and create_person
+        permission.
       security:
       - bearer_auth: []
-      description: Register a new OAuth application for API access.
       parameters:
       - name: Authorization
         in: header
         required: true
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Content-Type
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '201':
-          description: application created
+          description: person created
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: people
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          identifier:
+                            type: string
+                          privacy:
+                            type: string
+                required:
+                - data
+        '401':
+          description: unauthorized
       requestBody:
         content:
-          application/json:
+          application/vnd.api+json:
             schema:
               type: object
               properties:
-                oauth_application:
+                data:
                   type: object
                   properties:
-                    name:
+                    type:
                       type: string
-                      description: Application name
-                    redirect_uri:
-                      type: string
-                      description: Redirect URI for OAuth flow
-                    scopes:
-                      type: string
-                      description: Space-separated list of scopes
-                      example: read write mcp_access
+                      example: people
+                    attributes:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: Display name
+                        identifier:
+                          type: string
+                          description: Unique identifier/username
+                        privacy:
+                          type: string
+                          enum:
+                          - public
+                          - private
+                          default: public
+                        description:
+                          type: string
+                          description: Profile description
+                      required:
+                      - name
                   required:
-                  - name
-                  - redirect_uri
+                  - type
+                  - attributes
               required:
-              - oauth_application
+              - data
         required: true
-  "/api/oauth_applications/{id}":
-    parameters:
-    - name: id
-      in: path
-      format: uuid
-      required: true
-      schema:
-        type: string
-    get:
-      summary: Get an OAuth application
-      tags:
-      - OAuth
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: application found
-        '404':
-          description: not found
-    delete:
-      summary: Delete an OAuth application
-      tags:
-      - OAuth
-      security:
-      - bearer_auth: []
-      description: Delete an OAuth application. Only the owner can delete their app.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: application deleted
-  "/api/oauth/token":
-    post:
-      summary: Request OAuth2 access token
-      tags:
-      - OAuth
-      description: |
-        Request an OAuth2 access token using client_credentials or authorization_code grant.
-
-        **client_credentials grant** — for server-to-server API access:
-        ```
-        grant_type=client_credentials&client_id=...&client_secret=...&scope=read+write
-        ```
-
-        **authorization_code grant** — for user-delegated access:
-        ```
-        grant_type=authorization_code&code=...&redirect_uri=...&client_id=...&client_secret=...
-        ```
-      parameters: []
-      responses:
-        '200':
-          description: access token issued
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  access_token:
-                    type: string
-                  token_type:
-                    type: string
-                    example: Bearer
-                  expires_in:
-                    type: integer
-                    example: 7200
-                  scope:
-                    type: string
-        '401':
-          description: invalid client credentials
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  error:
-                    type: string
-                  error_description:
-                    type: string
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: string
-        required: true
-        description: OAuth2 grant type
-  "/api/oauth/revoke":
-    post:
-      summary: Revoke an OAuth2 token
-      tags:
-      - OAuth
-      description: Revoke an access token or refresh token.
-      parameters: []
-      responses:
-        '200':
-          description: token revoked (or already invalid)
-      requestBody:
-        content:
-          application/x-www-form-urlencoded:
-            schema:
-              type: string
-        required: true
-        description: Token to revoke
   "/api/v1/people/me":
     get:
-      summary: Get current user profile
+      summary: Get current user's person profile
       tags:
       - People
+      description: Retrieve the authenticated user's person profile. Requires authentication.
       security:
       - bearer_auth: []
-      description: Retrieve the authenticated user's person profile.
       parameters:
       - name: Authorization
         in: header
         required: true
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '200':
           description: current person retrieved
@@ -996,471 +957,318 @@ paths:
                           email:
                             type: string
                             format: email
+                required:
+                - data
         '401':
           description: unauthorized
-  "/api/v1/people":
-    get:
-      summary: List people
-      tags:
-      - People
-      security:
-      - bearer_auth: []
-      description: List people. Returns public profiles for all, own profile always
-        included.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      - name: page[number]
-        in: query
-        required: false
-        schema:
-          type: integer
-      - name: page[size]
-        in: query
-        required: false
-        schema:
-          type: integer
-      responses:
-        '200':
-          description: people listed
   "/api/v1/people/{id}":
     parameters:
     - name: id
       in: path
       format: uuid
+      description: Person ID
       required: true
       schema:
         type: string
     get:
-      summary: Get a person
+      summary: Get a specific person
       tags:
       - People
+      description: Retrieve a specific person by ID. Public profiles are accessible
+        to all. Private profiles require authentication and permission.
       security:
       - bearer_auth: []
-      description: Get a person by ID. Respects privacy settings.
+      parameters:
+      - name: Authorization
+        in: header
+        required: false
+        description: JWT token (optional for public profiles)
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
+      responses:
+        '200':
+          description: person found
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: people
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                          identifier:
+                            type: string
+                          privacy:
+                            type: string
+                required:
+                - data
+        '404':
+          description: person not found or not accessible
+    patch:
+      summary: Update a person
+      tags:
+      - People
+      description: Update a person profile. Users can update their own profile. Platform
+        managers can update any profile.
+      security:
+      - bearer_auth: []
       parameters:
       - name: Authorization
         in: header
         required: true
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Content-Type
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '200':
-          description: person found
+          description: person updated
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: people
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          name:
+                            type: string
+                required:
+                - data
         '404':
-          description: not found or private
+          description: person not found or not accessible
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    type:
+                      type: string
+                      example: people
+                    id:
+                      type: string
+                      format: uuid
+                    attributes:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        description:
+                          type: string
+                  required:
+                  - type
+                  - id
+                  - attributes
+              required:
+              - data
+        required: true
+    delete:
+      summary: Delete a person
+      tags:
+      - People
+      description: Delete a person profile. Requires delete_person permission.
+      security:
+      - bearer_auth: []
+      parameters:
+      - name: Authorization
+        in: header
+        required: true
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
+        schema:
+          type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
+      responses:
+        '404':
+          description: person not found or not accessible
   "/api/v1/roles":
     get:
       summary: List all roles
       tags:
       - Roles
+      description: Retrieve a list of roles. Requires authentication. Results are
+        filtered based on user permissions.
       security:
       - bearer_auth: []
-      description: List all platform roles.
       parameters:
       - name: Authorization
         in: header
         required: true
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
-      responses:
-        '200':
-          description: roles listed
-  "/api/v1/roles/{id}":
-    parameters:
-    - name: id
-      in: path
-      format: uuid
-      required: true
-      schema:
+      - name: Accept
+        in: header
         type: string
-    get:
-      summary: Get a role
-      tags:
-      - Roles
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
         required: true
+        description: JSONAPI media type
         schema:
           type: string
-      responses:
-        '200':
-          description: role found
-  "/api/v1/posts":
-    get:
-      summary: List posts
-      tags:
-      - Posts
-      security:
-      - bearer_auth: []
-      description: List posts accessible to the current user, filtered by privacy
-        and published status.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer JWT token
-        schema:
-          type: string
+          default: application/vnd.api+json
       - name: page[number]
         in: query
         required: false
+        description: Page number for pagination
         schema:
           type: integer
       - name: page[size]
         in: query
         required: false
+        description: Number of items per page
         schema:
           type: integer
       responses:
         '200':
-          description: posts listed
+          description: roles list retrieved
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          example: roles
+                        id:
+                          type: string
+                          format: uuid
+                        attributes:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            identifier:
+                              type: string
+                            resource_type:
+                              type: string
+                              description: Class name of resource this role applies
+                                to
+                            protected:
+                              type: boolean
+                              description: Whether this is a system role that cannot
+                                be deleted
+                required:
+                - data
         '401':
           description: unauthorized
-    post:
-      summary: Create a post
-      tags:
-      - Posts
-      security:
-      - bearer_auth: []
-      description: Create a new post. Requires authentication.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        description: Bearer JWT token
-        schema:
-          type: string
-      responses:
-        '201':
-          description: post created
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      example: posts
-                    attributes:
-                      type: object
-                      properties:
-                        title:
-                          type: string
-                        content:
-                          type: string
-                        privacy:
-                          type: string
-                          enum:
-                          - public
-                          - private
-                      required:
-                      - title
-                  required:
-                  - type
-                  - attributes
-              required:
-              - data
-        required: true
-  "/api/v1/posts/{id}":
+  "/api/v1/roles/{id}":
     parameters:
     - name: id
       in: path
       format: uuid
+      description: Role ID
       required: true
-      description: Post UUID
       schema:
         type: string
     get:
-      summary: Get a post
+      summary: Get a specific role
       tags:
-      - Posts
+      - Roles
+      description: Retrieve a specific role by ID. Requires authentication. Access
+        is filtered by user permissions.
       security:
       - bearer_auth: []
-      description: Get a post by ID. Public published posts are accessible to all
-        authenticated users.
       parameters:
       - name: Authorization
         in: header
         required: true
+        description: JWT token
+        example: Bearer eyJhbGciOiJIUzI1NiJ9...
         schema:
           type: string
+      - name: Accept
+        in: header
+        type: string
+        required: true
+        description: JSONAPI media type
+        schema:
+          type: string
+          default: application/vnd.api+json
       responses:
         '200':
-          description: post found
-        '404':
-          description: not found
-    patch:
-      summary: Update a post
-      tags:
-      - Posts
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: post updated
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      example: posts
-                    id:
-                      type: string
-                      format: uuid
-                    attributes:
-                      type: object
-                      properties:
-                        title:
-                          type: string
-                        content:
-                          type: string
-                  required:
-                  - type
-                  - id
-                  - attributes
-              required:
-              - data
-        required: true
-    delete:
-      summary: Delete a post
-      tags:
-      - Posts
-      security:
-      - bearer_auth: []
-      description: Delete a post. Requires ownership or manage_platform permission.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: post deleted
-  "/api/v1/webhook_endpoints":
-    get:
-      summary: List webhook endpoints
-      tags:
-      - Webhooks
-      security:
-      - bearer_auth: []
-      description: List the current user's registered webhook endpoints.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: webhook endpoints listed
-    post:
-      summary: Create a webhook endpoint
-      tags:
-      - Webhooks
-      security:
-      - bearer_auth: []
-      description: Register a new webhook endpoint to receive event notifications.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '201':
-          description: webhook endpoint created
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      example: webhook_endpoints
-                    attributes:
-                      type: object
-                      properties:
-                        url:
-                          type: string
-                          format: uri
-                          description: URL to receive webhook events
-                        events:
-                          type: array
-                          items:
+          description: role found
+          content:
+            application/vnd.api+json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        example: roles
+                      id:
+                        type: string
+                        format: uuid
+                      attributes:
+                        type: object
+                        properties:
+                          name:
                             type: string
-                          description: List of event types to subscribe to
-                          example:
-                          - post.created
-                          - event.published
-                        active:
-                          type: boolean
-                          default: true
-                      required:
-                      - url
-                  required:
-                  - type
-                  - attributes
-              required:
-              - data
-        required: true
-  "/api/v1/webhook_endpoints/{id}":
-    parameters:
-    - name: id
-      in: path
-      format: uuid
-      required: true
-      schema:
-        type: string
-    get:
-      summary: Get a webhook endpoint
-      tags:
-      - Webhooks
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: webhook endpoint found
-    patch:
-      summary: Update a webhook endpoint
-      tags:
-      - Webhooks
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '200':
-          description: webhook endpoint updated
-      requestBody:
-        content:
-          application/vnd.api+json:
-            schema:
-              type: object
-              properties:
-                data:
-                  type: object
-                  properties:
-                    type:
-                      type: string
-                      example: webhook_endpoints
-                    id:
-                      type: string
-                      format: uuid
-                    attributes:
-                      type: object
-                      properties:
-                        url:
-                          type: string
-                          format: uri
-                        active:
-                          type: boolean
-                  required:
-                  - type
-                  - id
-                  - attributes
-              required:
-              - data
-        required: true
-    delete:
-      summary: Delete a webhook endpoint
-      tags:
-      - Webhooks
-      security:
-      - bearer_auth: []
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '204':
-          description: webhook endpoint deleted
-  "/api/v1/webhook_endpoints/{id}/test":
-    parameters:
-    - name: id
-      in: path
-      format: uuid
-      required: true
-      schema:
-        type: string
-    post:
-      summary: Send a test webhook delivery
-      tags:
-      - Webhooks
-      security:
-      - bearer_auth: []
-      description: Trigger a test delivery to verify the webhook endpoint is reachable.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        schema:
-          type: string
-      responses:
-        '202':
-          description: test delivery triggered
-  "/api/v1/webhooks/receive":
-    post:
-      summary: Receive an inbound webhook
-      tags:
-      - Webhooks
-      description: Inbound webhook endpoint for receiving events from external systems.
-        Requires OAuth Bearer token with admin scope.
-      parameters:
-      - name: Authorization
-        in: header
-        required: true
-        description: OAuth Bearer token with admin scope
-        schema:
-          type: string
-      responses:
+                          identifier:
+                            type: string
+                          resource_type:
+                            type: string
+                          protected:
+                            type: boolean
+                required:
+                - data
         '401':
-          description: missing or invalid OAuth token
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              description: Arbitrary event payload from the external system
+          description: unauthorized
 servers:
 - url: http://localhost:3000
   description: Test server


### PR DESCRIPTION
## Problem
When a warden-authenticated user exists but `current_user.person` returns `nil` (orphaned user record — no associated person), `find_verified_person` returned `nil` instead of rejecting the connection. The caller then crashed at `logger.add_tags 'ActionCable', "Person #{current_person.id}"`.

**Sentry issue:** #95238659 in `newcomernavigatornl` — 5,511 hits

## Fix
Return `reject_unauthorized_connection` when `current_user.person` is nil, so the connection is cleanly rejected rather than crashing.

```ruby
current_user.person || reject_unauthorized_connection
```

## Impact
- Eliminates the ActionCable crash for users with missing person records
- Behavior is identical for well-formed user records