### PR TITLE
perf: fix N+1 queries across controllers (5 Sentry patterns)

### DIFF
--- a/app/controllers/better_together/content/blocks_controller.rb
+++ b/app/controllers/better_together/content/blocks_controller.rb
@@ -105,6 +105,10 @@ module BetterTogether
         BetterTogether::Content::Block
       end
 
+      def resource_collection
+        super.with_translations
+      end
+
       def authorize_preview
         authorize(resource_class, :preview_markdown?)
       end

--- a/app/controllers/better_together/events_controller.rb
+++ b/app/controllers/better_together/events_controller.rb
@@ -184,7 +184,7 @@ module BetterTogether
       invitation_token = params[:invitation_token] || session[:event_invitation_token]
       self.current_invitation_token = invitation_token
 
-      super
+      super.includes(:categories)
     end
 
     # Override the parent's authorize_resource method to include invitation token context

--- a/app/controllers/better_together/metrics/link_click_reports_controller.rb
+++ b/app/controllers/better_together/metrics/link_click_reports_controller.rb
@@ -12,7 +12,8 @@ module BetterTogether
       def index
         authorize %i[metrics link_click_report], :index?,
                   policy_class: BetterTogether::Metrics::LinkClickReportPolicy
-        @link_click_reports = BetterTogether::Metrics::LinkClickReport.order(created_at: :desc)
+        @link_click_reports = BetterTogether::Metrics::LinkClickReport.with_attached_report_file
+                                                                       .order(created_at: :desc)
         if request.headers['Turbo-Frame'].present?
           render partial: 'better_together/metrics/link_click_reports/index',
                  locals: { link_click_reports: @link_click_reports }, layout: false

--- a/app/controllers/better_together/metrics/link_click_reports_controller.rb
+++ b/app/controllers/better_together/metrics/link_click_reports_controller.rb
@@ -13,7 +13,7 @@ module BetterTogether
         authorize %i[metrics link_click_report], :index?,
                   policy_class: BetterTogether::Metrics::LinkClickReportPolicy
         @link_click_reports = BetterTogether::Metrics::LinkClickReport.with_attached_report_file
-                                                                       .order(created_at: :desc)
+                                                                      .order(created_at: :desc)
         if request.headers['Turbo-Frame'].present?
           render partial: 'better_together/metrics/link_click_reports/index',
                  locals: { link_click_reports: @link_click_reports }, layout: false

--- a/app/controllers/better_together/metrics/page_view_reports_controller.rb
+++ b/app/controllers/better_together/metrics/page_view_reports_controller.rb
@@ -12,7 +12,7 @@ module BetterTogether
       def index
         authorize %i[metrics page_view_report], :index?, policy_class: BetterTogether::Metrics::PageViewReportPolicy
         @page_view_reports = BetterTogether::Metrics::PageViewReport.with_attached_report_file
-                                                                     .order(created_at: :desc)
+                                                                    .order(created_at: :desc)
         if request.headers['Turbo-Frame'].present?
           render partial: 'better_together/metrics/page_view_reports/index',
                  locals: { page_view_reports: @page_view_reports }, layout: false

--- a/app/controllers/better_together/metrics/page_view_reports_controller.rb
+++ b/app/controllers/better_together/metrics/page_view_reports_controller.rb
@@ -11,7 +11,8 @@ module BetterTogether
       # GET /metrics/page_view_reports
       def index
         authorize %i[metrics page_view_report], :index?, policy_class: BetterTogether::Metrics::PageViewReportPolicy
-        @page_view_reports = BetterTogether::Metrics::PageViewReport.order(created_at: :desc)
+        @page_view_reports = BetterTogether::Metrics::PageViewReport.with_attached_report_file
+                                                                     .order(created_at: :desc)
         if request.headers['Turbo-Frame'].present?
           render partial: 'better_together/metrics/page_view_reports/index',
                  locals: { page_view_reports: @page_view_reports }, layout: false

--- a/app/controllers/better_together/navigation_areas_controller.rb
+++ b/app/controllers/better_together/navigation_areas_controller.rb
@@ -7,7 +7,7 @@ module BetterTogether
 
     def index
       authorize resource_class
-      @navigation_areas = policy_scope(resource_class.with_translations)
+      @navigation_areas = policy_scope(resource_class.with_translations.includes(:platform))
     end
 
     def show # rubocop:todo Metrics/MethodLength

--- a/app/controllers/better_together/notifications_controller.rb
+++ b/app/controllers/better_together/notifications_controller.rb
@@ -9,7 +9,7 @@ module BetterTogether
     before_action :disallow_robots
 
     def index
-      @notifications = helpers.current_person.notifications.includes(:event).order(created_at: :desc)
+      @notifications = helpers.current_person.notifications.includes(event: :record).order(created_at: :desc)
       @unread_count = helpers.current_person.notifications.unread.size
     end
 

--- a/app/controllers/better_together/pages_controller.rb
+++ b/app/controllers/better_together/pages_controller.rb
@@ -26,6 +26,7 @@ module BetterTogether
 
       # Preload content blocks with their associations for better performance
       @content_blocks = @page.content_blocks.includes(
+        :string_translations,
         background_image_file_attachment: :blob
       )
       @layout = 'layouts/better_together/page'
@@ -189,7 +190,7 @@ module BetterTogether
       resource_collection.includes(
         :string_translations,
         page_blocks: {
-          block: [{ background_image_file_attachment: :blob }]
+          block: [:string_translations, { background_image_file_attachment: :blob }]
         }
       )
     end
@@ -213,7 +214,7 @@ module BetterTogether
         :string_translations,
         :sidebar_nav,
         { page_blocks: {
-          block: [{ background_image_file_attachment: :blob }]
+          block: [:string_translations, { background_image_file_attachment: :blob }]
         } }
       ]
     end

--- a/app/controllers/better_together/platforms_controller.rb
+++ b/app/controllers/better_together/platforms_controller.rb
@@ -11,7 +11,9 @@ module BetterTogether
       # @platforms = ::BetterTogether::Platform.all
       # authorize @platforms
       authorize ::BetterTogether::Platform
-      @platforms = policy_scope(::BetterTogether::Platform.with_translations)
+      @platforms = policy_scope(::BetterTogether::Platform.with_translations
+                                                          .with_attached_profile_image
+                                                          .with_attached_cover_image)
     end
 
     # GET /platforms/1

--- a/app/controllers/better_together/resource_permissions_controller.rb
+++ b/app/controllers/better_together/resource_permissions_controller.rb
@@ -9,7 +9,7 @@ module BetterTogether
     def index
       authorize resource_class
       @resource_permissions = policy_scope(resource_class.with_translations)
-                              .includes(:roles)
+                              .includes(:roles, :platform)
                               .order(:resource_type, :action, :position, :identifier)
       @resource_permissions_by_resource_type = @resource_permissions.group_by(&:resource_type)
       @rbac_nav_counts = {

--- a/app/controllers/better_together/roles_controller.rb
+++ b/app/controllers/better_together/roles_controller.rb
@@ -10,7 +10,7 @@ module BetterTogether
       # Assuming Role class is under the same namespace for consistency
       authorize resource_class # Add this to authorize action
       @roles = policy_scope(resource_class.with_translations)
-               .includes(:resource_permissions)
+               .includes(:resource_permissions, :platform)
                .order(:resource_type, :position, :identifier)
       @roles_by_resource_type = @roles.group_by(&:resource_type)
       @rbac_nav_counts = {

--- a/app/services/better_together/metrics/http_link_checker.rb
+++ b/app/services/better_together/metrics/http_link_checker.rb
@@ -20,13 +20,17 @@ module BetterTogether
       def initialize(uri, retries: DEFAULT_RETRIES,
                      open_timeout: DEFAULT_OPEN_TIMEOUT,
                      read_timeout: DEFAULT_READ_TIMEOUT)
-        @uri = URI.parse(uri)
+        @uri = URI.parse(URI::RFC2396_Parser.new.escape(uri))
         @retries = retries
         @open_timeout = open_timeout
         @read_timeout = read_timeout
+      rescue URI::InvalidURIError => e
+        @invalid_uri_error = e
       end
 
       def call
+        return CheckResult.new(false, nil, @invalid_uri_error) if @invalid_uri_error
+
         attempts = 0
         begin
           attempts += 1

--- a/spec/requests/better_together/events_controller_spec.rb
+++ b/spec/requests/better_together/events_controller_spec.rb
@@ -485,4 +485,16 @@ RSpec.describe 'BetterTogether::EventsController', :as_user do
       end
     end
   end
+
+  describe 'GET /:locale/events', :as_platform_manager do
+    it 'renders index without N+1 on categories association' do
+      events = create_list(:event, 3)
+      category = create(:event_category)
+      events.each { |e| e.categories << category }
+
+      get better_together.events_path(locale:)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
 end

--- a/spec/requests/better_together/pages_controller_spec.rb
+++ b/spec/requests/better_together/pages_controller_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BetterTogether::PagesController', :as_platform_manager do
+  let(:locale) { I18n.default_locale }
+
+  describe 'GET /:locale/pages' do
+    it 'renders index without N+1 on block string_translations' do
+      pages = create_list(:better_together_page, 3, published_at: 1.day.ago, privacy: 'public')
+      pages.each do |page|
+        block = create(:content_markdown, markdown_source: '## Heading')
+        page.page_blocks.create!(block:, position: 0)
+      end
+
+      get better_together.pages_path(locale:)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /:locale/pages/:slug' do
+    let(:page) do
+      create(:better_together_page,
+             slug: 'test-page-spec',
+             identifier: 'test-page-spec',
+             protected: false,
+             published_at: 1.day.ago,
+             privacy: 'public')
+    end
+
+    before do
+      block = create(:content_markdown, markdown_source: '## Content block')
+      page.page_blocks.create!(block:, position: 0)
+    end
+
+    it 'renders show without N+1 on content block string_translations' do
+      get better_together.page_path(page.slug, locale:)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'GET /:locale/pages/:slug/edit' do
+    let(:page) do
+      create(:better_together_page,
+             slug: 'test-page-edit-spec',
+             identifier: 'test-page-edit-spec',
+             protected: false,
+             published_at: 1.day.ago)
+    end
+
+    before do
+      block = create(:content_markdown, markdown_source: '## Editable content')
+      page.page_blocks.create!(block:, position: 0)
+    end
+
+    it 'renders edit without N+1 on block string_translations' do
+      get better_together.edit_page_path(page.slug, locale:)
+
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/services/better_together/metrics/http_link_checker_spec.rb
+++ b/spec/services/better_together/metrics/http_link_checker_spec.rb
@@ -24,5 +24,30 @@ module BetterTogether
       expect(result.status_code).to be_nil
       expect(result.error).to be_a(StandardError)
     end
+
+    describe 'invalid URI handling' do
+      it 'returns failure without raising for non-ASCII URI (French accented slug)' do
+        result = described_class.new('https://example.com/fréquemment-posées').call
+
+        expect(result.success).to be(false)
+        expect(result.status_code).to be_nil
+        expect(result.error).to be_a(StandardError)
+      end
+
+      it 'returns failure without raising for CSS gradient stored as href' do
+        gradient_uri = 'linear-gradient(to bottom, #ffffff 0%, #000000 100%)'
+        result = described_class.new(gradient_uri).call
+
+        expect(result.success).to be(false)
+        expect(result.status_code).to be_nil
+        expect(result.error).to be_a(StandardError)
+      end
+
+      it 'does not raise URI::InvalidURIError for malformed URIs' do
+        expect do
+          described_class.new('https://example.com/path with spaces').call
+        end.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem
Sentry identified 5 distinct N+1 query patterns causing hundreds of repeated DB hits per page load.

## Fixes

### Pattern A — `active_storage_attachments` (N queries per record)
- `PageViewReportsController#index` → `.with_attached_report_file`
- `LinkClickReportsController#index` → `.with_attached_report_file`
- `PlatformsController#index` → `.with_attached_profile_image.with_attached_cover_image`

### Pattern B — `mobility_string_translations` (93 hits in BlocksController)
- `Content::BlocksController` → override `resource_collection` with `.with_translations`

### Pattern C — `better_together_platforms` (N+1 via belongs_to :platform)
- `NavigationAreasController#index` → add `.includes(:platform)`
- `ResourcePermissionsController#index` → add `:platform` to includes
- `RolesController#index` → add `:platform` to includes

### Pattern D — `better_together_messages` via Noticed (64 NNL + 23 CE hits)
- `NotificationsController#index` → `includes(:event)` → `includes(event: :record)`
  Noticed::Event has a polymorphic `belongs_to :record` (BetterTogether::Message). Without preloading, each notification triggers a separate message query.

### Pattern E — `better_together_categories` (15 hits in EventsController)
- `EventsController#resource_collection` → add `.includes(:categories)`

## Sentry Issues Addressed
16424452, 50903911, 91714614, 54127363, 84922205, 84922204, 91721638, 91721636, 91721633, 91722011, 88004447, 84921945, 87453718, 84921935, 90073807, 77612254, 65451325, 77782771