### PR TITLE
fix: avoid AssociationNotFoundError on Content::Template in preload_page_associations

### DIFF
--- a/app/controllers/better_together/pages_controller.rb
+++ b/app/controllers/better_together/pages_controller.rb
@@ -24,11 +24,17 @@ module BetterTogether
       # Hide pages that don't exist or aren't viewable to the current user as 404s
       render_not_found and return if @page.nil?
 
-      # Preload content blocks with their associations for better performance
-      @content_blocks = @page.content_blocks.includes(
-        :string_translations,
+      # Preload content blocks with their associations for better performance.
+      # Do NOT include :string_translations here — block STI collections may
+      # contain Content::Template records that have no string_translations
+      # association, causing AssociationNotFoundError in Rails 8 (branch.rb:85).
+      # Instead, use preload_block_string_translations to selectively preload
+      # only on block types that define the association.
+      content_blocks = @page.content_blocks.includes(
         background_image_file_attachment: :blob
-      )
+      ).load
+      preload_block_string_translations(content_blocks)
+      @content_blocks = content_blocks
       @layout = 'layouts/better_together/page'
       @layout = @page.layout if @page.layout.present?
     end

--- a/app/controllers/better_together/pages_controller.rb
+++ b/app/controllers/better_together/pages_controller.rb
@@ -190,7 +190,7 @@ module BetterTogether
       resource_collection.includes(
         :string_translations,
         page_blocks: {
-          block: [:string_translations, { background_image_file_attachment: :blob }]
+          block: [{ background_image_file_attachment: :blob }]
         }
       )
     end
@@ -206,7 +206,9 @@ module BetterTogether
     end
 
     def preload_page_associations(page)
-      resource_class.includes(page_includes).find(page.id)
+      loaded_page = resource_class.includes(page_includes).find(page.id)
+      preload_block_string_translations(loaded_page.page_blocks.map(&:block))
+      loaded_page
     end
 
     def page_includes
@@ -214,7 +216,7 @@ module BetterTogether
         :string_translations,
         :sidebar_nav,
         { page_blocks: {
-          block: [:string_translations, { background_image_file_attachment: :blob }]
+          block: [{ background_image_file_attachment: :blob }]
         } }
       ]
     end
@@ -251,6 +253,16 @@ module BetterTogether
         *BetterTogether::Content::Block.storext_keys,
         *BetterTogether::Content::Block.extra_permitted_attributes
       ]
+    end
+
+    # Preloads string_translations only on block types that define the association,
+    # avoiding AssociationNotFoundError on STI subclasses (e.g. Content::Template)
+    # that do not have any Mobility string-translated attributes.
+    def preload_block_string_translations(blocks)
+      translatable = blocks.select { |b| b.class.reflect_on_association(:string_translations) }
+      return if translatable.empty?
+
+      ActiveRecord::Associations::Preloader.new(records: translatable, associations: :string_translations).call
     end
   end
 end

--- a/spec/factories/better_together/content/templates.rb
+++ b/spec/factories/better_together/content/templates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :content_template, class: 'BetterTogether::Content::Template' do
+    template_path { 'better_together/content/blocks/template/default' }
+  end
+end

--- a/spec/requests/better_together/pages_controller_spec.rb
+++ b/spec/requests/better_together/pages_controller_spec.rb
@@ -39,6 +39,21 @@ RSpec.describe 'BetterTogether::PagesController', :as_platform_manager do
 
       expect(response).to have_http_status(:ok)
     end
+
+    context 'when the page contains a Content::Template block (no string_translations association)' do
+      before do
+        # Content::Template has no Mobility string attributes — it must not raise
+        # AssociationNotFoundError when preloading string_translations on mixed block types.
+        template_block = create(:content_template)
+        page.page_blocks.create!(block: template_block, position: 1)
+      end
+
+      it 'renders without AssociationNotFoundError' do
+        get better_together.page_path(page.slug, locale:)
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
   end
 
   describe 'GET /:locale/pages/:slug/edit' do


### PR DESCRIPTION
## Problem

Rails 8.0.4 preloader calls `record.association(:string_translations).klass` on every block loaded via `page_includes`. `Content::Template` (and any Block STI subclass without Mobility string-translated attributes) doesn't define `string_translations`, causing:

```
ActiveRecord::AssociationNotFoundError:
  Association named 'string_translations' was not found on BetterTogether::Content::Template
```

This crashes the homepage (`GET /en`) on apps with Template blocks — a regression introduced by #1267.

## Root Cause

`page_includes` and `base_collection` both included:
```ruby
block: [:string_translations, { background_image_file_attachment: :blob }]
```

This puts ALL loaded Block STI instances (including non-translatable types like `Content::Template`) into the `:string_translations` preloader branch. Rails 8's `Preloader::Branch#grouped_records` calls `record.association(name)` even when the reflection is nil, raising immediately.

## Fix

1. Remove `:string_translations` from the `block:` subtree in both `page_includes` and `base_collection`.
2. Add `preload_block_string_translations` — a separate post-load step that uses `ActiveRecord::Associations::Preloader` only on blocks whose class defines `:string_translations` (checked via `reflect_on_association`).

## Tests

Regression test added in `spec/requests/better_together/pages_controller_spec.rb`: creates a page with both a Markdown block (has `string_translations`) and a Template block (does not), then verifies `GET /page` returns 200 without raising.