### PR TITLE
fix: remove invalid :platform includes causing AssociationNotFoundError in CI

### DIFF
--- a/app/controllers/better_together/navigation_areas_controller.rb
+++ b/app/controllers/better_together/navigation_areas_controller.rb
@@ -7,7 +7,7 @@ module BetterTogether
 
     def index
       authorize resource_class
-      @navigation_areas = policy_scope(resource_class.with_translations.includes(:platform))
+      @navigation_areas = policy_scope(resource_class.with_translations)
     end
 
     def show # rubocop:todo Metrics/MethodLength

--- a/app/controllers/better_together/resource_permissions_controller.rb
+++ b/app/controllers/better_together/resource_permissions_controller.rb
@@ -9,7 +9,7 @@ module BetterTogether
     def index
       authorize resource_class
       @resource_permissions = policy_scope(resource_class.with_translations)
-                              .includes(:roles, :platform)
+                              .includes(:roles)
                               .order(:resource_type, :action, :position, :identifier)
       @resource_permissions_by_resource_type = @resource_permissions.group_by(&:resource_type)
       @rbac_nav_counts = {

--- a/app/controllers/better_together/roles_controller.rb
+++ b/app/controllers/better_together/roles_controller.rb
@@ -10,7 +10,7 @@ module BetterTogether
       # Assuming Role class is under the same namespace for consistency
       authorize resource_class # Add this to authorize action
       @roles = policy_scope(resource_class.with_translations)
-               .includes(:resource_permissions, :platform)
+               .includes(:resource_permissions)
                .order(:resource_type, :position, :identifier)
       @roles_by_resource_type = @roles.group_by(&:resource_type)
       @rbac_nav_counts = {


### PR DESCRIPTION
## Problem

PR #1267 added `.includes(:platform)` to three controllers whose models don't have a `:platform` association:

- `RolesController`: `Role` has no `belongs_to :platform`
- `NavigationAreasController`: `NavigationArea` has no `belongs_to :platform`
- `ResourcePermissionsController`: `ResourcePermission` has no `belongs_to :platform`

This causes `AssociationNotFoundError: Association named 'platform' was not found` in both CI rspec runs and production.

## Fix

Remove `:platform` from the `includes` calls on those three controllers. The remaining includes (`:resource_permissions`, `:roles`) are valid.

## Impact

Fixes CI rspec failures on `main` (both rspec matrix jobs failing).