### PR TITLE
chore: add *.log to .gitignore to prevent test log file commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ spec/dummy/storage/*
 
 .env.prod
 spec/dummy/config/master.key
+
+# Prevent accidental commits of test log output files
+*.log


### PR DESCRIPTION
## Problem

An RSpec log file (`rspec_full_run_20251215_184759.log`) was accidentally committed to the repo root on Dec 15 2025 and flagged by GitGuardian (Dec 16 2025) as containing a Generic High Entropy Secret.

The file was removed in commit 87ca87b but remains in git history.

## Root Cause

`.gitignore` had `/log` (covers the `log/` directory) but not `*.log` at the repo root, so a log file saved to the root was not excluded.

## Fix

Add `*.log` to `.gitignore` to prevent future accidental commits of test log output files.

## Note on History

The original commit is still in git history. The secret appears to be a test-generated token (not a production credential), so risk is low. If desired, `git filter-repo` can be used to scrub the history.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>