### PR TITLE
fix(mermaid-diagram): add missing blocks/new/_mermaid_diagram partial

### DIFF
--- a/app/views/better_together/content/blocks/new/_mermaid_diagram.html.erb
+++ b/app/views/better_together/content/blocks/new/_mermaid_diagram.html.erb
@@ -1,0 +1,8 @@
+<div class="fa-stack fa-3x mb-3" role="img" aria-label="<%= block_type.model_name.human %> icon">
+  <i class="fas fa-square fa-stack-2x text-light"></i>
+  <i class="fas fa-diagram-project fa-stack-1x text-dark"></i>
+</div>
+
+<h5 class="text-center">
+  <span aria-hidden="true"><%= block_type.model_name.human %></span>
+</h5>


### PR DESCRIPTION
## Problem

When navigating to the block type picker, `blocks/new/_block.html.erb` renders:

```erb
render partial: "better_together/content/blocks/new/\#{block_type.block_name}"
```

for every registered block type. `MermaidDiagram` (`block_name = 'mermaid_diagram'`) was added without its `new/` picker partial, causing:

```
ActionView::MissingTemplate: Missing partial better_together/content/blocks/new/mermaid_diagram
```

This was reported in Sentry on the production CE app.

## Fix

Add the missing `blocks/new/_mermaid_diagram.html.erb` partial following the same icon + label pattern as all other block type picker cards. Uses `fa-diagram-project` icon, consistent with `page_blocks/block_types/_mermaid_diagram.html.erb`.