### PR TITLE
fix(routing): prevent URI::InvalidURIError on non-default locale + accented slug URLs

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -482,13 +482,22 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
     end
   end
 
-  # Catch all requests without a locale and redirect to the default...
+  # Catch all requests without a locale and redirect to the default locale.
+  # The constraint must check ALL available locales (not just I18n.locale) because
+  # locale is set via before_action *after* route matching. Without this, requests
+  # like /fr/à-propos-de-nous slip through and become /en/fr/à-propos-de-nous,
+  # causing URI::InvalidURIError when ActionDispatch calls URI.parse on the redirect URL.
+  # The redirect also percent-encodes non-ASCII path characters defensively.
   get '*path',
-      to: redirect { |params, _request| "/#{I18n.locale}/#{params[:path]}" },
+      to: redirect { |params, _request|
+        path = params[:path].to_s.gsub(/[^\x00-\x7F]/) do |char|
+          char.bytes.map { |byte| format('%%%02X', byte) }.join
+        end
+        "/#{I18n.default_locale}/#{path}"
+      },
       constraints: lambda { |req|
-        # raise 'error'
-        !req.path.starts_with? "/#{I18n.locale}" and
-          !req.path.starts_with? '/rails'
+        I18n.available_locales.none? { |locale| req.path.start_with?("/#{locale}/") || req.path == "/#{locale}" } and
+          !req.path.start_with?('/rails')
       }
   get '', to: redirect("/#{I18n.default_locale}")
 end

--- a/spec/requests/better_together/locale_redirect_spec.rb
+++ b/spec/requests/better_together/locale_redirect_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# @hermetic
+# Tests for the catch-all locale redirect route.
+# Regression coverage for URI::InvalidURIError on non-default locale + accented slug URLs.
+# Root cause: the constraint only checked I18n.locale (the default, :en), so /fr/... URLs
+# slipped through and were double-prefixed to /en/fr/à-propos-de-nous. ActionDispatch's
+# Redirect#build_response then called URI.parse on the decoded URL and raised.
+RSpec.describe 'Locale redirect catch-all' do
+  let(:default_locale) { I18n.default_locale }
+
+  describe 'paths with a valid locale prefix' do
+    it 'does NOT redirect English-prefixed paths' do
+      get '/en/some-page'
+      expect(response).not_to have_http_status(:redirect)
+    end
+
+    it 'does NOT redirect French-prefixed paths (regression: was redirecting to /en/fr/...)' do
+      get '/fr/some-page'
+      # Must not redirect; should either render or 404 but never issue a redirect
+      expect(response).not_to have_http_status(:moved_permanently)
+      expect(response).not_to have_http_status(:found)
+    end
+
+    it 'does NOT raise URI::InvalidURIError for French paths with accented slugs' do
+      expect do
+        get '/fr/%C3%A0-propos-de-nous'
+      end.not_to raise_error
+    end
+
+    it 'does NOT redirect French paths with accented slugs to a double-locale URL' do
+      get '/fr/%C3%A0-propos-de-nous'
+      if response.redirect?
+        # If somehow a redirect fires, it must not double-prefix the locale
+        expect(response.location).not_to include('/en/fr/')
+      end
+    end
+  end
+
+  describe 'paths without any locale prefix' do
+    it 'redirects bare paths to the default locale' do
+      get '/some-page'
+      expect(response).to have_http_status(:redirect)
+      expect(response.location).to include("/#{default_locale}/some-page")
+    end
+
+    it 'percent-encodes non-ASCII characters in the redirected path' do
+      get '/caf%C3%A9'
+      expect(response).to have_http_status(:redirect)
+      # The redirect location must be valid ASCII (no raw non-ASCII chars)
+      expect(response.location).to match(%r{/#{default_locale}/})
+      expect(response.location.encoding).to eq(Encoding::UTF_8)
+      expect(response.location).not_to match(/[^\x00-\x7F]/)
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Sentry issue **#87339162** (281+ hits over several months) on NNL (newcomernavigatornl.ca):

```
URI::InvalidURIError: URI must be ascii only "/en/fr/à-propos-de-nous"
```

**Root cause** (confirmed via full Sentry stack trace): The catch-all locale redirect route:

```ruby
get '*path',
    to: redirect { |params, _request| "/\#{I18n.locale}/\#{params[:path]}" },
    constraints: lambda { |req|
    }
```

...uses `I18n.locale` (the _default_ locale, `:en`) in the constraint. Since `I18n.locale` is set via `before_action :set_locale` **after** route matching, French URLs like `/fr/à-propos-de-nous` were never recognised as already having a locale prefix. They matched the catch-all and got double-prefixed:

`/fr/à-propos-de-nous` → redirect → `/en/fr/à-propos-de-nous`

`ActionDispatch::Routing::Redirect#build_response` then calls `URI.parse` on the decoded redirect target, which raises `URI::InvalidURIError` because the decoded `à` is non-ASCII.

## Fix

1. **Constraint**: use `I18n.available_locales.none?` to skip the redirect for **any** valid locale prefix, not just the default.
2. **Redirect path**: percent-encode non-ASCII characters as a defensive measure so that any residual edge cases produce valid redirect URLs instead of raising.
3. **Clarity**: use `I18n.default_locale` (a stable constant) instead of `I18n.locale` in the redirect target.
4. **Spec**: `locale_redirect_spec.rb` covering the non-redirect case for already-localised paths and the encoding safety for bare paths.

## Testing

CI rspec suite + new request spec (`spec/requests/better_together/locale_redirect_spec.rb`).