### PR TITLE
fix(security): extend URI encoding + add rack-attack bot/scanner blocklists

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,6 +2,7 @@
 
 module Rack
   # Sets default Rack::Attack configuration
+  # rubocop:disable Metrics/ClassLength
   class Attack
     ### Configure Cache ###
 
@@ -134,20 +135,65 @@ module Rack
       req.path.end_with?('.php')
     end
 
-    # Block suspicious requests for '/etc/password' or wordpress specific paths.
-    # After 3 blocked requests in 10 minutes, block all requests from that IP for 5 minutes.
-    blocklist('fail2ban pentesters') do |req|
-      # `filter` returns truthy value if request fails, or if it's from a previously banned IP
-      # so the request is blocked
-      Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 3, findtime: 10.minutes, bantime: 5.minutes) do
-        # The count for the IP is incremented if the return value is truthy
-        CGI.unescape(req.query_string) =~ %r{/etc/passwd} ||
+    # Block WordPress and common CMS probe paths.
+    # After 3 hits in 10 minutes, block the IP for 5 minutes.
+    blocklist('fail2ban/pentesters') do |req|
+      Rack::Attack::Fail2Ban.filter("pentesters-#{req.ip}", maxretry: 3, findtime: 10.minutes,
+                                                            bantime: 5.minutes) do
+        CGI.unescape(req.query_string).include?('/etc/passwd') ||
           req.path.include?('/etc/passwd') ||
           req.path.include?('wp-admin') ||
           req.path.include?('wp-content') ||
           req.path.include?('wp-files') ||
           req.path.include?('wp-login') ||
-          req.path.include?('.php')
+          req.path.end_with?('.php')
+      end
+    end
+
+    ### Fail2Ban for Scanner/Bot Probes ###
+
+    # Block URL template placeholders used by SEO crawlers and vulnerability scanners
+    # (e.g. /en/shop/[category]/*, /fr/blog/[year]/[month]/[slug]).
+    # These are never valid app paths. After 2 hits in 5 minutes, block for 30 minutes.
+    blocklist('fail2ban/url-template-probes') do |req|
+      Rack::Attack::Fail2Ban.filter("url-template-#{req.ip}", maxretry: 2, findtime: 5.minutes,
+                                                              bantime: 30.minutes) do
+        req.path.match?(/[\[\]*]/)
+      end
+    end
+
+    # Block path traversal attacks (/../, /..\ etc.). Block immediately for 1 hour.
+    blocklist('fail2ban/path-traversal') do |req|
+      Rack::Attack::Fail2Ban.filter("path-traversal-#{req.ip}", maxretry: 1, findtime: 10.minutes,
+                                                                bantime: 1.hour) do
+        req.path.include?('..') || CGI.unescape(req.path).include?('..')
+      end
+    end
+
+    # Block header/URL injection probes (paths with embedded protocol strings).
+    # Block immediately for 1 hour.
+    blocklist('fail2ban/url-injection') do |req|
+      Rack::Attack::Fail2Ban.filter("url-injection-#{req.ip}", maxretry: 1, findtime: 10.minutes,
+                                                               bantime: 1.hour) do
+        req.path.match?(/\s+https?:/i)
+      end
+    end
+
+    # Block common vulnerability scanner paths (env leaks, git config, shell probes, etc.)
+    # After 3 hits in 10 minutes, block for 1 hour.
+    SCANNER_PATH_PATTERNS = %r{
+      /\.env|/\.git/|/\.aws/|/\.ssh/|
+      /etc/shadow|/proc/self|
+      /var/log/|
+      /phpinfo|/xmlrpc\.php|
+      /actuator|
+      /cgi-bin/
+    }xi
+
+    blocklist('fail2ban/vuln-scanner-paths') do |req|
+      Rack::Attack::Fail2Ban.filter("vuln-scanner-#{req.ip}", maxretry: 3, findtime: 10.minutes,
+                                                              bantime: 1.hour) do
+        req.path.match?(SCANNER_PATH_PATTERNS)
       end
     end
 
@@ -171,4 +217,5 @@ module Rack
       [503, {}, ['Blocked']]
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -487,12 +487,13 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
   # locale is set via before_action *after* route matching. Without this, requests
   # like /fr/à-propos-de-nous slip through and become /en/fr/à-propos-de-nous,
   # causing URI::InvalidURIError when ActionDispatch calls URI.parse on the redirect URL.
-  # The redirect also percent-encodes non-ASCII path characters defensively.
+  # Non-ASCII and URI-invalid ASCII characters (brackets, spaces, backslashes, etc.)
+  # are percent-encoded defensively; malformed paths return 400 rather than 500.
   get '*path',
       to: redirect { |params, _request|
-        path = params[:path].to_s.gsub(/[^\x00-\x7F]/) do |char|
-          char.bytes.map { |byte| format('%%%02X', byte) }.join
-        end
+        path = params[:path].to_s
+                            .gsub(/[^\x00-\x7F]/) { |c| c.bytes.map { |b| format('%%%02X', b) }.join }
+                            .gsub(/[\[\]{}\s\\^`|<>]/) { |c| format('%%%02X', c.ord) }
         "/#{I18n.default_locale}/#{path}"
       },
       constraints: lambda { |req|


### PR DESCRIPTION
Extends #1351 URI encoding to cover ASCII-invalid chars (brackets, wildcards) and adds rack-attack Fail2Ban rules for scanner/bot patterns seen in Sentry (url-template-probes, path-traversal, url-injection, vuln-scanner-paths).