### PR TITLE
fix(cache): update RedisCacheStore pool options for Rails 8 compatibility

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,10 +17,11 @@ module Rack
 
     # Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
     if rack_attack_redis
+      # Rails 8 / ActiveSupport 8 changed the pool option API.
+      # pool_size/pool_timeout as top-level kwargs were removed; use pool: { size:, timeout: } instead.
       Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(
         url: rack_attack_redis,
-        pool_size: 5,
-        pool_timeout: 5
+        pool: { size: 5, timeout: 5 }
       )
     end
 


### PR DESCRIPTION
ActiveSupport 8 removed `pool_size`/`pool_timeout` as top-level kwargs on `RedisCacheStore`. Fixes `ArgumentError: unknown keywords: :pool_size, :pool_timeout` (Sentry issue 102848634, 1057+ hits). New API: `pool: { size: 5, timeout: 5 }`.