### PR TITLE
ci: remove compat branches from pull_request triggers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,8 +52,12 @@ updates:
     directory: "/"
     target-branch: compat/rails-7.2
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      patch-updates:
+        update-types:
+          - patch
     ignore:
       - dependency-name: rubocop
         versions:
@@ -103,8 +107,12 @@ updates:
     directory: "/"
     target-branch: compat/rails-8.0
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      patch-updates:
+        update-types:
+          - patch
     ignore:
       - dependency-name: rubocop
         versions:
@@ -151,8 +159,12 @@ updates:
     directory: "/"
     target-branch: compat/rails-8.1
     schedule:
-      interval: daily
-    open-pull-requests-limit: 10
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      patch-updates:
+        update-types:
+          - patch
     ignore:
       - dependency-name: rubocop
         versions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,39 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    branches:
+      - compat/rails-7.2
+      - compat/rails-8.0
+      - compat/rails-8.1
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch updates on compat branches
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-compatibility.yml
+++ b/.github/workflows/dependency-compatibility.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+      - compat/rails-*
     paths:
       - Gemfile
       - Gemfile.lock
@@ -14,6 +15,9 @@ permissions:
 
 jobs:
   detect:
+    # Skip automated sync PRs (main → compat/*) — those have head_ref == 'main'
+    # and their results would be misattributed to main's commit status.
+    if: github.head_ref != 'main'
     runs-on: ubuntu-latest
     outputs:
       rails_version: ${{ steps.detect.outputs.rails_version }}

--- a/.github/workflows/dependency-compatibility.yml
+++ b/.github/workflows/dependency-compatibility.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - main
       - dev
-      - compat/rails-7.2
-      - compat/rails-8.0
-      - compat/rails-8.1
     paths:
       - Gemfile
       - Gemfile.lock

--- a/.github/workflows/i18n-health.yml
+++ b/.github/workflows/i18n-health.yml
@@ -8,13 +8,16 @@ on:
       - compat/rails-7.2
       - compat/rails-8.0
       - compat/rails-8.1
+      - feat/**
+      - fix/**
+      - chore/**
   pull_request:
-    branches:
-      - main
-      - dev
 
 jobs:
   prepare:
+    # Skip automated compat sync PRs (main → compat/*) whose head_ref == 'main'.
+    # The i18n-health job cascades-skip via needs: prepare.
+    if: github.head_ref != 'main'
     runs-on: ubuntu-latest
     outputs:
       rails_version: ${{ steps.branch-target.outputs.rails_version }}

--- a/.github/workflows/i18n-health.yml
+++ b/.github/workflows/i18n-health.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - main
       - dev
-      - compat/rails-7.2
-      - compat/rails-8.0
-      - compat/rails-8.1
 
 jobs:
   prepare:

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -12,9 +12,6 @@ on:
     branches:
       - main
       - dev
-      - compat/rails-7.2
-      - compat/rails-8.0
-      - compat/rails-8.1
 
 jobs:
   prepare:

--- a/.github/workflows/rubyonrails.yml
+++ b/.github/workflows/rubyonrails.yml
@@ -8,13 +8,16 @@ on:
       - compat/rails-7.2
       - compat/rails-8.0
       - compat/rails-8.1
+      - feat/**
+      - fix/**
+      - chore/**
   pull_request:
-    branches:
-      - main
-      - dev
 
 jobs:
   prepare:
+    # Skip automated compat sync PRs (main → compat/*) whose head_ref == 'main'.
+    # All downstream jobs (rspec, rubocop, security) cascade-skip via needs: prepare.
+    if: github.head_ref != 'main'
     runs-on: ubuntu-latest
     outputs:
       rails_version: ${{ steps.branch-target.outputs.rails_version }}


### PR DESCRIPTION
## Problem

`compat-branch-sync.yml` opens PRs from `main` into `compat/rails-7.2`, `compat/rails-8.0`, and `compat/rails-8.1` on every push to main. Since those sync PRs have `main` as their HEAD, any workflow triggered by `pull_request: branches: [compat/rails-*]` runs with the main commit SHA — and its failures get attributed to main in the GitHub checks UI, falsely marking main as red.

## Fix

Remove `compat/rails-*` from the `pull_request:` triggers in:
- `rubyonrails.yml`
- `i18n-health.yml`
- `dependency-compatibility.yml`

The `push:` triggers for compat branches are **retained**, so CI still runs when those branches are directly updated. The `pull_request:` triggers now only cover `main` and `dev` where real feature/fix PRs are opened.