### PR TITLE
fix(security): upgrade devise to 5.0.3 for CVE-2026-32700

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,10 +283,10 @@ GEM
     declarative (0.0.20)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (4.9.4)
+    devise (5.0.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
-      railties (>= 4.1.0)
+      railties (>= 7.0)
       responders
       warden (~> 1.2.3)
     devise-i18n (1.15.0)

--- a/app/controllers/better_together/users/sessions_controller.rb
+++ b/app/controllers/better_together/users/sessions_controller.rb
@@ -7,9 +7,9 @@ module BetterTogether
 
       skip_before_action :check_platform_privacy
 
-      def respond_to_on_destroy
+      def respond_to_on_destroy(non_navigational_status: :no_content)
         respond_to do |format|
-          format.all { head :no_content }
+          format.all { head non_navigational_status }
           format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name), status: :see_other }
         end
       end


### PR DESCRIPTION
Upgrades Devise from 4.9.4 to 5.0.3 to address CVE-2026-32700 / GHSA-57hq-95w6-v4fc on `main`.

Validation:
- `bin/dc-run bash -lc "bundle update devise --conservative"`
- `bin/dc-run bash -lc "bundle exec bundler-audit check --update"`

This branch resolved cleanly without additional compatibility patches.