### PR TITLE
fix(migrations): make historical migrations self-contained

### DIFF
--- a/db/migrate/20250605204408_ensure_all_privacy_columns_default_to_private.rb
+++ b/db/migrate/20250605204408_ensure_all_privacy_columns_default_to_private.rb
@@ -2,13 +2,37 @@
 
 # Ensure that all privacy columns are defaulted to private, as "unlisted" has been removed
 class EnsureAllPrivacyColumnsDefaultToPrivate < ActiveRecord::Migration[7.1]
-  def up
-    load ::BetterTogether::Engine.root.join('lib', 'tasks', 'data_migration.rake').to_s
+  PRIVACY_TABLES = %i[
+    better_together_posts
+    better_together_communities
+    better_together_platforms
+    better_together_pages
+    better_together_email_addresses
+    better_together_phone_numbers
+    better_together_addresses
+    better_together_social_media_accounts
+    better_together_website_links
+    better_together_people
+    better_together_content_blocks
+    better_together_seeds
+    better_together_calendars
+    better_together_geography_maps
+    better_together_places
+    better_together_infrastructure_buildings
+    better_together_infrastructure_floors
+    better_together_infrastructure_rooms
+    better_together_uploads
+    better_together_events
+    better_together_agreements
+    better_together_calls_for_interest
+  ].freeze
 
-    begin
-      Rake::Task['better_together:migrate_data:set_privacy_default_to_private'].invoke
-    rescue RuntimeError
-      Rake::Task['app:better_together:migrate_data:set_privacy_default_to_private'].invoke
+  def up
+    PRIVACY_TABLES.each do |table_name|
+      next unless table_exists?(table_name)
+      next unless column_exists?(table_name, :privacy)
+
+      change_column_default table_name, :privacy, 'private'
     end
   end
 

--- a/db/migrate/20251229000000_add_posts_navigation_items.rb
+++ b/db/migrate/20251229000000_add_posts_navigation_items.rb
@@ -5,32 +5,84 @@ class AddPostsNavigationItems < ActiveRecord::Migration[7.2]
   def up
     puts 'Adding posts navigation items...'
 
-    load BetterTogether::Engine.root.join('lib', 'tasks', 'better_together', 'navigation_items.rake')
+    header_area = ensure_navigation_area(
+      identifier: 'platform-header',
+      name: 'Platform Header',
+      slug: 'platform-header'
+    )
 
-    # Set header posts privacy to 'private' for platform managers only during this migration.
-    # The navigation_items rake task defaults POSTS_PRIVACY to 'public'; here we override that default to 'private' for security,
-    # so posts navigation is initially restricted to platform managers. Platform organizers can later change it to 'public'
-    # via the admin interface.
-    ENV['POSTS_PRIVACY'] = 'private'
+    header_posts = header_area.navigation_items.find_or_initialize_by(identifier: 'posts')
+    header_posts.assign_attributes(
+      title_en: I18n.t('navigation.header.posts', default: 'Posts'),
+      slug_en: 'posts',
+      position: 1,
+      item_type: 'link',
+      route_name: 'posts_url',
+      visible: true,
+      privacy: 'private',
+      visibility_strategy: 'permission',
+      permission_identifier: 'manage_platform',
+      navigation_area: header_area
+    )
+    header_posts.save!
 
-    begin
-      Rake::Task['better_together:navigation_items:create_header_posts_item'].invoke
-    rescue RuntimeError
-      Rake::Task['app:better_together:navigation_items:create_header_posts_item'].invoke
-    end
+    host_area = ensure_navigation_area(
+      identifier: 'platform-host',
+      name: 'Platform Host',
+      slug: 'platform-host'
+    )
 
-    ENV.delete('POSTS_PRIVACY')
+    host_nav = host_area.navigation_items.find_or_initialize_by(identifier: 'host-nav')
+    host_nav.assign_attributes(
+      title_en: 'Host',
+      slug_en: 'host-nav',
+      position: 0,
+      visible: true,
+      protected: true,
+      item_type: 'dropdown',
+      url: '#',
+      privacy: 'private',
+      visibility_strategy: 'permission',
+      permission_identifier: 'view_metrics_dashboard',
+      navigation_area: host_area
+    )
+    host_nav.save!
 
-    # Host posts is always private (no env var needed)
-    begin
-      Rake::Task['better_together:navigation_items:create_host_posts_item'].invoke
-    rescue RuntimeError
-      Rake::Task['app:better_together:navigation_items:create_host_posts_item'].invoke
-    end
+    host_posts = host_nav.children.find_or_initialize_by(identifier: 'host-posts')
+    host_posts.assign_attributes(
+      title_en: 'Posts',
+      slug_en: 'host-posts',
+      position: host_posts[:position] || next_child_position(host_nav),
+      item_type: 'link',
+      route_name: 'posts_url',
+      privacy: 'private',
+      visibility_strategy: 'permission',
+      permission_identifier: 'manage_platform',
+      visible: true,
+      protected: true,
+      navigation_area: host_area
+    )
+    host_posts.save!
   end
 
   def down
     # Remove posts navigation items
     BetterTogether::NavigationItem.where(identifier: %w[posts host-posts]).destroy_all
+  end
+
+  private
+
+  def ensure_navigation_area(identifier:, name:, slug:)
+    BetterTogether::NavigationArea.find_or_initialize_by(identifier:).tap do |area|
+      area.name = name
+      area.slug = slug
+      area.visible = true
+      area.protected = true
+      area.save!
+    end
+  end
+
+  def next_child_position(parent)
+    parent.children.maximum(:position).to_i + 1
   end
 end


### PR DESCRIPTION
## What

Rewrites two historical migrations to be fully self-contained, fixing `db:migrate` failures on fresh installs.

### `20250605204408_ensure_all_privacy_columns_default_to_private`
- Replaces the Rake task invocation with a static `PRIVACY_TABLES` constant and `table_exists?/column_exists?` guards
- Eliminates the runtime dependency on `BetterTogether::Privacy.included_in_models`, which triggers a load of `seed_plantings.rb` before the `better_together_seed_plantings` table exists in a fresh migrate

### `20251229000000_add_posts_navigation_items`
- Inlines navigation item creation directly — no longer depends on `db:seed`
- Idempotent: safe to run multiple times

## Why
Fresh `bin/parallel-setup` and `db:migrate` on clean databases fail without these fixes.

**Origin:** Rescued from `codex/fix-migration-history` Codex session (2026-03-23)