### PR TITLE
fix(federation): idempotent mirror lookup + identifier conflict namespacing

### DIFF
--- a/app/services/better_together/content/federated_page_mirror_service.rb
+++ b/app/services/better_together/content/federated_page_mirror_service.rb
@@ -39,7 +39,15 @@ module BetterTogether
 
       def find_or_initialize_page
         if preserve_remote_uuid? && uuid?(remote_id)
+          # 1. Already mirrored with the same UUID — most common repeat-sync path.
           existing = ::BetterTogether::Page.find_by(id: remote_id)
+          return existing if existing
+
+          # 2. Previously mirrored via the source_id path (e.g. before preserve_remote_uuid
+          #    was enabled on this connection) — prevents duplicate record creation.
+          existing = ::BetterTogether::Page.find_by(
+            platform: connection.source_platform, source_id: remote_id
+          )
           return existing if existing
 
           ::BetterTogether::Page.new(id: remote_id)
@@ -86,9 +94,27 @@ module BetterTogether
       end
 
       def normalized_identifier(page)
-        remote_attributes[:identifier].presence ||
-          page.identifier.presence ||
-          "federated-page-#{remote_id.parameterize.presence || SecureRandom.hex(6)}"
+        # Preserve the existing identifier on a repeat sync — avoids churn on slug/history.
+        return page.identifier if page.persisted?
+
+        base = remote_attributes[:identifier].presence ||
+               "federated-page-#{remote_id.parameterize.presence || SecureRandom.hex(6)}"
+        identifier_or_namespaced(::BetterTogether::Page, base, page.id)
+      end
+
+      # Returns +base+ unchanged when no other record claims it; otherwise prepends the
+      # source platform identifier to prevent a uniqueness validation failure on ingest.
+      def identifier_or_namespaced(model_class, base, exclude_id)
+        return base unless identifier_taken?(model_class, base, exclude_id)
+
+        source_slug = connection.source_platform.identifier.to_s.parameterize.presence || 'remote'
+        "#{source_slug}-#{base}"
+      end
+
+      def identifier_taken?(model_class, identifier, exclude_id)
+        scope = model_class.where(identifier:)
+        scope = scope.where.not(id: exclude_id) if exclude_id.present?
+        scope.exists?
       end
 
       def normalized_source_updated_at

--- a/app/services/better_together/content/federated_post_mirror_service.rb
+++ b/app/services/better_together/content/federated_post_mirror_service.rb
@@ -39,7 +39,15 @@ module BetterTogether
 
       def find_or_initialize_post
         if preserve_remote_uuid? && uuid?(remote_id)
+          # 1. Already mirrored with the same UUID — most common repeat-sync path.
           existing = ::BetterTogether::Post.find_by(id: remote_id)
+          return existing if existing
+
+          # 2. Previously mirrored via the source_id path (e.g. before preserve_remote_uuid
+          #    was enabled on this connection) — prevents duplicate record creation.
+          existing = ::BetterTogether::Post.find_by(
+            platform: connection.source_platform, source_id: remote_id
+          )
           return existing if existing
 
           ::BetterTogether::Post.new(id: remote_id)
@@ -73,9 +81,27 @@ module BetterTogether
       end
 
       def normalized_identifier(post)
-        remote_attributes[:identifier].presence ||
-          post.identifier.presence ||
-          "federated-post-#{remote_id.parameterize.presence || SecureRandom.hex(6)}"
+        # Preserve the existing identifier on a repeat sync — avoids churn on slug/history.
+        return post.identifier if post.persisted?
+
+        base = remote_attributes[:identifier].presence ||
+               "federated-post-#{remote_id.parameterize.presence || SecureRandom.hex(6)}"
+        identifier_or_namespaced(::BetterTogether::Post, base, post.id)
+      end
+
+      # Returns +base+ unchanged when no other record claims it; otherwise prepends the
+      # source platform identifier to prevent a uniqueness validation failure on ingest.
+      def identifier_or_namespaced(model_class, base, exclude_id)
+        return base unless identifier_taken?(model_class, base, exclude_id)
+
+        source_slug = connection.source_platform.identifier.to_s.parameterize.presence || 'remote'
+        "#{source_slug}-#{base}"
+      end
+
+      def identifier_taken?(model_class, identifier, exclude_id)
+        scope = model_class.where(identifier:)
+        scope = scope.where.not(id: exclude_id) if exclude_id.present?
+        scope.exists?
       end
 
       def normalized_source_updated_at

--- a/app/services/better_together/federated_event_mirror_service.rb
+++ b/app/services/better_together/federated_event_mirror_service.rb
@@ -2,6 +2,8 @@
 
 module BetterTogether
   # Imports or updates a mirrored Event record from a connected remote platform.
+  # rubocop:disable Metrics/ClassLength -- Event service requires timezone validation and
+  #   event-host management that the simpler Post/Page services do not.
   class FederatedEventMirrorService
     def initialize(connection:, remote_attributes:, remote_id:, preserve_remote_uuid: false, source_updated_at: nil)
       @connection = connection
@@ -39,7 +41,15 @@ module BetterTogether
 
     def find_or_initialize_event
       if preserve_remote_uuid? && uuid?(remote_id)
+        # 1. Already mirrored with the same UUID — most common repeat-sync path.
         existing = ::BetterTogether::Event.find_by(id: remote_id)
+        return existing if existing
+
+        # 2. Previously mirrored via the source_id path (e.g. before preserve_remote_uuid
+        #    was enabled on this connection) — prevents duplicate record creation.
+        existing = ::BetterTogether::Event.find_by(
+          platform: connection.source_platform, source_id: remote_id
+        )
         return existing if existing
 
         ::BetterTogether::Event.new(id: remote_id)
@@ -83,9 +93,25 @@ module BetterTogether
     end
 
     def normalized_identifier(event)
-      remote_attributes[:identifier].presence ||
-        event.identifier.presence ||
-        "federated-event-#{remote_id.parameterize.presence || SecureRandom.hex(6)}"
+      # Preserve the existing identifier on a repeat sync — avoids churn on slug/history.
+      return event.identifier if event.persisted?
+
+      base = remote_attributes[:identifier].presence ||
+             "federated-event-#{remote_id.parameterize.presence || SecureRandom.hex(6)}"
+      identifier_or_namespaced(::BetterTogether::Event, base, event.id)
+    end
+
+    def identifier_or_namespaced(model_class, base, exclude_id)
+      return base unless identifier_taken?(model_class, base, exclude_id)
+
+      source_slug = connection.source_platform.identifier.to_s.parameterize.presence || 'remote'
+      "#{source_slug}-#{base}"
+    end
+
+    def identifier_taken?(model_class, identifier, exclude_id)
+      scope = model_class.where(identifier:)
+      scope = scope.where.not(id: exclude_id) if exclude_id.present?
+      scope.exists?
     end
 
     def normalized_timezone
@@ -112,3 +138,4 @@ module BetterTogether
     end
   end
 end
+# rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
## Summary

- **Duplicate record prevention on `preserve_remote_uuid` path**: all three mirror services (Post, Page, Event) now check `source_id` before creating a new record with the remote UUID, preventing duplicates when a connection transitions from `source_id` tracking to UUID preservation
- **Identifier conflict namespacing**: extracted `identifier_taken?` / `identifier_or_namespaced` helpers that prepend the source platform slug to an incoming identifier when a local record already holds it, preventing `FriendlySlug has already been taken` failures on cross-platform sync
- **Rubocop**: extracted helpers resolve the `Metrics/AbcSize` violation on `normalized_identifier` in all three services; `FederatedEventMirrorService` carries a targeted `ClassLength` disable because its timezone validation and event-host management are legitimately larger responsibilities than the simpler Post/Page services

## Background

Both bugs were surfaced during an end-to-end federation sync eval across 5 staging apps (CE, BTR, NLO, NLVenues, NNL). Phase C ingest was failing with uniqueness validation errors when:
1. Phase B created identically-slugged content on multiple apps and Phase C re-ingested without the namespace guard
2. A connection had previously used `source_id` tracking before `preserve_remote_uuid` was enabled, causing `find_or_initialize_by(id:)` to create a duplicate instead of finding the existing record

## Test plan

- [ ] Verify existing mirror service specs pass (`bundle exec rspec spec/services/better_together/content/federated_post_mirror_service_spec.rb spec/services/better_together/content/federated_page_mirror_service_spec.rb spec/services/better_together/federated_event_mirror_service_spec.rb`)
- [ ] Run federation sync eval on staging: `python3 scripts/federation_sync_eval.py --phase sync` — confirm Phase C passes without uniqueness errors
- [ ] Spot-check identifier namespacing: create a Post on CE with a slug that already exists on BTR, trigger sync, confirm mirrored record gets `ce-staging-<slug>` identifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)