### PR TITLE
fix(ci): stabilize setup wizard base platform spec on main

### DIFF
--- a/spec/requests/better_together/setup_wizard_steps_controller_spec.rb
+++ b/spec/requests/better_together/setup_wizard_steps_controller_spec.rb
@@ -422,18 +422,34 @@ module BetterTogether # :nodoc:
 
       describe '#base_platform' do
         before do
+          @original_host_platform_ids = BetterTogether::Platform.where(host: true).pluck(:id)
+          BetterTogether::Platform.where(host: true).update_all(host: false)
           # rubocop:disable RSpec/MessageChain
           allow(controller).to receive_message_chain(:helpers, :base_url).and_return('http://test.example.com')
           # rubocop:enable RSpec/MessageChain
         end
 
-        it 'creates a platform with default attributes' do
+        after do
+          BetterTogether::Platform.where(id: @original_host_platform_ids).update_all(host: true)
+        end
+
+        it 'initializes a host platform with default attributes when one does not exist' do
           platform = controller.send(:base_platform)
           expect(platform).to be_a(Platform)
           expect(platform.privacy).to eq('private')
           expect(platform.protected).to be true
           expect(platform.host).to be true
           expect(platform.time_zone).to eq(Time.zone.name)
+        end
+
+        it 'returns the existing host platform unchanged when one already exists' do
+          existing_platform = BetterTogether::Platform.find(@original_host_platform_ids.first)
+          existing_platform.update_columns(host: true, privacy: 'public')
+
+          platform = controller.send(:base_platform)
+
+          expect(platform).to eq(existing_platform)
+          expect(platform.privacy).to eq('public')
         end
       end
     end


### PR DESCRIPTION
## Summary
- fix the `main` CI failure in `spec/requests/better_together/setup_wizard_steps_controller_spec.rb`
- make `#base_platform` specs cover both code paths explicitly
- stop assuming the method always initializes a brand-new private host platform

## Root Cause
The failing `main` run was:
- Actions run: `23555208996`
- Workflow: `Ruby on Rails CI`
- Failing job: `rspec (3.4.4, 8.0.3)`

The uploaded RSpec JSON artifact showed one failure:
- `BetterTogether::SetupWizardStepsController private methods #base_platform creates a platform with default attributes`

That spec expected `privacy == 'private'`, but on `main` the method can legally return an existing host platform unchanged. In that case the existing record's privacy was `public`, so the spec was asserting the wrong contract.

## Changes
- reset host flags inside the example group so the default-initialization branch is tested deterministically
- add an explicit example covering the existing-host branch
- preserve host flags after each example to avoid leaking state

## Validation
- `./bin/dc-run bundle exec rspec spec/requests/better_together/setup_wizard_steps_controller_spec.rb --format documentation --example "initializes a host platform with default attributes when one does not exist"`
- `./bin/dc-run bundle exec rspec spec/requests/better_together/setup_wizard_steps_controller_spec.rb --format documentation --example "returns the existing host platform unchanged when one already exists"`
- `./bin/dc-run bundle exec rubocop spec/requests/better_together/setup_wizard_steps_controller_spec.rb`
