### PR TITLE
fix(federation): mirror remote content onto target platform

### DIFF
--- a/app/services/better_together/content/federated_page_mirror_service.rb
+++ b/app/services/better_together/content/federated_page_mirror_service.rb
@@ -46,13 +46,13 @@ module BetterTogether
           # 2. Previously mirrored via the source_id path (e.g. before preserve_remote_uuid
           #    was enabled on this connection) — prevents duplicate record creation.
           existing = ::BetterTogether::Page.find_by(
-            platform: connection.source_platform, source_id: remote_id
+            platform: connection.target_platform, source_id: remote_id
           )
           return existing if existing
 
           ::BetterTogether::Page.new(id: remote_id)
         else
-          ::BetterTogether::Page.find_or_initialize_by(platform: connection.source_platform, source_id: remote_id)
+          ::BetterTogether::Page.find_or_initialize_by(platform: connection.target_platform, source_id: remote_id)
         end
       end
 
@@ -86,7 +86,7 @@ module BetterTogether
 
       def mirror_tracking_attributes
         {
-          platform: connection.source_platform,
+          platform: connection.target_platform,
           source_id: effective_preserve_remote_uuid? ? nil : remote_id,
           source_updated_at: normalized_source_updated_at,
           last_synced_at: Time.current

--- a/app/services/better_together/content/federated_post_mirror_service.rb
+++ b/app/services/better_together/content/federated_post_mirror_service.rb
@@ -46,13 +46,13 @@ module BetterTogether
           # 2. Previously mirrored via the source_id path (e.g. before preserve_remote_uuid
           #    was enabled on this connection) — prevents duplicate record creation.
           existing = ::BetterTogether::Post.find_by(
-            platform: connection.source_platform, source_id: remote_id
+            platform: connection.target_platform, source_id: remote_id
           )
           return existing if existing
 
           ::BetterTogether::Post.new(id: remote_id)
         else
-          ::BetterTogether::Post.find_or_initialize_by(platform: connection.source_platform, source_id: remote_id)
+          ::BetterTogether::Post.find_or_initialize_by(platform: connection.target_platform, source_id: remote_id)
         end
       end
 
@@ -68,7 +68,7 @@ module BetterTogether
           privacy: remote_attributes[:privacy].presence || 'public',
           published_at: remote_attributes[:published_at],
           creator_id: remote_attributes[:creator_id],
-          platform: connection.source_platform
+          platform: connection.target_platform
         }.merge(post_sync_attributes)
       end
 

--- a/app/services/better_together/federated_event_mirror_service.rb
+++ b/app/services/better_together/federated_event_mirror_service.rb
@@ -48,13 +48,13 @@ module BetterTogether
         # 2. Previously mirrored via the source_id path (e.g. before preserve_remote_uuid
         #    was enabled on this connection) — prevents duplicate record creation.
         existing = ::BetterTogether::Event.find_by(
-          platform: connection.source_platform, source_id: remote_id
+          platform: connection.target_platform, source_id: remote_id
         )
         return existing if existing
 
         ::BetterTogether::Event.new(id: remote_id)
       else
-        ::BetterTogether::Event.find_or_initialize_by(platform: connection.source_platform, source_id: remote_id)
+        ::BetterTogether::Event.find_or_initialize_by(platform: connection.target_platform, source_id: remote_id)
       end
     end
 
@@ -79,7 +79,7 @@ module BetterTogether
         identifier: normalized_identifier(record),
         privacy: remote_attributes[:privacy].presence || 'public',
         creator_id: remote_attributes[:creator_id],
-        platform: connection.source_platform,
+        platform: connection.target_platform,
         source_id: effective_preserve_remote_uuid? ? nil : remote_id,
         source_updated_at: normalized_source_updated_at,
         last_synced_at: Time.current

--- a/spec/services/better_together/content/federated_content_ingest_service_spec.rb
+++ b/spec/services/better_together/content/federated_content_ingest_service_spec.rb
@@ -135,10 +135,17 @@ module BetterTogether # :nodoc:
 
         described_class.call(connection:, seeds:)
 
+        post = BetterTogether::Post.find_by(identifier: 'remote-post')
+        page = BetterTogether::Page.find_by(identifier: 'remote-page')
+        event = BetterTogether::Event.find_by(identifier: 'remote-event')
+
         expect(Current.platform).to eq(previous_platform)
-        expect(BetterTogether::Post.find_by(identifier: 'remote-post')).to be_remote_to_platform(target_platform)
-        expect(BetterTogether::Page.find_by(identifier: 'remote-page')).to be_remote_to_platform(target_platform)
-        expect(BetterTogether::Event.find_by(identifier: 'remote-event')).to be_remote_to_platform(target_platform)
+        expect(post.platform).to eq(target_platform)
+        expect(post.source_id).to be_present
+        expect(page.platform).to eq(target_platform)
+        expect(page.source_id).to eq('legacy-page-42')
+        expect(event.platform).to eq(target_platform)
+        expect(event.source_id).to eq('legacy-event-42')
       end
 
       it 'requires a connection' do

--- a/spec/services/better_together/content/federated_page_mirror_service_spec.rb
+++ b/spec/services/better_together/content/federated_page_mirror_service_spec.rb
@@ -40,7 +40,7 @@ module BetterTogether # :nodoc:
         ).call
 
         expect(page.id).not_to eq(remote_id)
-        expect(page.platform).to eq(source_platform)
+        expect(page.platform).to eq(target_platform)
         expect(page.source_id).to eq(remote_id)
         expect(page.last_synced_at).to be_present
       end
@@ -66,7 +66,7 @@ module BetterTogether # :nodoc:
 
         expect(page.id).to eq(remote_id)
         expect(page.source_id).to be_nil
-        expect(page.platform).to eq(source_platform)
+        expect(page.platform).to eq(external_target)
       end
 
       it 'falls back to source_id for non-UUID remote identifiers' do
@@ -79,7 +79,7 @@ module BetterTogether # :nodoc:
 
         expect(page.id).not_to eq('legacy-page-42')
         expect(page.source_id).to eq('legacy-page-42')
-        expect(page.platform).to eq(source_platform)
+        expect(page.platform).to eq(target_platform)
       end
 
       it 'updates an existing mirrored page on repeat import' do

--- a/spec/services/better_together/content/federated_post_mirror_service_spec.rb
+++ b/spec/services/better_together/content/federated_post_mirror_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe BetterTogether::Content::FederatedPostMirrorService do
       ).call
 
       expect(post.id).not_to eq(remote_id)
-      expect(post.platform).to eq(source_platform)
+      expect(post.platform).to eq(target_platform)
       expect(post.source_id).to eq(remote_id)
       expect(post.last_synced_at).to be_present
     end
@@ -63,7 +63,7 @@ RSpec.describe BetterTogether::Content::FederatedPostMirrorService do
 
       expect(post.id).to eq(remote_id)
       expect(post.source_id).to be_nil
-      expect(post.platform).to eq(source_platform)
+      expect(post.platform).to eq(external_target)
     end
 
     it 'falls back to source_id for non-UUID remote identifiers' do
@@ -76,7 +76,7 @@ RSpec.describe BetterTogether::Content::FederatedPostMirrorService do
 
       expect(post.id).not_to eq('legacy-post-42')
       expect(post.source_id).to eq('legacy-post-42')
-      expect(post.platform).to eq(source_platform)
+      expect(post.platform).to eq(target_platform)
     end
 
     it 'updates an existing mirrored post on repeat import' do

--- a/spec/services/better_together/federated_event_mirror_service_spec.rb
+++ b/spec/services/better_together/federated_event_mirror_service_spec.rb
@@ -41,7 +41,7 @@ module BetterTogether # :nodoc:
         ).call
 
         expect(event.id).not_to eq(remote_id)
-        expect(event.platform).to eq(source_platform)
+        expect(event.platform).to eq(target_platform)
         expect(event.source_id).to eq(remote_id)
         expect(event.last_synced_at).to be_present
         expect(event.event_hosts.map(&:host)).to include(source_platform)
@@ -68,7 +68,7 @@ module BetterTogether # :nodoc:
 
         expect(event.id).to eq(remote_id)
         expect(event.source_id).to be_nil
-        expect(event.platform).to eq(source_platform)
+        expect(event.platform).to eq(external_target)
         expect(event.event_hosts.map(&:host)).to include(source_platform)
       end
 
@@ -82,7 +82,7 @@ module BetterTogether # :nodoc:
 
         expect(event.id).not_to eq('legacy-event-42')
         expect(event.source_id).to eq('legacy-event-42')
-        expect(event.platform).to eq(source_platform)
+        expect(event.platform).to eq(target_platform)
         expect(event.event_hosts.map(&:host)).to include(source_platform)
       end
 


### PR DESCRIPTION
## Summary
- mirror federated remote content onto `connection.target_platform` instead of `connection.source_platform`
- update the mirror-service and ingest regression specs to cover the corrected target-platform behavior
- fix the remote federation regression exposed when upgrading a staging app to CE `main`

## Validation
- `./bin/dc-run bundle exec rspec spec/services/better_together/content/federated_post_mirror_service_spec.rb spec/services/better_together/content/federated_page_mirror_service_spec.rb spec/services/better_together/federated_event_mirror_service_spec.rb spec/services/better_together/content/federated_content_ingest_service_spec.rb --format documentation`
- `./bin/dc-run bundle exec rubocop app/services/better_together/content/federated_post_mirror_service.rb app/services/better_together/content/federated_page_mirror_service.rb app/services/better_together/federated_event_mirror_service.rb spec/services/better_together/content/federated_post_mirror_service_spec.rb spec/services/better_together/content/federated_page_mirror_service_spec.rb spec/services/better_together/federated_event_mirror_service_spec.rb spec/services/better_together/content/federated_content_ingest_service_spec.rb`
- staging smoke: `python3 scripts/federation_sync_eval.py --scenario ce_multiplatform_mesh --phase sync --apps ce,btr --http-sync --json`
  - result: `24/24 passed`, `0 failed`
  - artifact: `/home/rob/bts-cloud/n8n/management-tool/logs/federation-eval/eval-20260326-012120-report.md`
