### PR TITLE
fix(security): allow configured asset host in CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,25 +1,20 @@
 # frozen_string_literal: true
 
 # See: https://guides.rubyonrails.org/security.html#content-security-policy
+require_relative '../../lib/better_together/content_security_policy_sources'
+
 Rails.application.configure do
   config.content_security_policy do |p|
     # Base policy
     p.default_src :self
     p.base_uri    :self
 
-    # Allow JS from self (importmap), blob for ES module shims, and CDN sources used by importmap pins
-    p.script_src  :self, :blob,
-                  'https://cdn.jsdelivr.net',
-                  'https://cdnjs.cloudflare.com',
-                  'https://unpkg.com',
-                  'https://ga.jspm.io'
-    p.style_src   :self, :unsafe_inline, # allow inline styles for ActionText/Trix
-                  'https://cdn.jsdelivr.net',
-                  'https://cdnjs.cloudflare.com',
-                  'https://unpkg.com'
-    p.img_src     :self, :data, :blob,
-                  'https://*.tile.openstreetmap.org' # Leaflet map tiles
-    p.font_src    :self, :data
+    # Allow JS from self (importmap), blob for ES module shims, CDN sources used by importmap pins,
+    # and the configured asset host when host apps serve digested assets from a separate CDN domain.
+    p.script_src(*BetterTogether::ContentSecurityPolicySources.script_sources)
+    p.style_src(*BetterTogether::ContentSecurityPolicySources.style_sources)
+    p.img_src(*BetterTogether::ContentSecurityPolicySources.img_sources)
+    p.font_src(*BetterTogether::ContentSecurityPolicySources.font_sources)
     p.connect_src :self,
                   :wss # ActionCable WebSocket connections
     p.form_action :self

--- a/lib/better_together/content_security_policy_sources.rb
+++ b/lib/better_together/content_security_policy_sources.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'uri'
+
+module BetterTogether
+  # Computes CSP source lists, including an optional configured asset host origin.
+  module ContentSecurityPolicySources
+    module_function
+
+    SCRIPT_SOURCES = [
+      :self,
+      :blob,
+      'https://cdn.jsdelivr.net',
+      'https://cdnjs.cloudflare.com',
+      'https://unpkg.com',
+      'https://ga.jspm.io'
+    ].freeze
+
+    STYLE_SOURCES = [
+      :self,
+      :unsafe_inline,
+      'https://cdn.jsdelivr.net',
+      'https://cdnjs.cloudflare.com',
+      'https://unpkg.com'
+    ].freeze
+
+    IMG_SOURCES = [
+      :self,
+      :data,
+      :blob,
+      'https://*.tile.openstreetmap.org'
+    ].freeze
+
+    FONT_SOURCES = %i[self data].freeze
+
+    def script_sources(raw_asset_host = ENV.fetch('ASSET_HOST', nil))
+      with_asset_host(SCRIPT_SOURCES, raw_asset_host)
+    end
+
+    def style_sources(raw_asset_host = ENV.fetch('ASSET_HOST', nil))
+      with_asset_host(STYLE_SOURCES, raw_asset_host)
+    end
+
+    def img_sources(raw_asset_host = ENV.fetch('ASSET_HOST', nil))
+      with_asset_host(IMG_SOURCES, raw_asset_host)
+    end
+
+    def font_sources(raw_asset_host = ENV.fetch('ASSET_HOST', nil))
+      with_asset_host(FONT_SOURCES, raw_asset_host)
+    end
+
+    def asset_host_source(raw_asset_host = ENV.fetch('ASSET_HOST', nil))
+      asset_host = raw_asset_host.to_s.strip
+      return nil if asset_host.empty?
+
+      normalized = asset_host.include?('://') ? asset_host : "https://#{asset_host}"
+      uri = URI.parse(normalized)
+      host = uri.host
+      return nil if host.nil? || host.empty?
+
+      "#{uri.scheme || 'https'}://#{host}#{normalized_port(uri)}"
+    rescue URI::InvalidURIError
+      nil
+    end
+
+    def with_asset_host(sources, raw_asset_host = ENV.fetch('ASSET_HOST', nil))
+      asset_host = asset_host_source(raw_asset_host)
+      return sources.dup unless asset_host
+
+      (sources + [asset_host]).uniq
+    end
+
+    def normalized_port(uri)
+      return '' if uri.port.nil? || [80, 443].include?(uri.port)
+
+      ":#{uri.port}"
+    end
+  end
+end

--- a/spec/lib/better_together/content_security_policy_sources_spec.rb
+++ b/spec/lib/better_together/content_security_policy_sources_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BetterTogether::ContentSecurityPolicySources do
+  describe '.asset_host_source' do
+    it 'returns nil when ASSET_HOST is blank' do
+      expect(described_class.asset_host_source(nil)).to be_nil
+      expect(described_class.asset_host_source('')).to be_nil
+    end
+
+    it 'normalizes a full asset host URL to its origin' do
+      expect(described_class.asset_host_source('https://cdn-assets.newfoundlandlabrador.online/assets'))
+        .to eq('https://cdn-assets.newfoundlandlabrador.online')
+    end
+
+    it 'defaults a bare hostname to https' do
+      expect(described_class.asset_host_source('cdn-assets.newfoundlandlabrador.online'))
+        .to eq('https://cdn-assets.newfoundlandlabrador.online')
+    end
+
+    it 'preserves non-default ports' do
+      expect(described_class.asset_host_source('https://assets.example.test:8443/static'))
+        .to eq('https://assets.example.test:8443')
+    end
+  end
+
+  describe '.style_sources' do
+    it 'includes the configured asset host origin' do
+      sources = described_class.style_sources('https://cdn-assets.newfoundlandlabrador.online/assets')
+
+      expect(sources).to include('https://cdn-assets.newfoundlandlabrador.online')
+    end
+
+    it 'does not duplicate the asset host origin' do
+      sources = described_class.style_sources('https://cdn.jsdelivr.net/assets')
+
+      expect(sources.count('https://cdn.jsdelivr.net')).to eq(1)
+    end
+  end
+
+  describe '.script_sources' do
+    it 'includes the configured asset host origin' do
+      sources = described_class.script_sources('https://cdn-assets.newfoundlandlabrador.online/assets')
+
+      expect(sources).to include('https://cdn-assets.newfoundlandlabrador.online')
+    end
+  end
+
+  describe '.font_sources' do
+    it 'includes the configured asset host origin' do
+      sources = described_class.font_sources('https://cdn-assets.newfoundlandlabrador.online/assets')
+
+      expect(sources).to include('https://cdn-assets.newfoundlandlabrador.online')
+    end
+  end
+
+  describe '.img_sources' do
+    it 'includes the configured asset host origin' do
+      sources = described_class.img_sources('https://cdn-assets.newfoundlandlabrador.online/assets')
+
+      expect(sources).to include('https://cdn-assets.newfoundlandlabrador.online')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- allow the configured ASSET_HOST origin in CE CSP directives
- keep CSP source-list construction centralized in a small helper
- add regression coverage for asset-host origin normalization and inclusion

## Why
Host apps serving assets from a CDN origin were rendering unstyled because the CDN stylesheet URLs were blocked by CSP.

## Validation
- bundle exec rubocop on touched CE files
- direct Ruby sanity check for asset-host origin handling
- added targeted spec coverage for the CSP source helper
