### PR TITLE
fix: make agreement generation non-destructive by default

### DIFF
--- a/lib/tasks/generate.rake
+++ b/lib/tasks/generate.rake
@@ -61,9 +61,9 @@ namespace :better_together do # rubocop:todo Metrics/BlockLength
       BetterTogether::SetupWizardBuilder.build(clear: true)
     end
 
-    desc 'Generate default Agreement data'
+    desc 'Generate default Agreement data (set CLEAR=1 to rebuild from scratch)'
     task agreements: :environment do
-      BetterTogether::AgreementBuilder.build(clear: true)
+      BetterTogether::AgreementBuilder.build(clear: ENV['CLEAR'].to_s == '1')
     end
 
     desc 'Generate default event and Joatu categories'

--- a/spec/tasks/better_together/generate_agreements_spec.rb
+++ b/spec/tasks/better_together/generate_agreements_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+# rubocop:disable RSpec/DescribeClass, RSpec/SpecFilePathFormat
+RSpec.describe 'better_together:generate:agreements', type: :task do
+  around do |example|
+    previous_clear = ENV.delete('CLEAR')
+    example.run
+    ENV['CLEAR'] = previous_clear
+  end
+
+  before do
+    Rake.application = Rake::Application.new
+    load BetterTogether::Engine.root.join('lib/tasks/generate.rake')
+    Rake::Task.define_task(:environment)
+    Current.platform = BetterTogether::Platform.find_by(host: true)
+    task.reenable
+  end
+
+  after do
+    Current.platform = nil
+  end
+
+  let(:task) { Rake::Task['better_together:generate:agreements'] }
+
+  it 'preserves existing agreement participation by default while seeding missing agreements' do
+    agreement = BetterTogether::Agreement.find_by!(identifier: 'privacy_policy')
+    participant = create(
+      :better_together_agreement_participant,
+      agreement:,
+      accepted_at: Time.current
+    )
+
+    task.invoke
+
+    expect(BetterTogether::AgreementParticipant.exists?(participant.id)).to be(true)
+    expect(
+      BetterTogether::Agreement.find_by(identifier: 'content_publishing_agreement')&.page&.slug
+    ).to eq('content-contributor-agreement')
+  end
+
+  it 'supports explicit destructive rebuilds when CLEAR=1 is set' do
+    agreement = BetterTogether::Agreement.find_by!(identifier: 'privacy_policy')
+    create(
+      :better_together_agreement_participant,
+      agreement:,
+      accepted_at: Time.current
+    )
+
+    ENV['CLEAR'] = '1'
+
+    task.invoke
+
+    expect(BetterTogether::AgreementParticipant.count).to eq(0)
+    expect(BetterTogether::Agreement.find_by!(identifier: 'content_publishing_agreement')).to be_present
+  end
+end
+# rubocop:enable RSpec/DescribeClass, RSpec/SpecFilePathFormat


### PR DESCRIPTION
## Summary
- make `better_together:generate:agreements` preserve existing agreement records and participation by default
- require `CLEAR=1` for the old destructive rebuild behavior
- add task coverage for both the default safe path and the explicit destructive path

## Why
`communityengine.app` was missing the seeded `content_publishing_agreement` even though the release branch already contained the builder logic for it. Repairing that in production required running the agreements generator. While doing that, I confirmed the current task implementation always calls `AgreementBuilder.build(clear: true)`, which deletes all agreements and agreement participation rows before rebuilding.

The source fix here changes the task default to the non-destructive path that operators actually need for post-deploy agreement repair. Full rebuilds are still available when they are explicitly intended.

## Validation
- `bin/dc-run bundle exec rspec spec/builders/better_together/agreement_builder_spec.rb spec/tasks/better_together/generate_agreements_spec.rb`
- `bin/dc-run bundle exec rubocop lib/tasks/generate.rake spec/tasks/better_together/generate_agreements_spec.rb spec/builders/better_together/agreement_builder_spec.rb`
- `bin/dc-run bundle exec i18n-tasks health`

## Production note
I used the live repair path on `communityengine.app` before landing this source fix, so the app now has the missing `content_publishing_agreement` and linked page. This PR is the follow-up to make that repair path safe by default going forward.