### PR TITLE
fix(middleware): cache host platform UUID instead of AR object

### DIFF
--- a/app/middleware/better_together/platform_context_middleware.rb
+++ b/app/middleware/better_together/platform_context_middleware.rb
@@ -38,9 +38,15 @@ module BetterTogether
     private
 
     def cached_host_platform
-      Rails.cache.fetch('better_together/host_platform', expires_in: 5.minutes) do
-        BetterTogether::Platform.find_by(host: true)
+      # Cache only the UUID to avoid serializing an AR object into the cache store.
+      # Caching a full ActiveRecord object as YAML triggers Psych::DisallowedClass on
+      # read when Psych safe-load mode is active (Psych 4 / Ruby 3.1+), causing every
+      # request to 500 after the first cache write. Storing only the UUID is safe and
+      # still eliminates the DB query on the hot path.
+      id = Rails.cache.fetch('better_together/host_platform_id', expires_in: 5.minutes) do
+        BetterTogether::Platform.where(host: true).pick(:id)
       end
+      id ? BetterTogether::Platform.find_by(id: id) : nil
     end
   end
 end


### PR DESCRIPTION
Caching a full ActiveRecord object via Rails.cache serializes it as YAML. Psych 4 (Ruby 3.1+) uses safe-load by default and raises Psych::DisallowedClass when reading back an AR object, causing every request to 500 after the first cache write cycle.

Fix: store only the host platform UUID in cache (via .pick(:id)) and look up the record on cache hit. This avoids YAML-serializing an AR object entirely while preserving the hot-path DB query elimination.

## Summary

Describe the change and the motivation.

## Evidence Tier

Select one:

- [ ] Docs-only
- [ ] Backend / behavioral
- [ ] UI / workflow

## Evidence Checklist

- [ ] Tests added/updated and passing (`bin/ci`).
- [ ] Lint and security checks (`rubocop`, `brakeman`, `bundler-audit`).
- [ ] Documentation updated under `docs/` describing new/changed functionality.
- [ ] Mermaid diagram source updated under `docs/diagrams/source/` when architecture or workflow changed.
- [ ] Rendered PNGs regenerated with `bin/render_diagrams` and committed.
- [ ] Screenshot spec added or updated under `spec/docs_screenshots/` for UI/workflow changes.
- [ ] Desktop screenshots committed under `docs/screenshots/desktop/` for UI/workflow changes.
- [ ] Mobile screenshots committed under `docs/screenshots/mobile/` for UI/workflow changes.
- [ ] For DB changes, included any needed backfills/dedupes and noted risks.
- [ ] If a normally required evidence type is intentionally omitted, the PR body or a PR comment explains the exemption.

## Screenshots / Diagrams

Link the canonical evidence for this PR:

- Docs:
- Changed files:
- Spec / test coverage:
- Diagram source/export:
- Screenshot spec:
- Desktop/mobile screenshots:

## Stakeholder Packet

For significant PRs, add the private Community Engine stakeholder packet links:

- Private page:
- Private post:
- If intentionally deferred, explain why:

## Notes

Anything reviewers should be aware of (migration order, flags, feature toggles).
