### PR TITLE
feat: mail ingress

### DIFF
--- a/app/services/better_together/content_security/orchestrator_runner.rb
+++ b/app/services/better_together/content_security/orchestrator_runner.rb
@@ -20,10 +20,9 @@ module BetterTogether
         raise Error, 'Content safety orchestrator command is not configured.' if command_tokens.blank?
 
         input_path = write_payload(payload)
-        stdout, stderr, status = Open3.capture3(*command_tokens, '--input-json', input_path.to_s, '--format', 'json')
-        raise Error, failure_message(stderr, stdout) unless status.success?
-
-        JSON.parse(stdout)
+        JSON.parse(run_command(input_path))
+      rescue Errno::ENOENT => e
+        raise Error, "Content safety orchestrator failed: #{e.message}"
       rescue JSON::ParserError => e
         raise Error, "Content safety orchestrator returned invalid JSON: #{e.message}"
       ensure
@@ -48,6 +47,13 @@ module BetterTogether
         FileUtils.mkdir_p(path.dirname)
         path.write(JSON.pretty_generate(payload))
         path
+      end
+
+      def run_command(input_path)
+        stdout, stderr, status = Open3.capture3(*command_tokens, '--input-json', input_path.to_s, '--format', 'json')
+        raise Error, failure_message(stderr, stdout) unless status.success?
+
+        stdout
       end
 
       def failure_message(stderr, stdout)

--- a/db/migrate/20260408030000_add_content_screening_to_better_together_inbound_email_messages.rb
+++ b/db/migrate/20260408030000_add_content_screening_to_better_together_inbound_email_messages.rb
@@ -2,14 +2,23 @@
 
 class AddContentScreeningToBetterTogetherInboundEmailMessages < ActiveRecord::Migration[7.2]
   def change
-    change_table :better_together_inbound_email_messages, bulk: true do |t|
-      t.string :screening_state, null: false, default: 'pending'
-      t.string :screening_verdict
-      t.text :content_screening_summary
-      t.text :content_security_records_json
+    return unless table_exists?(:better_together_inbound_email_messages)
+
+    {
+      screening_state: [:string, { null: false, default: 'pending' }],
+      screening_verdict: [:string, {}],
+      content_screening_summary: [:text, {}],
+      content_security_records_json: [:text, {}]
+    }.each do |column_name, (type, options)|
+      next if column_exists?(:better_together_inbound_email_messages, column_name)
+
+      add_column :better_together_inbound_email_messages, column_name, type, **options
     end
 
-    add_index :better_together_inbound_email_messages, :screening_state
-    add_index :better_together_inbound_email_messages, :screening_verdict
+    %i[screening_state screening_verdict].each do |column_name|
+      next if index_exists?(:better_together_inbound_email_messages, column_name)
+
+      add_index :better_together_inbound_email_messages, column_name
+    end
   end
 end

--- a/db/migrate/20260408030000_add_content_screening_to_better_together_inbound_email_messages.rb
+++ b/db/migrate/20260408030000_add_content_screening_to_better_together_inbound_email_messages.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AddContentScreeningToBetterTogetherInboundEmailMessages < ActiveRecord::Migration[7.2]
+  def change
+    change_table :better_together_inbound_email_messages, bulk: true do |t|
+      t.string :screening_state, null: false, default: 'pending'
+      t.string :screening_verdict
+      t.text :content_screening_summary
+      t.text :content_security_records_json
+    end
+
+    add_index :better_together_inbound_email_messages, :screening_state
+    add_index :better_together_inbound_email_messages, :screening_verdict
+  end
+end

--- a/docs/mail_ingress_mvp.md
+++ b/docs/mail_ingress_mvp.md
@@ -40,6 +40,21 @@ This prevents cross-tenant leakage when two tenants have similar community names
 
 ## Privacy and security posture
 
+### Shared content-security intake and hold gate
+
+- every inbound email now enters a **content-security screening gate** before any downstream membership-request creation or future routing action
+- the gate builds shared-contract payloads for:
+  - the email body + metadata (`from`, `to`, `subject`, `Message-ID`, attachment manifest)
+  - each attachment as its own content item with tenant-scoped metadata
+- CE stores the returned contract records on `BetterTogether::InboundEmailMessage` and only allows downstream routing when the aggregate verdict is `clean` or `monitor`
+- when the scanner returns `review_required`, `restricted`, `quarantined`, `blocked`, or raises an error/unconfigured condition, CE **holds** the message and does not create downstream records
+
+### Shared orchestrator dependency
+
+- the prototype expects a stable command in `BETTER_TOGETHER_CONTENT_SAFETY_ORCHESTRATOR_COMMAND`
+- that command should point at the shared management-tool orchestrator entrypoint, for example a checked-in wrapper around `scripts/content_safety_scanner_orchestrator.py`
+- if the command is absent or fails, this prototype intentionally **fails closed** and keeps the inbound message held for review
+
 ### Fail-closed routing
 
 - unknown domains are rejected
@@ -92,5 +107,17 @@ The diagrams are paired with text so stakeholders who prefer screen readers, low
 - no end-user alias management UI yet
 - no automatic outbound acknowledgements yet
 - no external delivery integration beyond the relay endpoint contract
+- no stable mainline home for the shared scanner command yet; this prototype stores contract records and holds mail, but merge/mainline work still needs the shared scanner path to become a supported dependency
 
 Those are intentionally deferred until the tenant-safe intake substrate is in place.
+
+## Mainline merge requirements
+
+This implementation currently lives only in `tmp/worktrees/ce-mail-ingress-mvp/...`, because the inspected CE main tree still does not expose a canonical `app/mailboxes/` / Action Mailbox ingress seam.
+
+To merge/mainline it honestly, CE still needs:
+
+1. the Action Mailbox controller, mailbox classes, model, migrations, and specs from this prototype promoted into the canonical CE tree
+2. a **stable shared scanner entrypoint** for `BETTER_TOGETHER_CONTENT_SAFETY_ORCHESTRATOR_COMMAND` (vendored wrapper, gem, engine integration, or another supported dependency) instead of a worktree-only path
+3. host-app install/upgrade guidance for the new inbound-email and screening migrations
+4. a reviewer-facing queue or admin workflow that can release held mail after screening, because this tranche only implements intake + hold, not the full moderation UI

--- a/lib/better_together/configuration.rb
+++ b/lib/better_together/configuration.rb
@@ -19,6 +19,8 @@ module BetterTogether
 
     delegate :adapter_registry=, to: :BetterTogether
 
+    delegate :content_safety_orchestrator_command=, to: :BetterTogether
+
     delegate :new_user_password_path=, to: :BetterTogether
 
     delegate :user_class=, to: :BetterTogether

--- a/lib/better_together/configuration.rb
+++ b/lib/better_together/configuration.rb
@@ -11,8 +11,6 @@ module BetterTogether
 
     delegate :base_url=, to: :BetterTogether
 
-    delegate :content_safety_orchestrator_command=, to: :BetterTogether
-
     delegate :inbound_email_ingress_password=, to: :BetterTogether
     delegate :adapters_for, :clear_adapters!, :clear_error_reporters!, :dispatch_to_adapters,
              :register_adapter, :register_error_reporter, to: :BetterTogether

--- a/spec/services/better_together/content_security/orchestrator_runner_spec.rb
+++ b/spec/services/better_together/content_security/orchestrator_runner_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BetterTogether::ContentSecurity::OrchestratorRunner do
+  describe '#call' do
+    it 'wraps missing command errors as orchestrator errors' do
+      runner = described_class.new(command: ['/definitely/missing/orchestrator'])
+
+      expect do
+        runner.call('content_item' => { 'text' => 'hello' })
+      end.to raise_error(
+        BetterTogether::ContentSecurity::OrchestratorRunner::Error,
+        /Content safety orchestrator failed:/
+      )
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces a comprehensive content-security screening gate for inbound emails, integrating a shared content safety orchestrator and adding new model attributes, services, and configuration options to support this workflow. The system now holds inbound mail for review unless explicit screening verdicts allow routing, and stores detailed contract records for each message. The implementation also includes supporting tests, migration, and documentation updates.

**Content Security Screening Integration**

* Added new attributes to `BetterTogether::InboundEmailMessage` (`screening_state`, `screening_verdict`, `content_screening_summary`, `content_security_records_json`) with encryption and validation, and provided serialization helpers for contract records. (`[[1]](diffhunk://#diff-bea697d28a96b9f7c1571c091bcfd6aeff4bb4529d7b32293db21357652b85f2R10-R11)`, `[[2]](diffhunk://#diff-bea697d28a96b9f7c1571c091bcfd6aeff4bb4529d7b32293db21357652b85f2R34-R62)`)
* Introduced `MailScreeningService` to build payloads for the orchestrator, aggregate verdicts, and update messages with screening results, holding mail unless the verdict is `clean` or `monitor`. (`[app/services/better_together/content_security/mail_screening_service.rbR1-R222](diffhunk://#diff-ae0355abc613aaa9126257b49ff902f4811071fe4448c7768036ad5b860aa2c7R1-R222)`)
* Added `OrchestratorRunner` service to invoke the shared content safety orchestrator command, handle payloads, and return parsed contract records, failing closed on errors. (`[app/services/better_together/content_security/orchestrator_runner.rbR1-R59](diffhunk://#diff-f980c61cccad241df6f1382e56947cc634f653fce417451202b421c2f09d4f91R1-R59)`)

**Routing Workflow Changes**

* Updated `InboundEmailRoutingService` to invoke content screening before routing, only proceeding if the screening result allows it. (`[[1]](diffhunk://#diff-4a7c35847858909e8466fc73940b637958b798cb5387d67858be0ba0aa87dc22L6-R9)`, `[[2]](diffhunk://#diff-4a7c35847858909e8466fc73940b637958b798cb5387d67858be0ba0aa87dc22R20-R21)`, `[[3]](diffhunk://#diff-4a7c35847858909e8466fc73940b637958b798cb5387d67858be0ba0aa87dc22R75-R87)`)

**Configuration and Migration**

* Added new migration to support message screening attributes and indexes. (`[db/migrate/20260408030000_add_content_screening_to_better_together_inbound_email_messages.rbR1-R15](diffhunk://#diff-9c33f247a26216b63db80445c8866df686ca2f1dca55a20c5fc7f849a1b94ba2R1-R15)`)
* Introduced configuration for the orchestrator command, with environment variable support, and exposed it in the configuration interface. (`[[1]](diffhunk://#diff-fec5c5fdadced4da1c03fe669dd12c930f831aa14b5f7503100cde2ec6e378c3R13)`, `[[2]](diffhunk://#diff-fec5c5fdadced4da1c03fe669dd12c930f831aa14b5f7503100cde2ec6e378c3R137-R141)`, `[[3]](diffhunk://#diff-806a624c71965b18814fa751c38a05371540cbfb044fab85c0f3dc8ab4119017R19-R20)`)

**Testing and Documentation**

* Added factory and model specs for screening attributes and contract record serialization. (`[[1]](diffhunk://#diff-ec409e3ed4cb62d55b4dd2b08577bde883656954ca5ce21e7ebc64272b716133R20-R23)`, `[[2]](diffhunk://#diff-80a01843aa68a99a0abe21e8738426e094abeb8fb64d495fea62074c39d1f63eL21-R36)`)
* Added a service spec to ensure the system fails closed when the orchestrator is unavailable. (`[spec/services/better_together/content_security/mail_screening_service_spec.rbR1-R69](diffhunk://#diff-3ad78f9cd29af377fbd4b16767217b1e1a9c9b9a5141068fb5d0c2ced280edcdR1-R69)`)
* Updated documentation to describe the new content-security gate, orchestrator dependency, and mainline merge requirements. (`[[1]](diffhunk://#diff-aaae3a80ad6c9465d91307421512fdd7a21297bb238b701811483ecc8c57f1f2R31-R45)`, `[[2]](diffhunk://#diff-aaae3a80ad6c9465d91307421512fdd7a21297bb238b701811483ecc8c57f1f2R97-R110)`)