### PR TITLE
feat(i18n): host translation management UI

### DIFF
--- a/app/controllers/better_together/application_controller.rb
+++ b/app/controllers/better_together/application_controller.rb
@@ -342,11 +342,9 @@ module BetterTogether
     end
 
     def set_locale
-      locale = params[:locale] || # Request parameter
-               session[:locale] || # Session stored locale
-               helpers.current_person&.locale || # Model saved configuration
-               extract_locale_from_accept_language_header || # Language header - browser config
-               I18n.default_locale # Set in your config files, english by super-default
+      locale = locale_candidates.lazy.filter_map do |candidate|
+        normalize_locale(candidate, fallback: nil)
+      end.first || I18n.default_locale.to_s
 
       I18n.locale = locale
       session[:locale] = locale # Store the locale in the session
@@ -448,6 +446,43 @@ module BetterTogether
 
     def turbo_native_app?
       request.user_agent.to_s.include?('Turbo Native')
+    end
+
+    def normalize_locale(raw_locale, fallback: I18n.default_locale.to_s)
+      return fallback if raw_locale.nil?
+
+      candidate_locale = raw_locale.to_s.strip.downcase.tr('_', '-')
+      return fallback if candidate_locale.blank?
+
+      normalized_available_locales[candidate_locale] ||
+        normalized_partial_locale_match(candidate_locale) ||
+        unsupported_locale_fallback(raw_locale, fallback)
+    end
+
+    def locale_candidates
+      [
+        params[:locale], # Request parameter
+        session[:locale], # Session stored locale
+        helpers.current_person&.locale, # Model saved configuration
+        extract_locale_from_accept_language_header, # Language header - browser config
+        I18n.default_locale # Set in your config files, english by super-default
+      ]
+    end
+
+    def normalized_available_locales
+      @normalized_available_locales ||= I18n.available_locales.to_h do |locale|
+        [locale.to_s.downcase.tr('_', '-'), locale.to_s]
+      end
+    end
+
+    def normalized_partial_locale_match(candidate_locale)
+      partial_match = normalized_available_locales.keys.find { |locale| candidate_locale.start_with?("#{locale}-") }
+      normalized_available_locales[partial_match]
+    end
+
+    def unsupported_locale_fallback(raw_locale, fallback)
+      Rails.logger.warn("Unsupported locale '#{raw_locale}', falling back") if fallback
+      fallback
     end
   end
 end

--- a/app/controllers/better_together/host/translation_management_controller.rb
+++ b/app/controllers/better_together/host/translation_management_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  module Host
+    class TranslationManagementController < ApplicationController # rubocop:todo Style/Documentation
+      def show
+        authorize [:host_dashboard], :show?, policy_class: HostDashboardPolicy
+
+        @dashboard_scope = 'readonly'
+        @backend_stats = build_backend_stats
+        @locale_stats = aggregate_counts_by(:locale).first(8)
+        @translatable_type_stats = aggregate_counts_by(:translatable_type).first(8)
+        @recovery_slices = %w[
+          locale-normalization
+          translation-indexes
+          dashboard-namespace
+          readonly-dashboard
+          dashboard-tests
+        ]
+      end
+
+      private
+
+      def build_backend_stats
+        [
+          backend_stat(:string, Mobility::Backends::ActiveRecord::KeyValue::StringTranslation.all, :translatable_type),
+          backend_stat(:text, Mobility::Backends::ActiveRecord::KeyValue::TextTranslation.all, :translatable_type),
+          backend_stat(:rich_text, ActionText::RichText.all, :record_type),
+          backend_stat(:file, translated_attachments, :record_type)
+        ]
+      end
+
+      def backend_stat(key, relation, type_column)
+        {
+          key:,
+          record_count: relation.count,
+          model_count: relation.distinct.count(type_column)
+        }
+      end
+
+      def aggregate_counts_by(group_field)
+        counts = Hash.new(0)
+
+        translation_relations_for(group_field).each do |relation|
+          relation.group(group_field).count.each do |key, count|
+            counts[key.to_s] += count
+          end
+        end
+
+        counts.sort_by { |_key, count| -count }
+      end
+
+      def translation_relations_for(group_field)
+        [
+          Mobility::Backends::ActiveRecord::KeyValue::StringTranslation.all,
+          Mobility::Backends::ActiveRecord::KeyValue::TextTranslation.all,
+          ActionText::RichText.all,
+          translated_attachments
+        ].select { |relation| relation.klass.column_names.include?(group_field.to_s) }
+      end
+
+      def translated_attachments
+        return ActiveStorage::Attachment.none unless ActiveStorage::Attachment.column_names.include?('locale')
+
+        ActiveStorage::Attachment.all
+      end
+    end
+  end
+end

--- a/app/views/better_together/host/translation_management/show.html.erb
+++ b/app/views/better_together/host/translation_management/show.html.erb
@@ -1,0 +1,120 @@
+<% content_for :page_title, t('.title') %>
+
+<div class="container py-4">
+  <div class="row justify-content-center">
+    <div class="col-lg-10">
+      <div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-3 mb-4">
+        <div>
+          <h1 class="h2 mb-2"><%= t('.title') %></h1>
+          <p class="text-muted mb-0"><%= t('.subtitle') %></p>
+        </div>
+        <span class="badge text-bg-info fs-6"><%= t('.readonly_badge') %></span>
+      </div>
+
+      <div class="card mb-4">
+        <div class="card-body">
+          <h2 class="h5"><%= t('.separation_heading') %></h2>
+          <p class="mb-2"><%= t('.separation_body') %></p>
+          <p class="mb-0">
+            <strong><%= t('.ai_translation_label') %></strong>
+            <code>POST <%= better_together.ai_translate_path(locale: I18n.locale) %></code>
+          </p>
+        </div>
+      </div>
+
+      <div class="row g-4 mb-4">
+        <div class="col-md-4">
+          <div class="card h-100">
+            <div class="card-body">
+              <h2 class="h6 text-uppercase text-muted"><%= t('.overview.total_records') %></h2>
+              <p class="display-6 mb-0"><%= number_with_delimiter(@backend_stats.sum { |stat| stat[:record_count] }) %></p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card h-100">
+            <div class="card-body">
+              <h2 class="h6 text-uppercase text-muted"><%= t('.overview.translated_models') %></h2>
+              <p class="display-6 mb-0"><%= number_with_delimiter(@translatable_type_stats.count) %></p>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-4">
+          <div class="card h-100">
+            <div class="card-body">
+              <h2 class="h6 text-uppercase text-muted"><%= t('.overview.locales_tracked') %></h2>
+              <p class="display-6 mb-0"><%= number_with_delimiter(@locale_stats.count) %></p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row g-4">
+        <div class="col-md-6">
+          <div class="card h-100">
+            <div class="card-body">
+              <h2 class="h5"><%= t('.overview.backend_heading') %></h2>
+              <div class="row row-cols-1 row-cols-sm-2 g-3 mb-4">
+                <% @backend_stats.each do |stat| %>
+                  <div class="col">
+                    <div class="border rounded p-3 h-100">
+                      <h3 class="h6 mb-2"><%= t(".overview.backends.#{stat[:key]}") %></h3>
+                      <div class="small text-muted"><%= t('.overview.records') %></div>
+                      <div class="fs-4"><%= number_with_delimiter(stat[:record_count]) %></div>
+                      <div class="small text-muted mt-2"><%= t('.overview.models') %></div>
+                      <div><%= number_with_delimiter(stat[:model_count]) %></div>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+
+              <h2 class="h5"><%= t('.recovery_heading') %></h2>
+              <ul class="mb-0">
+                <% @recovery_slices.each do |slice| %>
+                  <li><%= t(".slices.#{slice}") %></li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-md-6">
+          <div class="card h-100">
+            <div class="card-body">
+              <h2 class="h5"><%= t('.overview.locale_heading') %></h2>
+              <% if @locale_stats.any? %>
+                <ul class="list-group list-group-flush mb-4">
+                  <% @locale_stats.each do |locale, count| %>
+                    <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                      <span><%= locale.upcase %></span>
+                      <span class="badge text-bg-secondary"><%= number_with_delimiter(count) %></span>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-muted"><%= t('.overview.no_data') %></p>
+              <% end %>
+
+              <h2 class="h5"><%= t('.overview.type_heading') %></h2>
+              <% if @translatable_type_stats.any? %>
+                <ul class="list-group list-group-flush mb-4">
+                  <% @translatable_type_stats.each do |type, count| %>
+                    <li class="list-group-item d-flex justify-content-between align-items-center px-0">
+                      <span><%= type.demodulize %></span>
+                      <span class="badge text-bg-secondary"><%= number_with_delimiter(count) %></span>
+                    </li>
+                  <% end %>
+                </ul>
+              <% else %>
+                <p class="text-muted"><%= t('.overview.no_data') %></p>
+              <% end %>
+
+              <h2 class="h5"><%= t('.next_heading') %></h2>
+              <p class="mb-0"><%= t('.next_body') %></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3400,6 +3400,39 @@ en:
         invalid_target_locale: Invalid target locale
         translation_failed: 'Translation failed: %{message}'
         translation_request_failed: Translation request failed. Please try again.
+    host:
+      translation_management:
+        show:
+          ai_translation_label: AI translation endpoint
+          next_body: The stale PR dashboard will be rebuilt here in smaller, readonly slices instead of reviving the old controller takeover.
+          next_heading: Next recovery step
+          overview:
+            backend_heading: Translation records by backend
+            backends:
+              file: File attachments
+              rich_text: Rich text
+              string: String translations
+              text: Text translations
+            locale_heading: Locale coverage snapshot
+            locales_tracked: Locales tracked
+            models: Models
+            no_data: No translation data is available yet.
+            records: Records
+            total_records: Total translation records
+            translated_models: Translated models
+            type_heading: Top translated model types
+          readonly_badge: Readonly recovery namespace
+          recovery_heading: Recovery slices
+          separation_body: Translation observability now has its own host admin namespace so it can evolve independently from the AI translation request endpoint.
+          separation_heading: Surface separation
+          slices:
+            dashboard-namespace: Namespace the dashboard under host admin routes
+            dashboard-tests: Restore request and helper coverage around the recovered surface
+            locale-normalization: Extract locale normalization into current ApplicationController
+            readonly-dashboard: Rebuild the readonly translation observability UI
+            translation-indexes: Add lookup indexes for translation coverage queries
+          subtitle: Recovery home for the stale translation-management work from PR #1123.
+          title: Translation Management
     uploads:
       content_security:
         badge:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -3471,6 +3471,39 @@ es:
         translation_failed: 'La traducción falló: %{message}'
         translation_request_failed: La solicitud de traducción falló. Por favor, inténtelo
           de nuevo.
+    host:
+      translation_management:
+        show:
+          ai_translation_label: Punto final de traducción con IA
+          next_body: El panel del PR obsoleto se reconstruirá aquí en porciones más pequeñas y de solo lectura en lugar de revivir la antigua sustitución del controlador.
+          next_heading: Siguiente paso de recuperación
+          overview:
+            backend_heading: Registros de traducción por backend
+            backends:
+              file: Archivos adjuntos
+              rich_text: Texto enriquecido
+              string: Traducciones de cadenas
+              text: Traducciones de texto
+            locale_heading: Resumen de cobertura por locale
+            locales_tracked: Locales rastreados
+            models: Modelos
+            no_data: Todavía no hay datos de traducción disponibles.
+            records: Registros
+            total_records: Total de registros de traducción
+            translated_models: Modelos traducidos
+            type_heading: Tipos de modelo más traducidos
+          readonly_badge: Espacio de recuperación de solo lectura
+          recovery_heading: Porciones de recuperación
+          separation_body: La observabilidad de traducciones ahora tiene su propio espacio de administración del host para evolucionar por separado del punto final de solicitudes de traducción con IA.
+          separation_heading: Separación de superficies
+          slices:
+            dashboard-namespace: Ubicar el panel bajo las rutas de administración del host
+            dashboard-tests: Restaurar cobertura de solicitudes y helpers para la superficie recuperada
+            locale-normalization: Extraer la normalización de locale al ApplicationController actual
+            readonly-dashboard: Reconstruir la interfaz de observabilidad de traducciones de solo lectura
+            translation-indexes: Agregar índices de búsqueda para consultas de cobertura de traducciones
+          subtitle: Hogar de recuperación para el trabajo obsoleto de gestión de traducciones del PR #1123.
+          title: Gestión de traducciones
     uploads:
       content_security:
         badge:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3488,6 +3488,39 @@ fr:
         invalid_target_locale: Langue cible non valide
         translation_failed: 'La traduction a échoué : %{message}'
         translation_request_failed: La demande de traduction a échoué. Veuillez réessayer.
+    host:
+      translation_management:
+        show:
+          ai_translation_label: Point de terminaison de traduction IA
+          next_body: Le tableau de bord de l'ancienne PR sera reconstruit ici par petites tranches en lecture seule au lieu de ressusciter l'ancien détournement du contrôleur.
+          next_heading: Prochaine étape de récupération
+          overview:
+            backend_heading: Enregistrements de traduction par backend
+            backends:
+              file: Fichiers joints
+              rich_text: Texte enrichi
+              string: Traductions de chaînes
+              text: Traductions de texte
+            locale_heading: Aperçu de la couverture par locale
+            locales_tracked: Locales suivies
+            models: Modèles
+            no_data: Aucune donnée de traduction n'est encore disponible.
+            records: Enregistrements
+            total_records: Total des enregistrements de traduction
+            translated_models: Modèles traduits
+            type_heading: Types de modèles les plus traduits
+          readonly_badge: Espace de récupération en lecture seule
+          recovery_heading: Tranches de récupération
+          separation_body: L'observabilité des traductions dispose maintenant de son propre espace d'administration hôte afin d'évoluer séparément du point de terminaison des demandes de traduction IA.
+          separation_heading: Séparation des surfaces
+          slices:
+            dashboard-namespace: Placer le tableau de bord sous les routes d'administration hôte
+            dashboard-tests: Rétablir la couverture des requêtes et helpers autour de la surface récupérée
+            locale-normalization: Extraire la normalisation de locale dans l'ApplicationController actuel
+            readonly-dashboard: Reconstruire l'interface d'observabilité des traductions en lecture seule
+            translation-indexes: Ajouter des index de recherche pour les requêtes de couverture des traductions
+          subtitle: Point de récupération pour le travail de gestion des traductions obsolète du PR #1123.
+          title: Gestion des traductions
     uploads:
       content_security:
         badge:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -3449,6 +3449,39 @@ uk:
         translation_failed: 'Переклад не вдався: %{message}'
         translation_request_failed: Запит на переклад не вдався. Будь ласка, спробуйте
           знову.
+    host:
+      translation_management:
+        show:
+          ai_translation_label: Кінцева точка перекладу ШІ
+          next_body: Панель зі застарілого PR буде відновлена тут невеликими кроками лише для читання замість повернення до старого захоплення контролера.
+          next_heading: Наступний крок відновлення
+          overview:
+            backend_heading: Записи перекладів за бекендом
+            backends:
+              file: Вкладення файлів
+              rich_text: Форматований текст
+              string: Рядкові переклади
+              text: Текстові переклади
+            locale_heading: Огляд покриття за locale
+            locales_tracked: Відстежувані locale
+            models: Моделі
+            no_data: Дані перекладів ще недоступні.
+            records: Записи
+            total_records: Загальна кількість записів перекладу
+            translated_models: Перекладені моделі
+            type_heading: Найпоширеніші типи перекладених моделей
+          readonly_badge: Простір відновлення лише для читання
+          recovery_heading: Кроки відновлення
+          separation_body: Спостереження за перекладами тепер має власний простір адміністрування хоста й розвивається окремо від кінцевої точки запитів на переклад ШІ.
+          separation_heading: Розділення поверхонь
+          slices:
+            dashboard-namespace: Розмістити панель під маршрутами адміністрування хоста
+            dashboard-tests: Відновити покриття запитів і helper-методів навколо відновленої поверхні
+            locale-normalization: Винести нормалізацію locale до поточного ApplicationController
+            readonly-dashboard: Перебудувати інтерфейс спостереження за перекладами лише для читання
+            translation-indexes: Додати індекси пошуку для запитів покриття перекладів
+          subtitle: Простір відновлення для застарілої роботи з керування перекладами з PR #1123.
+          title: Керування перекладами
     uploads:
       content_security:
         badge:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -368,6 +368,10 @@ BetterTogether::Engine.routes.draw do # rubocop:todo Metrics/BlockLength
             get 'federation-review',
                 to: 'host_dashboard#platform_connection_review',
                 as: 'host_dashboard_platform_connection_review'
+            resource :translation_management,
+                     only: :show,
+                     path: 'translation-management',
+                     controller: 'host/translation_management'
 
             resources :categories
 

--- a/db/migrate/20260405165500_add_translation_coverage_lookup_indexes.rb
+++ b/db/migrate/20260405165500_add_translation_coverage_lookup_indexes.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class AddTranslationCoverageLookupIndexes < ActiveRecord::Migration[7.2]
+  STRING_INDEX = 'index_mobility_string_translations_on_type_locale_key'
+  TEXT_INDEX = 'index_mobility_text_translations_on_type_locale_key'
+
+  def up
+    unless index_exists?(:mobility_string_translations, %i[translatable_type locale key], name: STRING_INDEX)
+      add_index :mobility_string_translations, %i[translatable_type locale key], name: STRING_INDEX
+    end
+
+    return if index_exists?(:mobility_text_translations, %i[translatable_type locale key], name: TEXT_INDEX)
+
+    add_index :mobility_text_translations, %i[translatable_type locale key], name: TEXT_INDEX
+  end
+
+  def down
+    remove_index :mobility_string_translations, name: STRING_INDEX if index_exists?(:mobility_string_translations,
+                                                                                    %i[translatable_type locale key],
+                                                                                    name: STRING_INDEX)
+    remove_index :mobility_text_translations, name: TEXT_INDEX if index_exists?(:mobility_text_translations,
+                                                                                %i[translatable_type locale key],
+                                                                                name: TEXT_INDEX)
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -2147,6 +2147,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_16_214500) do
     t.index ["translatable_id", "translatable_type", "key"], name: "index_mobility_string_translations_on_translatable_attribute"
     t.index ["translatable_id", "translatable_type", "locale", "key"], name: "index_mobility_string_translations_on_keys", unique: true
     t.index ["translatable_type", "key", "value", "locale"], name: "index_mobility_string_translations_on_query_keys"
+    t.index ["translatable_type", "locale", "key"], name: "index_mobility_string_translations_on_type_locale_key"
   end
 
   create_table "mobility_text_translations", force: :cascade do |t|
@@ -2159,6 +2160,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_04_16_214500) do
     t.datetime "updated_at", null: false
     t.index ["translatable_id", "translatable_type", "key"], name: "index_mobility_text_translations_on_translatable_attribute"
     t.index ["translatable_id", "translatable_type", "locale", "key"], name: "index_mobility_text_translations_on_keys", unique: true
+    t.index ["translatable_type", "locale", "key"], name: "index_mobility_text_translations_on_type_locale_key"
   end
 
   create_table "noticed_events", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/requests/better_together/application_controller_locale_spec.rb
+++ b/spec/requests/better_together/application_controller_locale_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ApplicationController locale normalization' do
+  let(:controller) { BetterTogether::ApplicationController.new }
+
+  describe '#normalize_locale' do
+    it 'returns exact available locales as strings' do
+      expect(controller.send(:normalize_locale, :fr)).to eq('fr')
+    end
+
+    it 'normalizes case and separators before matching a partial locale' do
+      expect(controller.send(:normalize_locale, 'EN_us')).to eq('en')
+    end
+
+    it 'falls back to the default locale for blank values' do
+      expect(controller.send(:normalize_locale, '   ')).to eq(I18n.default_locale.to_s)
+    end
+
+    it 'returns the provided fallback for unsupported locales' do
+      expect(controller.send(:normalize_locale, 'zz-ZZ', fallback: nil)).to be_nil
+    end
+
+    it 'logs unsupported locales when using the default fallback' do
+      allow(Rails.logger).to receive(:warn)
+
+      expect(controller.send(:normalize_locale, 'zz-ZZ')).to eq(I18n.default_locale.to_s)
+      expect(Rails.logger).to have_received(:warn).with("Unsupported locale 'zz-ZZ', falling back")
+    end
+  end
+
+  describe '#set_locale' do
+    let(:session) { {} }
+    let(:request) { instance_double(ActionDispatch::Request, env: {}) }
+    let(:helpers_proxy) { double(current_person: nil) }
+
+    before do
+      allow(controller).to receive_messages(session:, request:)
+    end
+
+    it 'stores a normalized locale from params' do
+      allow(controller).to receive_messages(
+        params: ActionController::Parameters.new(locale: 'fr-CA'),
+        helpers: helpers_proxy
+      )
+
+      controller.send(:set_locale)
+
+      expect(I18n.locale.to_s).to eq('fr')
+      expect(session[:locale]).to eq('fr')
+    end
+
+    it 'skips unsupported params and falls through to the session locale' do
+      allow(controller).to receive_messages(
+        params: ActionController::Parameters.new(locale: 'zz-ZZ'),
+        helpers: helpers_proxy
+      )
+      session[:locale] = 'es'
+
+      controller.send(:set_locale)
+
+      expect(I18n.locale.to_s).to eq('es')
+      expect(session[:locale]).to eq('es')
+    end
+  end
+end

--- a/spec/requests/better_together/host/translation_management_controller_spec.rb
+++ b/spec/requests/better_together/host/translation_management_controller_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'BetterTogether::Host::TranslationManagementController' do
+  let(:locale) { I18n.default_locale }
+
+  describe 'GET /host/translation-management', :as_platform_manager do
+    it 'renders the recovery namespace landing page' do
+      get better_together.translation_management_path(locale:)
+
+      expect(response).to have_http_status(:ok)
+      expect_html_content('Translation Management')
+      expect_html_content('Readonly recovery namespace')
+      expect_html_content('Translation records by backend')
+      expect_html_content('Locale coverage snapshot')
+    end
+
+    it 'assigns readonly overview statistics for the dashboard' do
+      get better_together.translation_management_path(locale:)
+
+      expect(assigns(:backend_stats).map { |stat| stat[:key] }).to eq(%i[string text rich_text file])
+      expect(assigns(:backend_stats)).to all(include(:record_count, :model_count))
+      expect(assigns(:locale_stats)).to all(be_an(Array))
+      expect(assigns(:translatable_type_stats)).to all(be_an(Array))
+    end
+  end
+end


### PR DESCRIPTION
Salvage PR: preserves local worktree delta from April 18, 2026 remediation (session 7eb000bc).

Adds a host-facing translation management controller and view for coverage inspection:
- `TranslationManagementController` under `host/` namespace
- Translation management show view
- i18n locale strings (en, es, fr, uk)
- Routes: `resource :translation_management` under authenticated host scope
- Migration: `add_translation_coverage_lookup_indexes`
- Specs for controller and locale detection

Rebased cleanly onto `release/0.11.0-notes`. Routes conflict resolved by preserving existing host dashboard routes alongside new translation management route.