### PR TITLE
docs(release): 0.11.0 CHANGELOG and README updates

### DIFF
--- a/docs/api/block-management-api-guide.md
+++ b/docs/api/block-management-api-guide.md
@@ -1,0 +1,197 @@
+# Block Management API Guide
+
+This guide documents the block-management API surface that currently exists in Community Engine `0.11.0`.
+
+## Scope
+
+There are two JSON:API resources involved in block management:
+
+- `blocks` for the reusable `BetterTogether::Content::Block` records
+- `page_blocks` for the ordered page-to-block join records
+
+Routes are declared in `config/routes/api_v1.rb`:
+
+- `jsonapi_resources :blocks`
+- `jsonapi_resources :page_blocks`
+
+Relevant implementation:
+
+- `app/controllers/better_together/api/v1/blocks_controller.rb`
+- `app/controllers/better_together/api/v1/page_blocks_controller.rb`
+- `app/resources/better_together/api/v1/block_resource.rb`
+- `app/resources/better_together/api/v1/page_block_resource.rb`
+
+## Authentication and authorization
+
+Both controllers inherit from `BetterTogether::Api::ApplicationController`, and block access is authorized through `BetterTogether::Content::BlockPolicy`. In practice, write access is intended for platform content managers.
+
+For AI-agent access, these same block operations are also available through the MCP tools documented in [MCP Integration Guide](mcp-integration-guide.md) and summarized below.
+
+## `blocks` resource
+
+### Supported operations
+
+- `GET /api/v1/blocks`
+- `GET /api/v1/blocks/:id`
+- `POST /api/v1/blocks`
+- `PATCH /api/v1/blocks/:id`
+- `DELETE /api/v1/blocks/:id`
+
+### Filters
+
+`BlockResource` currently supports:
+
+- `filter[block_type]`
+- `filter[privacy]`
+- `filter[identifier]`
+- `filter[page_id]`
+
+Examples:
+
+```http
+GET /api/v1/blocks?filter[page_id]=PAGE_UUID
+GET /api/v1/blocks?filter[block_type]=BetterTogether::Content::AccordionBlock
+GET /api/v1/blocks?filter[identifier]=homepage-hero
+```
+
+### Key attributes
+
+`BlockResource` exposes:
+
+- `block_type` instead of raw STI `type`
+- shared fields such as `identifier`, `privacy`, `visible`, and `protected`
+- block-specific Storext attributes such as `video_url`, `accordion_items_json`, `stats_json`, and `navigation_area_id`
+- translated fields with locale suffixes for `en`, `fr`, `es`, and `uk`
+
+Examples of localized keys:
+
+- `heading_en`
+- `content_fr`
+- `caption_es`
+- `diagram_source_uk`
+
+### Create example
+
+Creating a block record does not attach it to a page. Use `page_blocks` for attachment.
+
+```json
+{
+  "data": {
+    "type": "blocks",
+    "attributes": {
+      "block_type": "BetterTogether::Content::AlertBlock",
+      "identifier": "homepage-alert",
+      "privacy": "public",
+      "visible": true,
+      "heading_en": "Important update",
+      "body_text": "Doors open at 7pm.",
+      "alert_level": "info",
+      "dismissible": true
+    }
+  }
+}
+```
+
+### Update example
+
+`block_type` is creatable but not updatable. After creation, update only the block's mutable attributes.
+
+```json
+{
+  "data": {
+    "type": "blocks",
+    "id": "BLOCK_UUID",
+    "attributes": {
+      "heading_en": "Updated heading",
+      "visible": false
+    }
+  }
+}
+```
+
+## `page_blocks` resource
+
+### Supported operations
+
+- `GET /api/v1/page_blocks`
+- `GET /api/v1/page_blocks/:id`
+- `POST /api/v1/page_blocks`
+- `PATCH /api/v1/page_blocks/:id`
+- `DELETE /api/v1/page_blocks/:id`
+
+### Purpose
+
+`PageBlockResource` manages the ordered join between a page and a block:
+
+- attach a block to a page
+- set or update `position`
+- detach a block without deleting the block record
+
+`DELETE /api/v1/page_blocks/:id` is intentionally a detach operation. `PageBlockResource#_remove` uses SQL `delete` so the block itself is not destroyed as a side effect.
+
+### Create example
+
+```json
+{
+  "data": {
+    "type": "page_blocks",
+    "attributes": {
+      "position": 0
+    },
+    "relationships": {
+      "page": {
+        "data": { "type": "pages", "id": "PAGE_UUID" }
+      },
+      "block": {
+        "data": { "type": "blocks", "id": "BLOCK_UUID" }
+      }
+    }
+  }
+}
+```
+
+### Reorder example
+
+```json
+{
+  "data": {
+    "type": "page_blocks",
+    "id": "PAGE_BLOCK_UUID",
+    "attributes": {
+      "position": 3
+    }
+  }
+}
+```
+
+## MCP block tools
+
+For AI-assisted content management, the engine also exposes page-oriented block tools:
+
+- `list_page_blocks`
+- `get_block`
+- `create_page_block`
+- `update_block`
+- `delete_page_block`
+
+These tools wrap the same models and policies, but they provide a task-oriented interface:
+
+- `create_page_block` both creates the block and attaches it to a page
+- `delete_page_block` detaches first and optionally destroys the block if it is unused elsewhere
+- `list_page_blocks` returns page order and block summaries without requiring separate join queries
+
+Relevant code:
+
+- `app/tools/better_together/mcp/create_page_block_tool.rb`
+- `app/tools/better_together/mcp/update_block_tool.rb`
+- `app/tools/better_together/mcp/delete_page_block_tool.rb`
+- `app/tools/better_together/mcp/list_page_blocks_tool.rb`
+- `app/tools/better_together/mcp/get_block_tool.rb`
+
+## Practical guidance
+
+- Use `blocks` when you need canonical block CRUD or filtering by type, identifier, or page.
+- Use `page_blocks` when you need to attach, detach, or reorder blocks on a page.
+- Use MCP tools when an authenticated AI assistant needs the higher-level page editing workflow.
+
+For the system-level model behind these endpoints, see [Block System and CMS](../developers/systems/block_system_and_cms.md).

--- a/docs/developers/systems/block_system_and_cms.md
+++ b/docs/developers/systems/block_system_and_cms.md
@@ -1,0 +1,167 @@
+# Block System and CMS
+
+This guide documents the current `0.11.0` block-management surface in Community Engine. It complements the broader [Content Management System](content_management.md) guide by focusing on the concrete block model, JSON:API endpoints, and MCP tools that exist on this branch.
+
+## What exists in this release lane
+
+The CMS block system is built around three layers:
+
+1. `BetterTogether::Content::Block` and its STI subclasses for reusable content blocks
+2. `BetterTogether::Content::PageBlock` for ordered page-to-block attachment
+3. host and page management surfaces for creating, attaching, updating, detaching, and deleting blocks
+
+Relevant code paths:
+
+- `app/models/better_together/content/block.rb`
+- `app/models/better_together/content/page_block.rb`
+- `app/controllers/better_together/content/blocks_controller.rb`
+- `app/controllers/better_together/content/page_blocks_controller.rb`
+- `app/controllers/better_together/api/v1/blocks_controller.rb`
+- `app/controllers/better_together/api/v1/page_blocks_controller.rb`
+- `app/resources/better_together/api/v1/block_resource.rb`
+- `app/resources/better_together/api/v1/page_block_resource.rb`
+- `app/tools/better_together/mcp/*block*_tool.rb`
+
+## Block hierarchy
+
+`BlockResource` exposes the engine's current block catalog polymorphically. The concrete block types wired into the API layer on this branch are:
+
+- `AccordionBlock`
+- `AlertBlock`
+- `CallToActionBlock`
+- `ChecklistBlock`
+- `CommunitiesBlock`
+- `Css`
+- `EventsBlock`
+- `Hero`
+- `Html`
+- `Image`
+- `Markdown`
+- `MermaidDiagram`
+- `NavigationAreaBlock`
+- `PeopleBlock`
+- `PostsBlock`
+- `QuoteBlock`
+- `RichText`
+- `StatisticsBlock`
+- `Template`
+- `VideoBlock`
+
+See also:
+
+- [content-block-completeness checklist](../../content-block-completeness-checklist.md)
+- [block resource hierarchy diagram](../../diagrams/source/blockresource_hierarchy_and_types.mmd)
+
+## Data model
+
+### `BetterTogether::Content::Block`
+
+The base block model stores shared CMS fields:
+
+- `identifier`
+- `privacy`
+- `visible`
+- `protected`
+- `type` for STI dispatch
+- JSON-backed configuration in fields such as `content_data`, `css_settings`, `media_settings`, and related settings columns
+
+`BlockResource` exposes `type` as `block_type` to avoid JSON:API reserved-word conflicts. It also flattens block-specific Storext attributes and locale-suffixed translated attributes into one API surface.
+
+### `BetterTogether::Content::PageBlock`
+
+`PageBlock` is the ordered join between a page and a block. It is the authoritative place for:
+
+- page attachment
+- display order via `position`
+- detach operations that leave the underlying block reusable
+
+This matters because creating a block record does not automatically place it on a page unless the caller uses a page-aware path such as `PageBlocksController`, `PageBlockResource`, or the page-oriented MCP tools.
+
+## Management surfaces
+
+### Host UI
+
+Platform-level content managers have a host inventory at:
+
+- `/host/content/blocks`
+
+The host UI can create, edit, inspect, and delete reusable block records through `BetterTogether::Content::BlocksController`.
+
+Authorization is handled by `BetterTogether::Content::BlockPolicy`, which currently allows management only for users with `manage_platform_settings` or `manage_platform`.
+
+### Page builder UI
+
+Page-specific block attachment flows run through:
+
+- `/host/pages/:page_id/page_blocks/new`
+- `/host/pages/:page_id/page_blocks/:id`
+
+`BetterTogether::Content::PageBlocksController` builds a new `PageBlock`, initializes the requested block type, and returns Turbo Stream form fragments for page editing.
+
+### JSON:API
+
+Two JSON:API resources are part of the public API namespace:
+
+- `blocks`
+- `page_blocks`
+
+Use `blocks` for block records and `page_blocks` for page attachment and ordering. The dedicated [Block Management API Guide](../../api/block-management-api-guide.md) covers the request patterns.
+
+### MCP tools
+
+Block management also has a dedicated MCP tool set:
+
+- `list_page_blocks`
+- `get_block`
+- `create_page_block`
+- `update_block`
+- `delete_page_block`
+
+These tools are implemented under `app/tools/better_together/mcp/` and are tagged `:authenticated`, so they are only exposed when the current MCP request resolves to an authenticated user context. The server-level filtering lives in `config/initializers/fast_mcp.rb`.
+
+## CRUD and attachment model
+
+The current block lifecycle is intentionally split:
+
+1. create or update a reusable block record
+2. attach it to a page through `PageBlock`
+3. reorder or detach the `PageBlock`
+4. optionally destroy the underlying block when it is no longer attached elsewhere
+
+Two details are easy to miss:
+
+- `PageBlockResource#_remove` uses SQL `delete`, not Active Record `destroy`, so detaching a block does not cascade into block deletion.
+- `DeletePageBlockTool` can delete the block record too, but only when it is no longer attached to other pages.
+
+See:
+
+- [block CRUD and management flow](../../diagrams/source/block_crud_and_management_flow.mmd)
+
+## Localization and block-specific attributes
+
+`BlockResource` exposes locale-suffixed translated attributes for `en`, `fr`, `es`, and `uk`, including fields such as:
+
+- `heading_en`
+- `content_fr`
+- `caption_es`
+- `diagram_source_uk`
+
+It also exposes guarded block-specific attributes such as:
+
+- `accordion_items_json`
+- `alert_level`
+- `video_url`
+- `stats_json`
+- `navigation_area_id`
+- `template_path`
+- `markdown_file_path`
+- `html_content`
+- `cta_url`
+
+The exact writable attribute set depends on the block class. `create_page_block_tool.rb`, `update_block_tool.rb`, and `BlockResource` all use the block class's permitted/localized attribute lists rather than allowing arbitrary keys.
+
+## What is not in scope here
+
+This release slice includes block JSON:API coverage and MCP tooling, but it does not add a separate admin framework or a different CMS storage model. The same `Content::Block` and `PageBlock` models back the host UI, the API, and the MCP tools.
+
+For page publishing, page visibility, and cache behavior beyond block CRUD, see [Content Management System](content_management.md).

--- a/docs/developers/systems/membership_request_system.md
+++ b/docs/developers/systems/membership_request_system.md
@@ -1,0 +1,124 @@
+# Membership Request System
+
+This guide documents the membership-request flow that exists in Community Engine `0.11.0`.
+
+## Overview
+
+Membership requests let people ask to join a community through either:
+
+- a public unauthenticated request flow
+- an authenticated request flow for an already signed-in person
+
+Relevant code paths:
+
+- `app/models/better_together/joatu/membership_request.rb`
+- `app/controllers/better_together/membership_requests_controller.rb`
+- `app/controllers/better_together/api/v1/membership_requests_controller.rb`
+- `app/resources/better_together/api/v1/membership_request_resource.rb`
+- `app/policies/better_together/joatu/membership_request_policy.rb`
+
+## Web routes
+
+Community-scoped routes are defined under:
+
+- `GET /c/:community_id/membership_requests`
+- `GET /c/:community_id/membership_requests/new`
+- `POST /c/:community_id/membership_requests`
+- `GET /c/:community_id/membership_requests/:id`
+- `DELETE /c/:community_id/membership_requests/:id`
+- `POST /c/:community_id/membership_requests/:id/approve`
+- `POST /c/:community_id/membership_requests/:id/decline`
+
+The controller skips authentication only for `new` and `create`, so submission is public but management is not.
+
+## Request model behavior
+
+`BetterTogether::Joatu::MembershipRequest` is a specialized `Request` subtype with a few important rules:
+
+- the target must be a `BetterTogether::Community`
+- unauthenticated requests require `requestor_email`
+- the request name is auto-generated from `requestor_name`, creator name, or email if needed
+- every request is automatically assigned to the "Membership Requests" category
+
+## Dual approval paths
+
+The core behavior lives in `after_agreement_acceptance!` and `approve!`.
+
+### 1. Unauthenticated visitor path
+
+If the request has no `creator`:
+
+1. the visitor submits a public membership request
+2. a manager approves it
+3. the model creates or reuses a `CommunityInvitation`
+4. the visitor later registers or accepts through the invitation flow
+5. membership is created from the invitation path
+
+### 2. Authenticated person path
+
+If the request has a `creator`:
+
+1. a signed-in person submits the request
+2. a manager approves it
+3. the model creates or finds a `PersonCommunityMembership`
+4. the request status is updated to fulfilled
+
+See:
+
+- [membership request lifecycle flow](../../diagrams/source/membership_request_lifecycle_flow.mmd)
+
+## Status model
+
+The current controller and model use three effective states:
+
+- `open` for newly submitted requests
+- `fulfilled` after approval
+- `closed` after decline
+
+`MembershipRequestsController#index` defaults to showing open requests unless a status filter is supplied.
+
+## Authorization
+
+`MembershipRequestPolicy` is intentionally asymmetric:
+
+- `create?` is open to the public
+- `approve?`, `decline?`, `destroy?`, and management reads are reserved for platform managers or community managers
+- the creator of an authenticated request can read their own request when authenticated
+
+The policy scope also allows community managers to see requests for communities they manage.
+
+## Captcha hook
+
+Both the HTML controller and the API controller expose a `validate_captcha_if_enabled?` hook. On this branch, the default implementation returns `true`, which means host applications are expected to override that hook if they want enforced captcha validation.
+
+## JSON:API surface
+
+The API layer exposes:
+
+- `GET /api/v1/membership_requests`
+- `GET /api/v1/membership_requests/:id`
+- `POST /api/v1/membership_requests`
+- `DELETE /api/v1/membership_requests/:id`
+
+The create action is intentionally public. Read and destroy actions still depend on the authenticated API context.
+
+`MembershipRequestResource` currently exposes:
+
+- `requestor_name`
+- `requestor_email`
+- `referral_source`
+- `target_type`
+- `target_id`
+- `description`
+
+`description` is serialized as plain text for JSON consumers.
+
+## What is not present
+
+This branch does not include dedicated MCP tools for membership requests. Automation currently goes through:
+
+- the HTML controller
+- the JSON:API resource/controller
+- the model and policy layer
+
+There is also no anonymous self-serve tracking link in the controller flow after public submission. Public users get the success page, but later management remains authenticated and manager-scoped.

--- a/docs/developers/systems/multi_tenant_platform_runtime.md
+++ b/docs/developers/systems/multi_tenant_platform_runtime.md
@@ -1,0 +1,131 @@
+# Multi-Tenant Platform Runtime
+
+This document explains the runtime platform model used in the `0.11.0` release lane. In Community Engine, “multi-tenant” currently means host-and-platform-aware request scoping and platform-bound records inside a shared application, not a fully separate schema per tenant.
+
+## Runtime model at a glance
+
+The current runtime model is built around:
+
+- a host platform record
+- `PlatformDomain` resolution from the incoming request host
+- `Current.platform` and `Current.platform_domain`
+- platform-bound content and memberships
+- explicit `PlatformConnection` records for inter-platform federation
+
+This is the runtime model operators and developers work with today.
+
+## What this release adds
+
+The `0.11.0` release lane introduces the main platform-level building blocks:
+
+- `better_together_platforms`
+- `better_together_person_platform_memberships`
+- `better_together_platform_connections`
+- `better_together_federation_access_tokens`
+- `platform_id` on posts, pages, events, and notifications
+
+These changes give the application a platform-aware runtime boundary even though data still lives in the same Rails application and primary database.
+
+## Context resolution
+
+### `Current`
+
+Location: `app/models/current.rb`
+
+`Current` stores:
+
+- `person`
+- `platform`
+- `platform_domain`
+
+This keeps platform resolution available throughout request handling, mailers, jobs, and helpers.
+
+### Rack middleware
+
+Location: `app/middleware/better_together/platform_context_middleware.rb`
+
+The middleware resolves the request host before controller actions run:
+
+1. get the hostname from the rack request
+2. resolve the matching `PlatformDomain`
+3. choose the domain’s platform, or fall back to the cached host platform
+4. assign `Current.platform_domain` and `Current.platform`
+5. reset `Current` and `ActiveStorage::Current` after the request
+
+This is the main reason platform-aware behavior is available consistently across:
+
+- web requests
+- JSON:API controllers
+- federation API controllers
+- MCP/tooling paths
+
+## Host platform fallback
+
+If the request does not resolve to a known `PlatformDomain`, the middleware falls back to the host platform. The host platform ID is cached rather than serializing a full Active Record object into the cache store, which avoids stale-object and YAML safe-load problems.
+
+## Platform-bound records
+
+Several release surfaces are now explicitly platform-bound:
+
+- posts
+- pages
+- events
+- notifications
+- platform memberships
+- storage configurations
+
+This keeps local queries and federation behaviors anchored to the active platform context.
+
+## Federation inside the platform runtime
+
+Federation is not a separate subsystem floating outside the tenant model. It is built directly on top of the platform runtime:
+
+- `PlatformConnection` links two platforms
+- federation OAuth trust uses the resolved source platform
+- mirrored content is imported into the target platform
+- sync state is stored on the connection itself
+
+That means multi-tenant runtime and federation docs should be read together.
+
+## Storage in the platform runtime
+
+Storage configuration is also platform-aware in this release:
+
+- a platform can own many `StorageConfiguration` records
+- a platform can select one active storage configuration
+- `StorageResolver` falls back to environment configuration if no platform config is active
+
+This is one of the first operator-facing examples of a platform-level runtime decision that changes infrastructure behavior without requiring a separate application instance.
+
+## Operational expectations
+
+For an upgraded deployment, operators should expect:
+
+- one host platform exists
+- existing content records are backfilled to the host platform
+- existing people gain host-platform memberships
+- platform-aware routes and federation endpoints are mounted after migration
+
+The deployment and migration sequence is documented in the upgrade guide.
+
+## What this is not
+
+This document is intentionally about the runtime model in the current release lane. It does **not** claim that Community Engine has completed schema-isolated tenant separation.
+
+For future or broader architecture planning, continue to treat:
+
+- `docs/implementation/multi_tenancy/*`
+- `docs/assessments/multi_tenancy_gap_assessment_2026-03-11.md`
+
+as planning and assessment artifacts rather than the canonical “how it works today” runtime source.
+
+## Related docs
+
+- [Federation system](federation_system.md)
+- [Multi-Tenancy Upgrade Guide](../../upgrade/multi-tenancy-upgrade.md)
+- [Storage configuration guide](../../platform_organizers/storage_configuration_guide.md)
+- [0.11.0 Release Overview](../../releases/0.11.0.md)
+
+## Diagram
+
+- [Multi-tenant platform runtime flow](../../diagrams/source/multi_tenant_platform_runtime_flow.mmd)

--- a/docs/developers/systems/personal_data_exports_and_seeds.md
+++ b/docs/developers/systems/personal_data_exports_and_seeds.md
@@ -1,0 +1,135 @@
+# Personal Data Exports and Seeds
+
+This guide documents the personal-export and seed-management functionality that exists in Community Engine `0.11.0`.
+
+## Overview
+
+On this branch, "seed" has three related meanings:
+
+1. a canonical `BetterTogether::Seed` record that stores a portable data envelope
+2. a self-service personal export created from a person's own account data
+3. a host-managed or federated import/export payload used to move structured data between systems
+
+Relevant code paths:
+
+- `app/models/better_together/seed.rb`
+- `app/models/concerns/better_together/seedable.rb`
+- `app/controllers/better_together/person_seeds_controller.rb`
+- `app/controllers/better_together/seeds_controller.rb`
+- `app/policies/better_together/person_seed_policy.rb`
+- `app/policies/better_together/seed_policy.rb`
+- `app/services/better_together/seeds/`
+
+## Core model: `BetterTogether::Seed`
+
+`BetterTogether::Seed` is the canonical storage model for portable exports.
+
+Current behaviors include:
+
+- attached YAML export via `has_one_attached :yaml_file`
+- structured metadata fields such as `type`, `identifier`, `version`, `created_by`, `seeded_at`, `description`, and `origin`
+- JSON payload storage in `payload`
+- import helpers such as `import`, `import_or_update!`, and `plant_with_validation`
+- classification helpers such as `personal_export?`, `private_linked?`, and `platform_shared?`
+
+The model also re-attaches the YAML export after create and after content-bearing updates so the stored file tracks the current record contents.
+
+## Security and validation
+
+The seed system includes several guardrails in `Seed` itself:
+
+- allowed seed file directories are limited to `config/seeds`
+- YAML file size is capped at 10 MB
+- YAML loading uses `YAML.safe_load_file`
+- aliases are disabled
+- only a small permitted class list is accepted during YAML load
+
+These guardrails are relevant for file-backed imports and for any host app code that works directly with seed files on disk.
+
+## Personal data exports
+
+### Entry point
+
+Authenticated users reach the self-service export flow through:
+
+- `GET /my/seeds`
+- `POST /my/seeds/export`
+- `GET /my/seeds/:id`
+- `DELETE /my/seeds/:id`
+
+Implementation lives in `BetterTogether::PersonSeedsController`.
+
+### Policy and scope
+
+`PersonSeedPolicy` and `PersonSeedPolicy::Scope` restrict self-service access to personal exports that:
+
+- belong to the current person
+- are seeded from `BetterTogether::Person`
+- were created by that same person
+
+### Export flow
+
+When a signed-in user requests an export:
+
+1. the controller authorizes against `PersonSeedPolicy`
+2. it resolves `current_user.person`
+3. it enforces a one-hour cooldown using `Seed.personal_exports_for(person)`
+4. it calls `person.export_as_seed(creator_id: person.id)`
+5. the resulting `Seed` record appears in the person's seed list and can be viewed, downloaded, or deleted
+
+The controller logs the export request under a GDPR-oriented log message, but this branch does not show a separate background-job queue for the personal export itself.
+
+See also:
+
+- [personal data export flow diagram](../../diagrams/source/personal_data_export_seed_flow.mmd)
+- [Personal Data Export Guide](../../end_users/personal_data_export_guide.md)
+
+## `Seedable`
+
+`BetterTogether::Seedable` is the export contract mixed into models that can emit seed envelopes.
+
+Current capabilities include:
+
+- `export_as_seed`
+- `export_as_seed_yaml`
+- `export_collection_as_seed`
+- `export_collection_as_seed_yaml`
+
+The concern also defines `plant`, which records the minimum model class and record identifier data needed for the seed envelope.
+
+## Host-managed seed CRUD
+
+Platform managers have a separate seed-management UI at:
+
+- `/host/seeds`
+
+`BetterTogether::SeedsController` provides CRUD for seed records, including JSON parsing for submitted `origin` and `payload` values.
+
+Authorization is handled by `SeedPolicy`, which currently restricts this surface to users who can `manage_platform`.
+
+## Federated and linked seed flows
+
+Beyond self-service exports, the branch also contains federation-oriented services:
+
+- `BetterTogether::Seeds::FederatedSeedBuilder`
+- `BetterTogether::Seeds::FederatedSeedIngestor`
+- `BetterTogether::Seeds::LinkedSeedExportService`
+- `BetterTogether::Seeds::LinkedSeedIngestService`
+- `BetterTogether::Seeds::PersonLinkedSeedCacheService`
+
+`FederatedSeedBuilder` currently supports portable export envelopes for:
+
+- `BetterTogether::Post`
+- `BetterTogether::Page`
+- `BetterTogether::Event`
+
+It embeds lane and source-platform metadata into the exported origin data.
+
+## What is not present
+
+The current branch does not expose a dedicated JSON:API resource or MCP tool for personal data exports or host seed management. Those workflows are implemented through:
+
+- Rails controllers and policies for self-service and host CRUD
+- model/service methods for import, export, and federation
+
+If you need the user-facing steps, see [Personal Data Export Guide](../../end_users/personal_data_export_guide.md).

--- a/docs/developers/systems/search_and_filtering_system.md
+++ b/docs/developers/systems/search_and_filtering_system.md
@@ -1,0 +1,138 @@
+# Search and Filtering System
+
+This document describes the search and filtering behavior that is actually present in the `0.11.0` release-docs worktree.
+
+## Scope
+
+Search and filtering currently live in four different surfaces:
+
+1. the global `/search` page
+2. the event index in `EventsController#index`
+3. MCP tools for posts and events
+4. the Joatu offer/request filter service
+
+The changelog references dedicated `PostsSearchFilter` and `EventsSearchFilter` services, but those classes and their user-facing filter partials are not present in this worktree. This document stays aligned to the code that exists now.
+
+## Global search
+
+Main files:
+
+- `app/controllers/better_together/search_controller.rb`
+- `app/services/better_together/search.rb`
+- `app/services/better_together/search/elasticsearch_backend.rb`
+- `app/services/better_together/search/elasticsearch_query.rb`
+- `app/services/better_together/search/registry.rb`
+- `app/models/concerns/better_together/searchable.rb`
+
+Current flow:
+
+1. `SearchController#search` reads `params[:q]`
+2. `BetterTogether::Search.backend.search(@query)` dispatches to the Elasticsearch backend
+3. results are paginated in memory at 10 per page
+4. `TrackSearchQueryJob` records query text, result count, and locale when a query is present
+
+Current backend statuses exposed by the controller:
+
+- `idle` when the query is blank
+- `ok` when the backend returns results normally
+- `unreachable` when Elasticsearch raises or cannot be reached
+- `disabled` when the backend is not configured
+
+## What the search registry indexes
+
+`BetterTogether::Search::Registry::ENTRIES` currently includes only:
+
+- `BetterTogether::Page`
+- `BetterTogether::Post`
+
+That means:
+
+- posts participate in global search
+- pages participate in global search
+- events do not currently participate in global search
+- the registry is also the scope used by the search rake tasks and audit tooling
+
+## Query behavior
+
+`BetterTogether::Search::ElasticsearchQuery` builds a `multi_match` query with:
+
+- `type: 'best_fields'`
+- `operator: 'and'`
+
+It also requests term suggestions against the `name` field.
+
+Search indexing is maintained through the `Searchable` concern:
+
+- `after_commit` enqueues index jobs for persisted records
+- destroy callbacks enqueue delete jobs
+- the concern provides helpers for create, delete, refresh, and import operations
+
+## Event discovery and filtering
+
+Main files:
+
+- `app/controllers/better_together/events_controller.rb`
+- `app/models/better_together/event.rb`
+- `app/policies/better_together/event_policy.rb`
+- `app/tools/better_together/mcp/list_events_tool.rb`
+
+The web index does not currently apply a dedicated search form. Instead, it:
+
+- loads the policy-scoped event relation
+- includes categories
+- derives `@draft_events`, `@upcoming_events`, `@ongoing_events`, and `@past_events`
+
+The event model supplies the timing scopes:
+
+- `draft`
+- `scheduled`
+- `upcoming`
+- `ongoing`
+- `past`
+
+Visibility is handled by `EventPolicy::Scope`, which allows extra access for creators, platform stewards, event hosts, attendees, and valid invitation tokens.
+
+## Post filtering outside global search
+
+There is no dedicated posts index filter controller on this branch.
+
+The closest implemented branch surface is the MCP `SearchPostsTool`, which:
+
+- starts from `policy_scope(BetterTogether::Post)`
+- limits results to published, accessible posts
+- respects block relationships through `PostPolicy::Scope`
+- searches translated post content and titles
+- orders by `published_at DESC`
+
+## Event filtering outside the web index
+
+`ListEventsTool` exposes the most explicit event filter API on this branch.
+
+Supported arguments:
+
+- `scope`: `upcoming`, `past`, `ongoing`, `draft`, `scheduled`
+- `privacy_filter`: `public` or `private`
+- `limit`
+
+Results are ordered by `starts_at ASC` and serialized as JSON for MCP clients.
+
+## Joatu filtering is separate
+
+`app/services/better_together/joatu/search_filter.rb` powers offer/request filtering, not posts or events. It supports category filters, text search, open/closed status, order-by, and pagination for Joatu resources only.
+
+## Operational hooks
+
+Search maintenance lives in `lib/tasks/search.rake`:
+
+- `better_together:search:audit`
+- `better_together:search:refresh`
+- `better_together:search:reindex_all`
+- `better_together:search:reindex_pages`
+- `better_together:search:recreate_indices`
+
+See also:
+
+- [Search and Filter Guide](../../end_users/search_and_filter_guide.md)
+- [Elasticsearch Upgrade to 8 Guide](../../platform_organizers/elasticsearch_upgrade_to_8_guide.md)
+- [Posts search and filter flow](../../diagrams/source/posts_search_and_filter_flow.mmd)
+- [Events search and filter flow](../../diagrams/source/events_search_and_filter_flow.mmd)

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -60,6 +60,17 @@ bin/render_diagrams
 5. **Verify**: Run tests and quality checks
 6. **Commit**: Submit pull request
 
+## Repo-local session wrappers
+
+This repository now includes repo-local wrappers so session logs and linked worktree metadata stay attached to the canonical repository root instead of disposable worktrees.
+
+Useful commands:
+
+```bash
+./scripts/session_command_log.sh init
+./scripts/session_worktree.sh ensure --repo . --agent local --session-id example --storage-mode local
+```
+
 ## Related Documentation
 
 - [Architecture](../developers/architecture/) - System architecture

--- a/docs/diagrams/source/block_crud_and_management_flow.mmd
+++ b/docs/diagrams/source/block_crud_and_management_flow.mmd
@@ -1,0 +1,18 @@
+flowchart TD
+  Manager["Platform content manager"] --> HostUI["Host block UI\n/host/content/blocks"]
+  Manager --> PageUI["Page builder UI\n/host/pages/:page_id"]
+  Agent["Authenticated MCP client"] --> MCP["MCP block tools"]
+  Script["Authenticated API client"] --> API["JSON:API\n/api/v1/blocks and /api/v1/page_blocks"]
+
+  HostUI --> Block["Content::Block"]
+  PageUI --> PageBlock["Content::PageBlock"]
+  MCP --> Block
+  MCP --> PageBlock
+  API --> Block
+  API --> PageBlock
+
+  Block --> Reusable["Reusable block record"]
+  PageBlock --> Placement["Page attachment and ordering"]
+
+  Reusable --> DeleteBlock["Delete block record\nonly when explicitly destroyed"]
+  Placement --> Detach["Detach from page\nwithout cascading block deletion"]

--- a/docs/diagrams/source/blockresource_hierarchy_and_types.mmd
+++ b/docs/diagrams/source/blockresource_hierarchy_and_types.mmd
@@ -1,0 +1,29 @@
+flowchart TD
+  BlockResource["BlockResource\nJSON:API polymorphic resource"]
+
+  BlockResource --> Editorial["Editorial and layout blocks"]
+  BlockResource --> Data["Data-backed blocks"]
+  BlockResource --> Visual["Visual and embed-style blocks"]
+
+  Editorial --> Hero["Hero"]
+  Editorial --> RichText["RichText"]
+  Editorial --> Markdown["Markdown"]
+  Editorial --> Html["Html"]
+  Editorial --> Css["Css"]
+  Editorial --> Template["Template"]
+  Editorial --> Accordion["AccordionBlock"]
+  Editorial --> Alert["AlertBlock"]
+  Editorial --> CTA["CallToActionBlock"]
+  Editorial --> Quote["QuoteBlock"]
+  Editorial --> Stats["StatisticsBlock"]
+
+  Visual --> Image["Image"]
+  Visual --> Video["VideoBlock"]
+  Visual --> Mermaid["MermaidDiagram"]
+
+  Data --> Communities["CommunitiesBlock"]
+  Data --> Events["EventsBlock"]
+  Data --> People["PeopleBlock"]
+  Data --> Posts["PostsBlock"]
+  Data --> Checklist["ChecklistBlock"]
+  Data --> Navigation["NavigationAreaBlock"]

--- a/docs/diagrams/source/elasticsearch_8_reindex_and_validation_flow.mmd
+++ b/docs/diagrams/source/elasticsearch_8_reindex_and_validation_flow.mmd
@@ -1,0 +1,18 @@
+        flowchart TD
+            EnvVars[Elasticsearch env vars] --> ClientOptions[ElasticsearchClientOptions.build]
+            ClientOptions --> Client[Elasticsearch::Client]
+            Client --> Backend[Search backend]
+
+            Backend --> AuditTask[rake better_together:search:audit]
+            AuditTask --> AuditService[AuditService]
+            AuditService --> Health[Backend status]
+            AuditService --> Drift[DB to index drift report]
+
+            Backend --> ReindexAll[rake better_together:search:reindex_all]
+            Backend --> Refresh[rake better_together:search:refresh]
+            Backend --> Recreate[rake better_together:search:recreate_indices]
+
+            Registry[Search::Registry
+Page + Post] --> ReindexAll
+            Registry --> Refresh
+            Registry --> Recreate

--- a/docs/diagrams/source/events_search_and_filter_flow.mmd
+++ b/docs/diagrams/source/events_search_and_filter_flow.mmd
@@ -1,0 +1,19 @@
+        flowchart LR
+            EventIndex[GET /events] --> EventScope[EventPolicy::Scope]
+            EventScope --> EventRelation[EventsController resource_collection]
+            EventRelation --> Draft[Event.draft]
+            EventRelation --> Upcoming[Event.upcoming]
+            EventRelation --> Ongoing[Event.ongoing]
+            EventRelation --> Past[Event.past]
+
+            InvitationToken[Invitation token] --> EventScope
+            HostOrAttendance[Creator host attendee context] --> EventScope
+
+            McpList[MCP ListEventsTool] --> McpScope[Optional scope filter]
+            McpScope --> PrivacyFilter[Optional privacy filter]
+            PrivacyFilter --> OrderedJson[Ordered JSON results
+starts_at ASC]
+
+            BranchNote[No dedicated EventsSearchFilter
+service in this worktree]
+            EventIndex --> BranchNote

--- a/docs/diagrams/source/federation_content_mirroring_flow.mmd
+++ b/docs/diagrams/source/federation_content_mirroring_flow.mmd
@@ -1,0 +1,19 @@
+flowchart TD
+  A[Remote platform exports seeds] --> B[FederatedContentPullJob]
+  B --> C[Mark PlatformConnection sync started]
+  C --> D[FederatedContentPullService fetches paginated batch]
+  D --> E[FederatedContentIngestService]
+  E --> F[Set Current.platform to target platform]
+  F --> G[FederatedSeedIngestor]
+  G --> H{Seed type}
+  H -->|post| I[FederatedPostMirrorService]
+  H -->|page| J[FederatedPageMirrorService]
+  H -->|event| K[FederatedEventMirrorService]
+  I --> L[Create or update mirrored record]
+  J --> L
+  K --> L
+  L --> M[Record processed count and sync cursor]
+  M --> N{next_cursor present?}
+  N -->|Yes| O[Enqueue next pull job]
+  N -->|No| P[Mark sync succeeded]
+

--- a/docs/diagrams/source/federation_oauth_trust_flow.mmd
+++ b/docs/diagrams/source/federation_oauth_trust_flow.mmd
@@ -1,0 +1,18 @@
+sequenceDiagram
+  participant Remote as Remote platform
+  participant CE as Federation::OauthTokensController
+  participant Conn as PlatformConnection
+  participant Issuer as FederationAccessTokenIssuer
+  participant Feed as Federation::ContentFeedController
+
+  Remote->>CE: POST /federation/oauth/token\nclient_credentials + scopes
+  CE->>Conn: Find active connection by Current.platform + client_id
+  CE->>Conn: Authenticate oauth client secret
+  CE->>Issuer: Authorize scopes and issue short-lived token
+  Issuer-->>CE: bearer token + scopes + expiry
+  CE-->>Remote: access_token response
+  Remote->>Feed: GET /federation/content_feed\nAuthorization: Bearer token
+  Feed->>Conn: Resolve token to platform_connection
+  Feed->>Feed: Enforce content.feed.read scope
+  Feed-->>Remote: seeds + next_cursor
+

--- a/docs/diagrams/source/federation_platform_connection_flow.mmd
+++ b/docs/diagrams/source/federation_platform_connection_flow.mmd
@@ -1,0 +1,13 @@
+flowchart TD
+  A[Create local and remote Platform records] --> B[Create PlatformConnection]
+  B --> C[Set connection kind and policy flags]
+  C --> D{Approve connection?}
+  D -->|No| E[Remain pending]
+  D -->|Yes| F[Status becomes active]
+  F --> G[Rotate or confirm OAuth credentials]
+  G --> H[Remote side requests token]
+  H --> I[Connection used for feed access and sync]
+  I --> J{Incident or governance pause?}
+  J -->|Yes| K[Suspend connection]
+  J -->|No| L[Continue sync operations]
+

--- a/docs/diagrams/source/membership_request_lifecycle_flow.mmd
+++ b/docs/diagrams/source/membership_request_lifecycle_flow.mmd
@@ -1,0 +1,16 @@
+flowchart TD
+  Visitor["Visitor or signed-in person"] --> Form["Membership request form"]
+  Form --> Create["Create MembershipRequest\nstatus=open"]
+  Create --> Queue["Community manager review"]
+
+  Queue --> Approve["Approve"]
+  Queue --> Decline["Decline"]
+
+  Decline --> Closed["status=closed"]
+
+  Approve --> Authenticated{"creator present?"}
+  Authenticated -->|yes| Membership["Create PersonCommunityMembership"]
+  Authenticated -->|no| Invitation["Create CommunityInvitation"]
+
+  Membership --> Fulfilled["status=fulfilled"]
+  Invitation --> Fulfilled

--- a/docs/diagrams/source/multi_tenant_platform_runtime_flow.mmd
+++ b/docs/diagrams/source/multi_tenant_platform_runtime_flow.mmd
@@ -1,0 +1,15 @@
+flowchart TD
+  A[Incoming request host] --> B[PlatformContextMiddleware]
+  B --> C[Resolve PlatformDomain]
+  C --> D{Domain found?}
+  D -->|Yes| E[Set Current.platform_domain]
+  D -->|No| F[Use cached host platform]
+  E --> G[Set Current.platform]
+  F --> G
+  G --> H[Controller, API, MCP, mailer helpers use platform context]
+  H --> I[Platform-scoped records and permissions]
+  I --> J[Platform connections and federation]
+  I --> K[Platform storage resolution]
+  J --> L[platform_sync jobs]
+  B --> M[Reset Current after request]
+

--- a/docs/diagrams/source/personal_data_export_seed_flow.mmd
+++ b/docs/diagrams/source/personal_data_export_seed_flow.mmd
@@ -1,0 +1,17 @@
+flowchart TD
+  User["Signed-in user"] --> Index["GET /my/seeds"]
+  Index --> Export["POST /my/seeds/export"]
+  Export --> Cooldown{"Export in\nlast hour?"}
+  Cooldown -->|yes| TooSoon["Reject new export"]
+  Cooldown -->|no| Seedable["current_user.person.export_as_seed"]
+
+  Seedable --> Seed["BetterTogether::Seed record"]
+  Seed --> Attachment["YAML attachment callbacks"]
+  Seed --> Show["GET /my/seeds/:id"]
+  Show --> Download["Download YAML"]
+  Show --> Destroy["DELETE /my/seeds/:id"]
+
+  PlatformManager["Platform manager"] --> HostSeeds["/host/seeds CRUD"]
+  HostSeeds --> Seed
+
+  Seed --> Federation["Federated seed services\nfor page/post/event export and ingest"]

--- a/docs/diagrams/source/posts_search_and_filter_flow.mmd
+++ b/docs/diagrams/source/posts_search_and_filter_flow.mmd
@@ -1,0 +1,21 @@
+        flowchart LR
+            SearchBar[Shared search bar
+GET /search?q=...] --> SearchController[SearchController#search]
+            SearchController --> SearchBackend[BetterTogether::Search.backend]
+            SearchBackend --> ElasticsearchBackend[ElasticsearchBackend]
+            ElasticsearchBackend --> Registry[Search::Registry
+Page + Post only]
+            Registry --> PostIndex[Post index]
+            Registry --> PageIndex[Page index]
+            SearchController --> Results[Paginated results
+10 per page]
+            SearchController --> Suggestions[Optional suggestions]
+
+            McpTool[MCP SearchPostsTool] --> PostScope[PostPolicy::Scope]
+            PostScope --> PostQuery[Translated title/body query
+published and accessible posts]
+            PostQuery --> McpResults[JSON post results]
+
+            BranchNote[No dedicated posts filter form
+on this branch]
+            Results --> BranchNote

--- a/docs/diagrams/source/rack_attack_rate_limiting_flow.mmd
+++ b/docs/diagrams/source/rack_attack_rate_limiting_flow.mmd
@@ -1,0 +1,25 @@
+        flowchart TD
+            Request[Incoming request] --> Safelist{Better Stack monitor?}
+            Safelist -->|yes| Allow[Allow request]
+            Safelist -->|no| CacheStore{RACK_ATTACK_REDIS_URL set?}
+
+            CacheStore -->|yes| RedisStore[Redis cache store
+with connection pool]
+            CacheStore -->|no| RailsCache[Rails cache store]
+            RedisStore --> Throttles
+            RailsCache --> Throttles
+
+            Throttles{Throttle match?}
+            Throttles -->|global| Global[req/ip 300 per 5 min]
+            Throttles -->|mcp| Mcp[mcp/ip and mcp/tool-calls]
+            Throttles -->|auth| Auth[login api and oauth throttles]
+            Throttles -->|none| Blocklists
+
+            Global --> Throttled503[503 throttled response]
+            Mcp --> Throttled503
+            Auth --> Throttled503
+
+            Blocklists{Scanner or exploit probe?}
+            Blocklists -->|php wp traversal injection scanners| Fail2Ban[Fail2Ban blocklist rules]
+            Blocklists -->|no| Allow
+            Fail2Ban --> Blocked503[503 blocklisted response]

--- a/docs/diagrams/source/safety_report_lifecycle_flow.mmd
+++ b/docs/diagrams/source/safety_report_lifecycle_flow.mmd
@@ -1,0 +1,24 @@
+        flowchart TD
+            ReportLink[Report link on profile or post] --> ReportForm[Structured report form]
+            ReportForm --> ReportCreate[ReportsController#create]
+            ReportCreate --> ReportModel[BetterTogether::Report]
+            ReportModel --> AutoCase[after_create_commit
+ensure_safety_case!]
+
+            AutoCase --> LaneCheck{Default lane}
+            LaneCheck -->|urgent or retaliation risk| Immediate[immediate_safety]
+            LaneCheck -->|spam scam fraud impersonation misinformation| Administrative[administrative]
+            LaneCheck -->|all other categories| Restorative[restorative]
+
+            Immediate --> CaseQueue[Safety case queue]
+            Administrative --> CaseQueue
+            Restorative --> CaseQueue
+
+            CaseQueue --> Filters[Filter by status lane harm level]
+            Filters --> Manage[Update case status lane closure summary review_at]
+            Manage --> Actions[Protective or accountability actions]
+            Manage --> Notes[Internal or participant-visible notes]
+            Manage --> Agreements[Restorative agreements]
+
+            Manage --> ReporterView[Reporter sees reduced status
+and optional closure summary]

--- a/docs/diagrams/source/storage_backend_selection_flow.mmd
+++ b/docs/diagrams/source/storage_backend_selection_flow.mmd
@@ -1,0 +1,17 @@
+flowchart TD
+  A[Need active storage backend] --> B[StorageResolver]
+  B --> C{Active platform storage config?}
+  C -->|Yes| D[Use StorageConfiguration]
+  C -->|No| E{ACTIVE_STORAGE_SERVICE set?}
+  E -->|Yes| F[Use env-based config]
+  E -->|No| G[Fall back to local disk]
+  D --> H{service_type}
+  H -->|local| I[Disk service]
+  H -->|amazon| J[S3 service with AWS region and bucket]
+  H -->|s3_compatible| K[S3 service with endpoint + force_path_style]
+  F --> L[Build env-based Active Storage config]
+  I --> M[Active service key resolved]
+  J --> M
+  K --> M
+  G --> M
+  L --> M

--- a/docs/end_users/README.md
+++ b/docs/end_users/README.md
@@ -8,9 +8,11 @@ Welcome! This guide helps community members use Better Together platform feature
 
 ## Community Features
 - [Exchange Process](exchange_process.md) - Participating in exchanges and offers
+- [Search and Filter Guide](search_and_filter_guide.md) - How to find posts, pages, and current event listings
 - See also: [Community Management](../community_organizers/community_management.md) for how communities operate
 
 ## Safety and Privacy
+- [Personal Data Export Guide](personal_data_export_guide.md) - How to request, download, and delete your personal export
 - [Safety and Reporting Tools](safety_reporting.md) - Main safety guide and navigation hub
 - [Submission Protection and Security Checks](submission_protection_and_bot_checks.md) - What background anti-bot checks protect public forms
 - [Blocking and Boundaries](blocking_and_boundaries.md) - How to block, unblock, and decide when to block

--- a/docs/end_users/personal_data_export_guide.md
+++ b/docs/end_users/personal_data_export_guide.md
@@ -1,0 +1,51 @@
+# Personal Data Export Guide
+
+This guide explains the self-service personal data export flow that currently exists in Community Engine `0.11.0`.
+
+## Who can use it
+
+The export flow is for signed-in users with an associated person record. The UI lives under:
+
+- `/my/seeds`
+
+## What the export does
+
+When you request an export, Community Engine creates a personal `Seed` record for your person profile. That export can then be:
+
+- viewed in the browser
+- downloaded as a YAML file
+- deleted later from the same screen
+
+The export list also shows metadata such as the export identifier, version, description, and creation time.
+
+## How to request an export
+
+1. open the "My Seeds" page
+2. choose the button to create a new export
+3. return to the export list after the request completes
+4. open the export you want to inspect or download
+
+## Downloading the YAML file
+
+On the export detail page, use the download button to retrieve the attached YAML file.
+
+The detail page also shows:
+
+- seed metadata
+- origin data
+- payload data
+- any recorded planting history attached to that export
+
+## Rate limit
+
+The current branch enforces a one-hour cooldown between personal exports for the same person. If you request another export too soon, the system will keep the existing export list and show an error message instead of creating a new one immediately.
+
+## Deleting an export
+
+You can delete your own personal export from the detail page. Deleting the export removes that stored export record; it does not delete your account or your underlying platform data.
+
+## What this feature is not
+
+This feature is not a public sharing link and it is not an external API. It is a signed-in self-service export flow tied to your own account.
+
+If you need help finding the page or understanding the file, contact your platform support team or organizers.

--- a/docs/end_users/search_and_filter_guide.md
+++ b/docs/end_users/search_and_filter_guide.md
@@ -1,0 +1,78 @@
+# Search and Filter Guide
+
+**Target Audience:** Community members  
+**Document Type:** User Guide  
+**Last Updated:** March 2026
+
+## Overview
+
+In the current `0.11.0` worktree, Community Engine gives you two main ways to find content:
+
+- the shared search bar for site-wide keyword search
+- the events index, which groups events by timing
+
+This guide only covers behavior that exists on this branch today.
+
+## Site-wide search
+
+The shared search form submits a `GET` request to `/search` with a `q` parameter.
+
+What to expect:
+
+- results are shown 10 at a time
+- suggestions may appear when the search backend can offer close matches
+- empty searches open the results page without recording a search query metric
+- search failures do not show a crash page; the app still renders the search screen
+
+## What search currently includes
+
+The current global search registry indexes:
+
+- pages
+- posts
+
+In practice, this means:
+
+- post titles and post body content can appear in results
+- page titles and indexed page block content can appear in results
+- events are **not** part of the current global Elasticsearch registry on this branch
+
+## Searching for posts
+
+Posts are the main user-facing content type currently covered by the search index.
+
+Tips:
+
+- search for distinctive words from a post title first
+- if that does not work, search for a phrase from the post body
+- try a shorter keyword if the first query returns no results
+- use suggestion links when the page offers a close spelling match
+
+## Browsing events
+
+Events are currently discovered through the events index rather than the site-wide search registry.
+
+The events index groups records into these sections:
+
+- **Draft**: no `starts_at` value yet
+- **Upcoming**: starts in the future
+- **Ongoing**: already started and not yet ended
+- **Past**: already finished
+
+Public visitors only see events that are visible through the current event privacy rules. If you have a host role, attendance relationship, or invitation token, you may be able to see more than the public list.
+
+## Current limitations on this branch
+
+The changelog mentions richer posts and events filter forms, but this worktree does not currently include a user-facing sidebar filter form for either content type.
+
+Today, the practical workflow is:
+
+- use `/search` to find pages and posts by keyword
+- use `/events` to browse events by timing
+- open the item itself to review categories, privacy context, and next actions
+
+## Related guides
+
+- [Events system](../developers/systems/events_system.md)
+- [Reporting Harm and Safety Concerns](reporting_harm_and_safety_concerns.md)
+- [0.11.0 Release Overview](../releases/0.11.0.md)

--- a/docs/platform_organizers/block_inventory_and_customization.md
+++ b/docs/platform_organizers/block_inventory_and_customization.md
@@ -1,0 +1,112 @@
+# Block Inventory and Customization
+
+**Target Audience:** Platform organizers and trusted content managers  
+**Document Type:** Operator Guide  
+**Last Updated:** March 2026
+
+## Overview
+
+Community Engine `0.11.0` ships with a reusable content-block inventory that can be managed at the host level and attached to individual pages. This guide summarizes the current block catalog and the customization surfaces that actually exist on this branch.
+
+For the lower-level model and API details, see:
+
+- [Block System and CMS](../developers/systems/block_system_and_cms.md)
+- [Block Management API Guide](../api/block-management-api-guide.md)
+
+## Where organizers manage blocks
+
+Two different UIs matter:
+
+1. `/host/content/blocks` for the reusable host-wide block inventory
+2. `/host/pages/:page_id/...` page editing flows for attaching blocks to specific pages
+
+The host inventory is managed by `BetterTogether::Content::BlocksController`. Page attachment flows are managed by `BetterTogether::Content::PageBlocksController`.
+
+Current authorization uses `BetterTogether::Content::BlockPolicy`, so these tools are intended for platform content managers rather than general community members.
+
+## Current block catalog
+
+The current branch exposes the following block types through the API and management layer.
+
+### Editorial and narrative blocks
+
+- `Hero`
+- `RichText`
+- `Markdown`
+- `Html`
+- `Css`
+- `Template`
+- `MermaidDiagram`
+- `Image`
+- `VideoBlock`
+- `QuoteBlock`
+- `AlertBlock`
+- `AccordionBlock`
+- `CallToActionBlock`
+- `StatisticsBlock`
+
+### Data-backed and navigational blocks
+
+- `CommunitiesBlock`
+- `EventsBlock`
+- `PeopleBlock`
+- `PostsBlock`
+- `ChecklistBlock`
+- `NavigationAreaBlock`
+
+## How customization works
+
+### Shared controls
+
+All blocks share a core management surface:
+
+- `identifier`
+- `privacy`
+- `visible`
+- the underlying block type
+
+Display also depends on page-level state such as page privacy and `published_at`, so a valid block can still be hidden if the page is not visible.
+
+### Reusable block records vs page placement
+
+The reusable block inventory and page placement are separate on purpose:
+
+- a block record can exist without being attached to a page
+- the same block can be reused on more than one page
+- `PageBlock` controls ordering with `position`
+
+This also affects cleanup. Detaching a block from one page does not automatically destroy the underlying block record.
+
+### Localized content
+
+Many block forms and APIs expose locale-specific content fields. In the API layer these appear as keys such as `heading_en`, `content_fr`, or `caption_es`. In the host UI, the same translated content is surfaced through the block forms for block types that define localized attributes.
+
+### Block-specific settings
+
+Different blocks expose different configuration fields. Examples from the current implementation include:
+
+- accordion items and open-first behavior
+- alert level and dismissibility
+- CTA labels and URLs
+- checklist, navigation area, or resource references
+- statistics JSON, media settings, and template paths
+
+The complete writable attribute surface is enforced by each block class and reflected in `BlockResource` and the MCP block tools.
+
+## Recommended organizer workflow
+
+1. create or update the reusable block in `/host/content/blocks`
+2. attach it to the relevant page through the page editing flow
+3. verify block order and page visibility
+4. use the JSON:API or MCP tools only when you need scripted or remote management
+
+## What this branch does not add
+
+This branch does not introduce a separate visual block marketplace or a separate admin-only CMS database. The same `Content::Block` and `PageBlock` records are used by:
+
+- the host UI
+- the page editing flow
+- JSON:API block endpoints
+- the block-focused MCP tools
+
+For implementation completeness tracking by block type, see the existing [Content Block Type Completeness Checklist](../content-block-completeness-checklist.md).

--- a/docs/platform_organizers/elasticsearch_upgrade_to_8_guide.md
+++ b/docs/platform_organizers/elasticsearch_upgrade_to_8_guide.md
@@ -1,0 +1,126 @@
+# Elasticsearch Upgrade to 8 Guide
+
+**Target Audience:** Platform organizers and operators  
+**Document Type:** Administrator Guide  
+**Last Updated:** March 2026
+
+## Overview
+
+This branch already carries Elasticsearch 8 client compatibility work, but it does not ship a one-click deployment script or a large migration playbook. The operator guidance here stays focused on the surfaces that exist in the repo today:
+
+- environment-based client configuration
+- backend health and drift auditing
+- index refresh and reindex tasks
+- current search scope limits
+
+## What is actually indexed on this branch
+
+The search registry currently includes only:
+
+- `BetterTogether::Page`
+- `BetterTogether::Post`
+
+Events are not currently part of the global Elasticsearch registry. If you are validating a release upgrade, treat pages and posts as the authoritative search coverage set for this worktree.
+
+## Client configuration
+
+Main code paths:
+
+- `config/initializers/elasticsearch.rb`
+- `app/services/better_together/elasticsearch_client_options.rb`
+
+Preferred variables:
+
+- `ELASTICSEARCH_URL`
+- `ELASTICSEARCH_USERNAME`
+- `ELASTICSEARCH_PASSWORD`
+- `ELASTICSEARCH_CA_CERT_FILE`
+- `ELASTICSEARCH_CA_FINGERPRINT`
+- `ELASTICSEARCH_SSL_VERIFY`
+
+Fallback variables still supported by the client builder:
+
+- `ES_HOST`
+- `ES_PORT`
+- `ES_USERNAME`
+- `ES_PASSWORD`
+- `ES_CA_CERT_FILE`
+- `ES_CA_FINGERPRINT`
+- `ES_SSL_VERIFY`
+
+## Why Elasticsearch 8 matters here
+
+The client options builder explicitly supports Elasticsearch 8-style TLS configuration by allowing both a CA file and a CA fingerprint. This is the most release-relevant ES8 surface currently represented in code.
+
+Example:
+
+```bash
+ELASTICSEARCH_URL=https://search.example.test:9200
+ELASTICSEARCH_USERNAME=elastic
+ELASTICSEARCH_PASSWORD=secret
+ELASTICSEARCH_CA_CERT_FILE=/certs/http_ca.crt
+ELASTICSEARCH_CA_FINGERPRINT=AA:BB:CC
+ELASTICSEARCH_SSL_VERIFY=true
+```
+
+## Validation workflow
+
+Run the search audit first. It gives you the cleanest branch-supported health view.
+
+```bash
+bundle exec rake better_together:search:audit
+bundle exec rake better_together:search:audit FORMAT=json
+```
+
+The audit reports:
+
+- backend availability
+- whether each expected index exists
+- database row count versus indexed document count
+- drift between database and index
+
+Status meanings from `AuditService`:
+
+- `ok` / `healthy`: configured, reachable, and aligned
+- `missing`: index missing for a registered model
+- `drifted`: document count does not match database count
+- `unreachable`: backend not responding
+- `disabled`: backend not configured
+
+## Reindex workflow
+
+If the backend is reachable but drifted, use the supported rake tasks.
+
+```bash
+bundle exec rake better_together:search:refresh
+bundle exec rake better_together:search:reindex_all
+bundle exec rake better_together:search:reindex_pages
+```
+
+Use `recreate_indices` only when you intentionally want to delete and rebuild all registered indices:
+
+```bash
+bundle exec rake better_together:search:recreate_indices
+```
+
+That task prompts before destructive work.
+
+## Application behavior during search trouble
+
+`SearchController#search` handles backend failures gracefully:
+
+- the page still renders
+- the backend status becomes `unreachable`
+- query tracking still records the attempted search with the returned result count
+
+This is useful for release verification because users do not get a hard exception page when search is down.
+
+## Release caveat
+
+The changelog mentions Elasticsearch 8 validation and optional full reindex support, and both are grounded in this repo. What is **not** present here is a dedicated deployment-orchestration script for cluster upgrades, rolling restarts, or index template migrations. Keep this guide scoped to application-side validation and reindex steps.
+
+## Related docs
+
+- [Search and Filtering System](../developers/systems/search_and_filtering_system.md)
+- [External Services Configuration](../production/external-services-to-configure.md)
+- [Elasticsearch 8 reindex and validation flow](../diagrams/source/elasticsearch_8_reindex_and_validation_flow.mmd)

--- a/docs/platform_organizers/federation_setup_and_activation.md
+++ b/docs/platform_organizers/federation_setup_and_activation.md
@@ -1,0 +1,141 @@
+# Federation Setup and Activation
+
+**Target Audience:** Platform organizers  
+**Document Type:** Operator guide  
+**Last Updated:** March 2026
+
+This guide explains how to activate and operate platform-to-platform federation in the `0.11.0` release lane.
+
+## What federation enables
+
+Federation lets your platform establish a durable trust relationship with another platform and then:
+
+- authorize machine access for content feed exchange
+- mirror selected posts, pages, and events
+- track sync state per connection
+- isolate sync jobs from ordinary user-facing background work
+
+## Before you begin
+
+Confirm the following first:
+
+- the `0.11.0` platform and federation migrations are deployed
+- the host platform exists and resolves correctly for the public host name
+- Sidekiq is running with the `platform_sync` queue available
+- the peer platform has a stable public base URL
+- you have reviewed the governance and privacy implications of sharing content with that platform
+
+See also:
+
+- [Multi-Tenancy Upgrade Guide](../upgrade/multi-tenancy-upgrade.md)
+- [Platform Sync Sidekiq Rollout Plan](../production/platform_sync_sidekiq_rollout_plan.md)
+
+## Step 1: create the platform records
+
+Federation depends on valid platform records for both sides of the relationship.
+
+Verify:
+
+- your local host platform is marked `host: true`
+- the remote platform exists as a non-host platform record with the correct host URL and issuer details
+
+## Step 2: create the `PlatformConnection`
+
+Use the platform connections interface to create a new connection between:
+
+- the local source platform
+- the target or peer platform
+
+Choose the correct connection kind:
+
+- `peer` for platform-to-platform federation
+- `member` only when the relationship model truly reflects that policy
+
+New connections begin in a controlled state and should be reviewed before activation.
+
+## Step 3: configure sharing and authorization policy
+
+Review the connection settings carefully.
+
+Important controls include:
+
+- content-sharing enabled or disabled
+- sharing policy
+- content-type toggles for posts, pages, and events
+- OAuth/federation auth policy
+- per-scope allow flags such as identity and content read
+
+Only grant the scopes your federation relationship actually needs.
+
+## Step 4: activate the connection
+
+Approve the connection only after both sides are configured as intended.
+
+Connection status moves through states such as:
+
+- `pending`
+- `active`
+- `suspended`
+- `blocked`
+
+Use `suspended` when you need to pause federation without deleting the relationship.
+
+## Step 5: verify token issuance and feed access
+
+At minimum, verify:
+
+- the federation OAuth token endpoint responds as expected
+- the remote platform can obtain a scoped bearer token
+- the content feed endpoint returns seeds for an authorized token
+
+If token issuance fails, check:
+
+- the resolved `Current.platform`
+- the connection status
+- the OAuth client ID and client secret
+- whether the requested scopes are actually allowed
+
+## Step 6: monitor sync behavior
+
+Once federation is active, monitor the connection directly.
+
+Key fields and behaviors to watch:
+
+- last sync status
+- last sync started and completed timestamps
+- last sync item count
+- sync cursor progression
+- last sync error message
+
+Because sync jobs run on `platform_sync`, you should also monitor that queue separately from ordinary mailer, notification, and default jobs.
+
+## Operational guidance
+
+### When to suspend a connection
+
+Suspend instead of deleting when:
+
+- a peer is misconfigured
+- a remote outage is causing retry churn
+- governance approval is being revisited
+- you need to pause data exchange during incident response
+
+### What federation does not do
+
+Federation does not merge governance or moderation domains automatically. Mirrored content still lands inside your local platform context and should be governed by your local platform’s stewardship and moderation practices.
+
+### Shared-database caution
+
+When the target is local-hosted in the same database, the mirror layer avoids blindly preserving remote UUIDs. This is intentional and protects against collisions.
+
+## Related docs
+
+- [Federation system](../developers/systems/federation_system.md)
+- [Multi-tenant platform runtime](../developers/systems/multi_tenant_platform_runtime.md)
+- [Platform Sync Sidekiq Rollout Plan](../production/platform_sync_sidekiq_rollout_plan.md)
+
+## Diagrams
+
+- [Platform connection flow](../diagrams/source/federation_platform_connection_flow.mmd)
+- [OAuth trust flow](../diagrams/source/federation_oauth_trust_flow.mmd)
+- [Content mirroring flow](../diagrams/source/federation_content_mirroring_flow.mmd)

--- a/docs/platform_organizers/rack_attack_tuning.md
+++ b/docs/platform_organizers/rack_attack_tuning.md
@@ -1,0 +1,100 @@
+# Rack Attack Tuning
+
+**Target Audience:** Platform organizers and operators  
+**Document Type:** Administrator Guide  
+**Last Updated:** March 2026
+
+## Overview
+
+Rack::Attack is active on this branch and is substantial enough to justify operator guidance. The configuration lives in `config/initializers/rack_attack.rb` and covers:
+
+- global request throttling
+- MCP-specific throttles
+- authentication endpoint throttles
+- Fail2Ban-style blocklists for common scanner and exploit patterns
+- optional Redis-backed counters
+
+## Cache store behavior
+
+If `RACK_ATTACK_REDIS_URL` is present, Rack::Attack uses `ActiveSupport::Cache::RedisCacheStore` backed by a connection pool.
+
+Related variables:
+
+- `RACK_ATTACK_REDIS_URL`
+- `RACK_ATTACK_REDIS_POOL_SIZE` (default `5`)
+- `RACK_ATTACK_REDIS_POOL_TIMEOUT` (default `5.0`)
+
+If `RACK_ATTACK_REDIS_URL` is not set, Rack::Attack falls back to the Rails cache store.
+
+## Current throttle set
+
+Global:
+
+- `req/ip`: 300 requests per 5 minutes per IP
+
+MCP:
+
+- `mcp/ip`: 60 requests per minute per IP for `/mcp*`
+- `mcp/tool-calls/ip`: 30 POST requests per minute for `/mcp/messages`
+- `mcp/token`: 120 requests per minute per bearer token prefix
+
+Authentication and identity endpoints:
+
+- `logins/ip`: 5 POSTs per 20 seconds to `/users/sign-in`
+- `logins/email`: 5 POSTs per 20 seconds per normalized email
+- `api_logins/ip`: 5 POSTs per 20 seconds to `/api/auth/sign_in`
+- `api_registrations/ip`: 3 POSTs per minute to `/api/auth/sign_up`
+- `api_password_resets/ip`: 5 POSTs per minute to `/api/auth/password`
+- `oauth/token/ip`: 10 POSTs per minute to `/oauth/token`
+- `oauth/token/client_id`: 10 POSTs per minute per OAuth `client_id`
+
+## Current blocklists
+
+Immediate or progressive blocks exist for:
+
+- `.php` requests
+- WordPress and common CMS probe paths
+- URL template probes such as `/blog/[year]/[slug]`
+- path traversal attempts
+- header or URL injection probes
+- common vulnerability scanner paths such as `.env`, `.git`, `cgi-bin`, and `xmlrpc.php`
+
+## Response behavior
+
+Both throttled and blocklisted requests return `503` responses on this branch.
+
+That means:
+
+- rate-limited clients do not receive the default `429`
+- logs and external monitors should treat repeated empty-body `503` responses carefully
+- application operators should distinguish genuine outages from deliberate Rack::Attack responses
+
+## Safelist
+
+The current config safelists Better Stack monitoring user agents. If you change monitoring vendors, compare user-agent strings before adding new safelist rules.
+
+## Tuning guidance
+
+Start conservatively:
+
+- raise limits only after confirming false positives in logs or support reports
+- keep MCP throttles stricter than general web limits because those requests are more expensive
+- keep both OAuth throttles in place; the `client_id` rule complements the IP rule
+- prefer a dedicated Redis DB or instance if throttle counters should not mix with other cache traffic
+
+## What to check during release validation
+
+- Redis-backed counters initialize cleanly when `RACK_ATTACK_REDIS_URL` is set
+- MCP clients stay below the `mcp/tool-calls/ip` threshold during expected usage
+- OAuth clients do not loop into the `client_id` throttle during federation testing
+- monitoring does not misclassify Rack::Attack `503` responses as generic app crashes
+
+## Release caveat
+
+This repo contains the Rack::Attack policy itself, but not a full operational dashboard, alert pack, or allowlist admin UI. Keep tuning changes deliberate and validate them against real logs before broadening limits.
+
+## Related docs
+
+- [Security Protection System](../developers/systems/security_protection_system.md)
+- [External Services Configuration](../production/external-services-to-configure.md)
+- [Rack Attack rate limiting flow](../diagrams/source/rack_attack_rate_limiting_flow.mmd)

--- a/docs/platform_organizers/safety_reporting_operations.md
+++ b/docs/platform_organizers/safety_reporting_operations.md
@@ -1,0 +1,196 @@
+# Safety Reporting Operations
+
+**Target Audience:** Platform organizers and platform-level safety reviewers  
+**Document Type:** Administrator Guide  
+**Last Updated:** March 2026
+
+## Overview
+
+The current branch includes a structured report intake flow and a linked safety-case workflow for platform managers. This guide describes the lifecycle that actually exists today.
+
+Main files:
+
+- `app/controllers/better_together/reports_controller.rb`
+- `app/models/better_together/report.rb`
+- `app/controllers/better_together/safety/cases_controller.rb`
+- `app/models/better_together/safety/case.rb`
+- `app/models/better_together/safety/action.rb`
+- `app/models/better_together/safety/note.rb`
+- `app/models/better_together/safety/agreement.rb`
+
+## Who can operate the moderation UI
+
+`BetterTogether::Safety::CasePolicy` currently limits case index, detail, and update access to people who can `manage_platform`.
+
+In practice, this is a platform-level operations surface, not a community-level self-service moderation queue.
+
+## Report intake
+
+The current report form collects:
+
+- category
+- harm level
+- requested outcome
+- reason
+- private details
+- consent to contact
+- consent to restorative process
+- retaliation risk
+
+Allowed reportable classes currently include:
+
+- people
+- posts
+- events
+- messages
+- Joatu offers, requests, and agreements
+
+`ReportsController` resolves reportable targets through `SafeClassResolver` and returns `404` for invalid or missing targets before the normal authorization flow completes.
+
+## Automatic case creation
+
+Every saved report automatically creates a linked `Safety::Case` through `after_create_commit :ensure_safety_case!` unless one already exists.
+
+The case copies the core intake fields from the report so reviewers can work from a normalized moderation record.
+
+## Default lane assignment
+
+`Safety::Case#set_default_lane` assigns a lane on create:
+
+- `immediate_safety` for urgent harm or retaliation risk
+- `administrative` for `spam_or_scam`, `fraud`, `impersonation`, or `misinformation`
+- `restorative` for everything else
+
+Treat this as the branch-supported default triage automation. Reviewers can still change the lane later from the case management form.
+
+## Status lifecycle
+
+Current statuses:
+
+- `submitted`
+- `triaged`
+- `needs_reporter_followup`
+- `restorative_in_progress`
+- `protective_action_in_effect`
+- `resolved`
+- `closed_no_action`
+
+When a case is updated to `resolved` and `resolved_at` is blank, `CasesController#update` stamps the resolution time.
+
+## Reporter-visible lifecycle
+
+Reporter-facing pages intentionally show less detail than the moderator workflow.
+
+`reporter_visible_status` currently maps:
+
+- `submitted` -> `under_review`
+- `triaged` -> `under_review`
+- all later statuses -> their actual status values
+
+The report detail page may also show a `closure_summary` when reviewers add one.
+
+## Moderator workflow in the current UI
+
+### Case list
+
+`/safety_cases` supports filtering by:
+
+- status
+- lane
+- harm level
+
+The list view shows the category, lane, truncated report reason, current status, and created timestamp.
+
+### Case detail
+
+The case detail page gives reviewers four operational areas:
+
+1. intake details from the original report
+2. actions
+3. notes
+4. agreements and case management
+
+## Actions
+
+Current action types include:
+
+- `content_hidden`
+- `content_removed`
+- `contact_restriction`
+- `messaging_restriction`
+- `event_restriction`
+- `temporary_suspension`
+- `restorative_referral`
+- `watch_flag`
+
+Current action statuses:
+
+- `active`
+- `completed`
+- `cancelled`
+
+Important constraint: active actions require `review_at`.
+
+The action form also records four BTS values checks and freeform review notes:
+
+- love/inclusivity
+- solidarity
+- accountability
+- care
+
+## Notes
+
+Notes can be saved as:
+
+- `internal_only`
+- `participant_visible`
+
+Use participant-visible notes carefully. Reporter-facing status pages are still limited, so do not assume every internal moderation detail is exposed back to the person who filed the report.
+
+## Agreements
+
+Agreements support a restorative path with:
+
+- summary
+- commitments
+- harmed-party consent
+- responsible-party consent
+- status updates
+- optional completion timestamps
+
+Agreement statuses:
+
+- `proposed`
+- `active`
+- `completed`
+- `breached`
+- `withdrawn`
+
+## Case management fields exposed today
+
+The current case-management form lets reviewers update:
+
+- `status`
+- `lane`
+- `closure_type`
+- `closure_summary`
+- `review_at`
+
+Even though `assigned_reviewer_id` is permitted in the controller, the current branch does not expose an assignee selector in the case detail UI. Plan staffing workflows accordingly.
+
+## Practical release checks
+
+Before calling the workflow ready for release, verify that:
+
+- a new report creates a linked safety case
+- urgent or retaliation-risk reports land in `immediate_safety`
+- administrative categories route to the administrative lane by default
+- reporter history pages show the expected reduced status vocabulary
+- closure summaries appear only when added to the safety case
+
+## Related docs
+
+- [Reporting Harm and Safety Concerns](../end_users/reporting_harm_and_safety_concerns.md)
+- [After You Report](../end_users/after_you_report.md)
+- [Safety report lifecycle flow](../diagrams/source/safety_report_lifecycle_flow.mmd)
+- [0.11.0 Release Overview](../releases/0.11.0.md)

--- a/docs/platform_organizers/storage_configuration_guide.md
+++ b/docs/platform_organizers/storage_configuration_guide.md
@@ -1,0 +1,124 @@
+# Storage Configuration Guide
+
+**Target Audience:** Platform organizers  
+**Document Type:** Operator guide  
+**Last Updated:** March 2026
+
+This guide explains the platform-scoped storage configuration system introduced in the `0.11.0` release lane.
+
+## What changed in 0.11.0
+
+Platforms can now define storage backends through `StorageConfiguration` records instead of relying only on environment-wide Active Storage settings.
+
+Supported service types:
+
+- `local`
+- `amazon`
+- `s3_compatible`
+
+Examples of S3-compatible backends include Garage and MinIO.
+
+## Core behavior
+
+### Platform-owned configurations
+
+A platform can own many storage configurations, but only one active configuration at a time.
+
+Relevant model relationships:
+
+- `Platform has_many :storage_configurations`
+- `Platform belongs_to :active_storage_configuration`
+
+### Resolution order
+
+`BetterTogether::StorageResolver` uses this order:
+
+1. active platform storage configuration
+2. environment-based Active Storage settings
+3. local disk fallback
+
+This means you can adopt platform-scoped storage incrementally without breaking existing deployments that still rely on environment variables.
+
+## Managing configurations
+
+The storage configuration UI is nested under the platform:
+
+- list configurations
+- create a configuration
+- edit a configuration
+- activate a configuration
+- delete an inactive configuration
+
+When activating a configuration, the controller immediately rebinds the Active Storage service in the current process so new uploads use the updated backend without waiting for a restart. Other processes still need their normal restart cycle.
+
+## Choosing a backend
+
+### Local disk
+
+Use local disk when:
+
+- you are in development
+- you are running a simple single-host deployment
+- you do not need remote object storage
+
+### Amazon S3
+
+Use Amazon S3 when:
+
+- you want a managed object store
+- you need mature ecosystem support
+- your deployment and compliance model already assume AWS
+
+### S3-compatible storage
+
+Use an S3-compatible backend when:
+
+- you want self-hosted object storage
+- you are standardizing on Garage or MinIO
+- you need a private object store with the Active Storage S3 adapter path
+
+For S3-compatible backends, an explicit endpoint is required and the system enables `force_path_style`.
+
+## Credentials and safety
+
+`StorageConfiguration` encrypts the following fields at rest:
+
+- `access_key_id`
+- `secret_access_key`
+
+When editing an existing configuration, blank credential fields are stripped from the update payload so existing encrypted values are preserved.
+
+## Activation workflow
+
+Recommended activation sequence:
+
+1. create the configuration for the target platform
+2. verify bucket, region, and endpoint settings
+3. activate the configuration
+4. perform a small upload test
+5. restart other long-lived processes on the deployment if needed
+
+Do not destroy the currently active configuration. The controller blocks that path intentionally.
+
+## Operator caveats
+
+### Platform config vs environment fallback
+
+If no active platform config exists, `StorageResolver` will still use environment variables. This is useful during migration, but it also means operators should verify which source is currently active before assuming a UI change is taking effect.
+
+### Stable storage keys
+
+Each `StorageConfiguration` produces a stable key based on the config record ID. This prevents an unrelated config swap from silently redirecting old blobs to a different backend identity.
+
+### Process rebinding
+
+Immediate rebinding only affects the current process. Background workers and other app processes should still be restarted or recycled through the normal deployment path.
+
+## Related docs
+
+- [Multi-tenant platform runtime](../developers/systems/multi_tenant_platform_runtime.md)
+- [0.11.0 Release Overview](../releases/0.11.0.md)
+
+## Diagram
+
+- [Storage backend selection flow](../diagrams/source/storage_backend_selection_flow.mmd)

--- a/docs/production/external-services-to-configure.md
+++ b/docs/production/external-services-to-configure.md
@@ -147,6 +147,7 @@ ELASTICSEARCH_URL=http://elasticsearch:9200
 
 Reference:
 - `config/initializers/elasticsearch.rb:6`
+- See also: [Elasticsearch Upgrade to 8 Guide](../platform_organizers/elasticsearch_upgrade_to_8_guide.md)
 
 ## Redis
 
@@ -165,6 +166,7 @@ REDIS_URL=redis://redis:6379/0
 
 Reference:
 - `config/initializers/rack_attack.rb:15`
+- See also: [Rack Attack Tuning](../platform_organizers/rack_attack_tuning.md)
 
 ## PostgreSQL (PostGIS)
 


### PR DESCRIPTION
Salvage PR: preserves local worktree delta from April 18, 2026 remediation (session 7eb000bc).

Adds CHANGELOG entries and README updates for the 0.11.0 release draft.

**⚠️ Has merge conflicts** — docs in `release/0.11.0-notes` have evolved significantly. Needs manual merge of changelog/README entries.