### PR TITLE
feat(privacy): community privacy feature — salvage triage needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 #### Multi-Tenant Platform Architecture & Federation MVP
-- Full multi-tenant platform support: isolated `CurrentPlatform` context, per-tenant scoping across all models (#1215)
+- Platform-aware multi-tenancy groundwork: isolated platform context, public platform-registry/domain routing groundwork, and partial platform-scoped records toward the intended schema-per-platform design (#1215)
 - Federation MVP: `PlatformConnection` model, OAuth-based cross-platform trust, `FederatedSeedAttributes` for content syndication
 - `LinkedSeedIngestService`: receive and persist federated content (posts, pages, events) as local mirrors
 - `PlatformConnectionsController` with full CRUD and federation OAuth token exchange flow
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MembershipRequest` STI model with `pending`/`approved`/`declined` states (#1356)
 - Public JSONAPI endpoint: `POST /api/v1/membership_requests`
 - Pundit policy enforcement; 404-not-403 leak prevention
+- invitation-required registration can expose a bounded membership-request interstitial when the platform or community allows requests
 
 #### Posts Index — Search, Filter & Pagination
 - New `PostsSearchFilter` service: ILIKE text search (Mobility joins), category filter, privacy filter, order-by, Kaminari pagination (#1409)
@@ -77,6 +78,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Safety Reporting Workflow
 - Accessible safety reporting workflow with documentation (#1277)
 - Report targets validated before auth to prevent enumeration
+
+#### Privacy hardening
+- membership-gated community privacy and least-privilege policy tightening across sensitive review/admin surfaces
+- local safety snapshot and membership-request workflow documentation/evidence added for reviewer and operator visibility
 
 #### Rack::Attack
 - Configurable Redis connection pool size and timeout for Rack::Attack rate limiting

--- a/app/controllers/better_together/application_controller.rb
+++ b/app/controllers/better_together/application_controller.rb
@@ -147,16 +147,26 @@ module BetterTogether
     end
 
     def set_current_platform_context
-      Current.platform_domain = BetterTogether::PlatformDomain.resolve(request.host)
-      Current.platform = Current.platform_domain&.platform || BetterTogether::Platform.find_by(host: true)
-      Current.person = current_user&.person
-      Current.governed_agent = Current.person
+      context = ::BetterTogether::PlatformRuntimeContextResolver.for_host(request.host)
+      assign_current_platform_context(context)
+      assign_current_actor_context
       ActiveStorage::Current.url_options = resolved_url_options
     end
 
     def reset_current_platform_context
       Current.reset
       ActiveStorage::Current.reset
+    end
+
+    def assign_current_platform_context(context)
+      Current.platform_domain = context.platform_domain
+      Current.platform = context.platform
+      Current.tenant_schema = context.tenant_schema
+    end
+
+    def assign_current_actor_context
+      Current.person = current_user&.person
+      Current.governed_agent = Current.person
     end
 
     def resolved_url_options

--- a/app/controllers/better_together/metrics/search_queries_controller.rb
+++ b/app/controllers/better_together/metrics/search_queries_controller.rb
@@ -23,6 +23,8 @@ module BetterTogether
       end
 
       def track_search_query
+        return unless metrics_platform.present?
+
         BetterTogether::Metrics::TrackSearchQueryJob.perform_later(
           tracked_query,
           params[:results_count].to_i,

--- a/app/controllers/better_together/search_controller.rb
+++ b/app/controllers/better_together/search_controller.rb
@@ -35,6 +35,7 @@ module BetterTogether
     def track_search_query(search_results)
       query = BetterTogether::Metrics::SearchQueryCaptureService.new.call(@query)
       return if query.blank?
+      return unless metrics_platform.present?
 
       BetterTogether::Metrics::TrackSearchQueryJob.perform_later(
         query,

--- a/app/controllers/concerns/better_together/metrics/platform_context.rb
+++ b/app/controllers/concerns/better_together/metrics/platform_context.rb
@@ -9,7 +9,7 @@ module BetterTogether
       private
 
       def metrics_platform
-        Current.platform || BetterTogether::Platform.find_by(host: true)
+        Current.platform if Current.platform&.internal?
       end
 
       def metrics_logged_in?

--- a/app/jobs/better_together/application_job.rb
+++ b/app/jobs/better_together/application_job.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 module BetterTogether
+  # Base job for BetterTogether background execution.
   class ApplicationJob < ActiveJob::Base
+    private
+
+    def with_platform_runtime_context(platform_id: nil, tenant_schema: nil)
+      context = ::BetterTogether::PlatformRuntimeContextResolver.for_platform(platform_id)
+
+      ::Current.platform = context.platform
+      ::Current.platform_domain = context.platform_domain
+      ::Current.tenant_schema = tenant_schema.presence || context.tenant_schema
+      yield
+    ensure
+      ::Current.reset
+    end
   end
 end

--- a/app/jobs/better_together/notification_cache_warming_job.rb
+++ b/app/jobs/better_together/notification_cache_warming_job.rb
@@ -7,27 +7,15 @@ module BetterTogether
 
     # @param notification_ids [Array<String>] IDs of notifications to warm
     # @param platform_id [String, nil] platform context for cache key resolution
-    def perform(notification_ids, platform_id: nil)
+    # @param tenant_schema [String, nil] future schema identity for tenant-aware runtime
+    def perform(notification_ids, platform_id: nil, tenant_schema: nil)
       notifications = Noticed::Notification.where(id: notification_ids).includes(event: :record)
 
-      with_platform_context(platform_id) do
+      with_platform_runtime_context(platform_id:, tenant_schema:) do
         notifications.find_each do |notification|
           warm_notification_fragments(notification) if should_warm_cache?(notification)
         end
       end
-    end
-
-    private
-
-    # Set Current.platform for the duration of the block so that cache keys
-    # generated during render match the keys used by the live request stack.
-    def with_platform_context(platform_id)
-      if platform_id.present?
-        ::Current.platform = BetterTogether::Platform.find_by(id: platform_id)
-      end
-      yield
-    ensure
-      ::Current.reset
     end
 
     def warm_notification_fragments(notification)

--- a/app/mailers/better_together/application_mailer.rb
+++ b/app/mailers/better_together/application_mailer.rb
@@ -35,10 +35,12 @@ module BetterTogether
     # rubocop:todo Metrics/PerceivedComplexity
     # rubocop:todo Metrics/AbcSize
     def set_locale_and_time_zone(&) # rubocop:todo Metrics/CyclomaticComplexity, Metrics/AbcSize, Metrics/PerceivedComplexity
+      context = resolve_mailer_platform_context
       # Use Current.platform (set by middleware for web/API requests) with
-      # fallback to host platform for background job mailer sends.
+      # host-platform fallback only when no explicit platform context was provided.
       # Set @platform ivar so mailer templates can reference it (e.g. @platform.name).
-      @platform ||= ::Current.platform || BetterTogether::Platform.find_by(host: true)
+      @platform ||= context.platform
+      ::Current.tenant_schema ||= context.tenant_schema
 
       self.time_zone ||= time_zone || @platform&.time_zone || Rails.application.config.time_zone
       self.locale ||= locale || I18n.locale || @platform&.locale || I18n.default_locale
@@ -47,6 +49,8 @@ module BetterTogether
       Time.use_zone(time_zone) do
         I18n.with_locale(locale, &)
       end
+    ensure
+      ::Current.tenant_schema = nil
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/PerceivedComplexity
@@ -67,6 +71,16 @@ module BetterTogether
 
     def default_port?(scheme, port)
       (scheme == 'https' && port == 443) || (scheme == 'http' && port == 80)
+    end
+
+    def resolve_mailer_platform_context
+      if @platform.present?
+        ::BetterTogether::PlatformRuntimeContextResolver.for_platform(@platform)
+      elsif ::Current.platform.present?
+        ::BetterTogether::PlatformRuntimeContextResolver.for_platform(::Current.platform)
+      else
+        ::BetterTogether::PlatformRuntimeContextResolver.for_platform(nil, fallback_to_host: true)
+      end
     end
   end
 end

--- a/app/middleware/better_together/platform_context_middleware.rb
+++ b/app/middleware/better_together/platform_context_middleware.rb
@@ -23,11 +23,13 @@ module BetterTogether
 
     def call(env)
       hostname = ActionDispatch::Request.new(env).host
-      domain   = BetterTogether::PlatformDomain.resolve(hostname)
-      platform = domain&.platform || cached_host_platform
+      context = ::BetterTogether::PlatformRuntimeContextResolver.for_host(hostname)
 
-      ::Current.platform_domain = domain
-      ::Current.platform        = platform
+      return external_platform_response if external_platform_route?(context)
+
+      ::Current.platform_domain = context.platform_domain
+      ::Current.platform = context.platform
+      ::Current.tenant_schema = context.tenant_schema
 
       @app.call(env)
     ensure
@@ -37,16 +39,12 @@ module BetterTogether
 
     private
 
-    def cached_host_platform
-      # Cache only the UUID to avoid serializing an AR object into the cache store.
-      # Caching a full ActiveRecord object as YAML triggers Psych::DisallowedClass on
-      # read when Psych safe-load mode is active (Psych 4 / Ruby 3.1+), causing every
-      # request to 500 after the first cache write. Storing only the UUID is safe and
-      # still eliminates the DB query on the hot path.
-      id = Rails.cache.fetch('better_together/host_platform_id', expires_in: 5.minutes) do
-        BetterTogether::Platform.where(host: true).pick(:id)
-      end
-      id ? BetterTogether::Platform.find_by(id: id) : nil
+    def external_platform_route?(context)
+      context.domain_matched? && context.platform&.external?
+    end
+
+    def external_platform_response
+      [404, { 'Content-Type' => 'text/plain; charset=utf-8' }, ['Not Found']]
     end
   end
 end

--- a/app/models/better_together/event.rb
+++ b/app/models/better_together/event.rb
@@ -323,10 +323,7 @@ module BetterTogether
       return unless has_attribute?(:platform_id)
       return if platform_id.present?
 
-      resolved = Current.platform ||
-                 BetterTogether::Platform.find_by(host: true) ||
-                 BetterTogether::Platform.first
-      self.platform = resolved if resolved
+      self.platform = Current.platform if Current.platform&.internal?
     end
 
     # Set default duration if not set and start time is present

--- a/app/models/better_together/page.rb
+++ b/app/models/better_together/page.rb
@@ -200,25 +200,14 @@ module BetterTogether
       return unless has_attribute?(:platform_id)
       return if platform_id.present?
 
-      resolved = Current.platform ||
-                 BetterTogether::Platform.find_by(host: true) ||
-                 BetterTogether::Platform.first
-      self.platform = resolved if resolved
+      self.platform = Current.platform if Current.platform&.internal?
     end
 
     def assign_host_community
       return unless has_attribute?(:community_id)
       return if community.present?
 
-      self.community ||= BetterTogether::Community.find_by(host: true)
-      self.community ||= host_platform_community
-    end
-
-    def host_platform_community
-      host_platform_community_id = BetterTogether::Platform.where(host: true).limit(1).pluck(:community_id).first
-      return unless host_platform_community_id
-
-      BetterTogether::Community.find_by(id: host_platform_community_id)
+      self.community = platform&.primary_community
     end
 
     # Touch navigation areas for all navigation items that link to this page

--- a/app/models/better_together/platform.rb
+++ b/app/models/better_together/platform.rb
@@ -53,6 +53,7 @@ module BetterTogether
       requires_invitation Boolean, default: true
       allow_membership_requests Boolean, default: false
       software_variant String
+      tenant_schema String
       network_visibility String, default: 'private'
       connection_bootstrap_state String
       federation_protocol String
@@ -81,6 +82,7 @@ module BetterTogether
     validates :search_query_analytics_mode, inclusion: { in: SEARCH_QUERY_ANALYTICS_MODES }
     validates :oauth_issuer_url, format: URI::DEFAULT_PARSER.make_regexp(%w[http https]), allow_blank: true
     validate :oauth_issuer_url_ssrf_safe
+    validate :tenant_schema_for_internal_platforms_only
     validate :validate_csp_origin_text_fields
     validate :require_publishing_agreement_for_public_network_visibility
 
@@ -196,6 +198,20 @@ module BetterTogether
       allow_membership_requests? || community&.allow_membership_requests?
     end
 
+    def internal=(value)
+      self.external = !ActiveModel::Type::Boolean.new.cast(value)
+    end
+
+    def internal?
+      !external?
+    end
+
+    alias internal internal?
+
+    def tenant_schema?
+      tenant_schema.present?
+    end
+
     def to_s
       name
     end
@@ -214,6 +230,12 @@ module BetterTogether
       BetterTogether::SafeFederationUrlValidator
         .new(attributes: [:oauth_issuer_url])
         .validate_each(self, :oauth_issuer_url, oauth_issuer_url)
+    end
+
+    def tenant_schema_for_internal_platforms_only
+      return if tenant_schema.blank? || internal?
+
+      errors.add(:tenant_schema, 'must be blank for external platforms')
     end
 
     def require_publishing_agreement_for_public_network_visibility

--- a/app/models/better_together/post.rb
+++ b/app/models/better_together/post.rb
@@ -99,10 +99,7 @@ module BetterTogether
       return unless has_attribute?(:platform_id)
       return if platform_id.present?
 
-      resolved = Current.platform ||
-                 BetterTogether::Platform.find_by(host: true) ||
-                 BetterTogether::Platform.first
-      self.platform = resolved if resolved
+      self.platform = Current.platform if Current.platform&.internal?
     end
   end
 end

--- a/app/models/concerns/better_together/metrics/platform_scoped.rb
+++ b/app/models/concerns/better_together/metrics/platform_scoped.rb
@@ -20,9 +20,7 @@ module BetterTogether
         return if platform_id.present?
 
         resolved = platform_from_parent_record ||
-                   Current.platform ||
-                   BetterTogether::Platform.find_by(host: true) ||
-                   BetterTogether::Platform.first
+                   (Current.platform if Current.platform&.internal?)
         self.platform = resolved if resolved
       end
 

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -2,5 +2,5 @@
 
 # Thread-local request context for runtime host/platform resolution and current person tracking.
 class Current < ActiveSupport::CurrentAttributes
-  attribute :person, :governed_agent, :platform, :platform_domain
+  attribute :person, :governed_agent, :platform, :platform_domain, :tenant_schema
 end

--- a/app/policies/better_together/conversation_policy.rb
+++ b/app/policies/better_together/conversation_policy.rb
@@ -94,7 +94,7 @@ module BetterTogether
     end
 
     def platform
-      Current.platform || BetterTogether::Platform.find_by(host: true)
+      Current.platform if Current.platform&.internal?
     end
 
     def platform_people
@@ -105,6 +105,8 @@ module BetterTogether
     end
 
     def current_platform_person_ids
+      return [] unless platform
+
       ids = BetterTogether::PersonPlatformMembership
             .active
             .where(joinable: platform)

--- a/app/policies/better_together/metrics/link_checker_report_policy.rb
+++ b/app/policies/better_together/metrics/link_checker_report_policy.rb
@@ -39,7 +39,7 @@ module BetterTogether
       end
 
       def platform
-        @platform ||= Platform.find_by(host: true)
+        @platform ||= Current.platform if Current.platform&.internal?
       end
     end
   end

--- a/app/policies/better_together/metrics/link_click_report_policy.rb
+++ b/app/policies/better_together/metrics/link_click_report_policy.rb
@@ -39,7 +39,7 @@ module BetterTogether
       end
 
       def platform
-        @platform ||= Current.platform || Platform.find_by(host: true)
+        @platform ||= Current.platform if Current.platform&.internal?
       end
     end
   end

--- a/app/policies/better_together/metrics/page_view_report_policy.rb
+++ b/app/policies/better_together/metrics/page_view_report_policy.rb
@@ -39,7 +39,7 @@ module BetterTogether
       end
 
       def platform
-        @platform ||= Current.platform || Platform.find_by(host: true)
+        @platform ||= Current.platform if Current.platform&.internal?
       end
     end
   end

--- a/app/policies/better_together/metrics/report_policy.rb
+++ b/app/policies/better_together/metrics/report_policy.rb
@@ -35,7 +35,7 @@ module BetterTogether
       end
 
       def platform
-        @platform ||= Current.platform || Platform.find_by(host: true)
+        @platform ||= Current.platform if Current.platform&.internal?
       end
     end
   end

--- a/app/policies/better_together/metrics/user_account_report_policy.rb
+++ b/app/policies/better_together/metrics/user_account_report_policy.rb
@@ -39,7 +39,7 @@ module BetterTogether
       end
 
       def platform
-        @platform ||= BetterTogether::Platform.find_by(host: true)
+        @platform ||= Current.platform if Current.platform&.internal?
       end
     end
   end

--- a/app/services/better_together/metrics/search_query_capture_service.rb
+++ b/app/services/better_together/metrics/search_query_capture_service.rb
@@ -8,8 +8,8 @@ module BetterTogether
     class SearchQueryCaptureService
       HASH_PREFIX = 'sha256:'
 
-      def initialize(platform: Current.platform || BetterTogether::Platform.find_by(host: true))
-        @platform = platform
+      def initialize(platform: Current.platform)
+        @platform = platform if platform&.internal?
       end
 
       def call(query)
@@ -23,7 +23,7 @@ module BetterTogether
       private
 
       def analytics_enabled?
-        return true if @platform.nil?
+        return false if @platform.nil?
 
         @platform.search_query_analytics_enabled != false
       end

--- a/app/services/better_together/platform_runtime_context_resolver.rb
+++ b/app/services/better_together/platform_runtime_context_resolver.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module BetterTogether
+  # Resolves the runtime platform context for requests, jobs, and mailers.
+  #
+  # This is intentionally a small foundation layer: it centralizes host/platform
+  # resolution and surfaces tenant schema metadata only for internal platforms.
+  # Actual schema switching remains a later implementation step.
+  class PlatformRuntimeContextResolver
+    Result = Struct.new(
+      :platform,
+      :platform_domain,
+      :tenant_schema,
+      :source
+    ) do
+      def resolved?
+        platform.present?
+      end
+
+      def domain_matched?
+        platform_domain.present?
+      end
+    end
+
+    def self.for_host(hostname, fallback_to_host: true)
+      domain = ::BetterTogether::PlatformDomain.resolve(hostname)
+      platform = domain&.platform
+      source = domain.present? ? :platform_domain : :none
+
+      if platform.blank? && fallback_to_host
+        platform = host_platform
+        source = :host_platform if platform.present?
+      end
+
+      build_result(platform:, platform_domain: domain, source:)
+    end
+
+    def self.for_platform(platform_or_id, fallback_to_host: false)
+      platform = resolve_platform(platform_or_id)
+      source = platform.present? ? :explicit_platform : :none
+
+      if platform.blank? && fallback_to_host
+        platform = host_platform
+        source = :host_platform if platform.present?
+      end
+
+      build_result(platform:, platform_domain: nil, source:)
+    end
+
+    def self.build_result(platform:, platform_domain:, source:)
+      Result.new(platform:, platform_domain:, tenant_schema: tenant_schema_for(platform), source:)
+    end
+    private_class_method :build_result
+
+    def self.tenant_schema_for(platform)
+      return unless platform&.internal?
+
+      platform.tenant_schema.presence
+    end
+    private_class_method :tenant_schema_for
+
+    def self.resolve_platform(platform_or_id)
+      return platform_or_id if platform_or_id.is_a?(::BetterTogether::Platform)
+      return if platform_or_id.blank?
+
+      ::BetterTogether::Platform.find_by(id: platform_or_id)
+    end
+    private_class_method :resolve_platform
+
+    def self.host_platform
+      id = Rails.cache.fetch('better_together/host_platform_id', expires_in: 5.minutes) do
+        ::BetterTogether::Platform.where(host: true).pick(:id)
+      end
+      id ? ::BetterTogether::Platform.find_by(id:) : nil
+    end
+    private_class_method :host_platform
+  end
+end

--- a/app/services/better_together/tenant_platform_provisioning_service.rb
+++ b/app/services/better_together/tenant_platform_provisioning_service.rb
@@ -1,37 +1,13 @@
 # frozen_string_literal: true
 
 module BetterTogether
-  # Provisions a new tenant Platform end-to-end in a single transaction.
-  #
-  # Model callbacks on Platform handle:
-  #   - primary PlatformDomain (sync_primary_platform_domain! after_commit)
-  #   - primary Community (create_primary_community before_validation)
-  #   - federation registry defaults (apply_platform_registry_defaults before_validation)
-  #
-  # This service adds:
-  #   - Optional admin User + PersonPlatformMembership (platform_steward)
-  #   - Optional admin PersonCommunityMembership (community_governance_council)
-  #   - Transactional wrapper so partial failures roll back completely
-  #
+  # Provisions a platform registry record and its shared-schema bootstrap data.
+  # Model callbacks handle primary domain/community creation and registry defaults.
+  # This service adds admin bootstrap, transactional rollback, and internal-first
+  # semantics while keeping the legacy external column.
   # Idempotent: uses find_or_initialize_by(host_url:) — safe to re-run.
-  #
-  # Usage:
-  #   result = BetterTogether::TenantPlatformProvisioningService.call(
-  #     name: 'My Tenant',
-  #     host_url: 'https://tenant.example.com',
-  #     time_zone: 'America/Toronto',
-  #     admin: { email: 'admin@example.com', password: 'SecurePass1!' }
-  #   )
-  #   result.success? # => true
-  #   result.platform # => BetterTogether::Platform instance
   class TenantPlatformProvisioningService
-    Result = Struct.new(
-      :platform,
-      :community,
-      :domain,
-      :admin_user,
-      :errors
-    ) do
+    Result = Struct.new(:platform, :community, :domain, :admin_user, :errors) do
       def success?
         errors.blank?
       end
@@ -41,12 +17,14 @@ module BetterTogether
       new(**).call
     end
 
-    def initialize(name:, host_url:, time_zone: 'UTC', host: false, admin: nil)
+    def initialize(name:, host_url:, **platform_options)
       @name      = name
       @host_url  = host_url
-      @time_zone = time_zone
-      @host      = host
-      @admin     = admin
+      @time_zone = platform_options.fetch(:time_zone, 'UTC')
+      @host      = platform_options.fetch(:host, false)
+      @admin     = platform_options[:admin]
+      @internal = resolved_internal_flag(platform_options)
+      @tenant_schema = platform_options[:tenant_schema]
     end
 
     def call # rubocop:disable Metrics/AbcSize
@@ -92,9 +70,10 @@ module BetterTogether
       platform.assign_attributes(
         name: @name,
         time_zone: @time_zone,
-        external: false,
+        external: !@internal,
         host: @host,
-        privacy: 'public'
+        privacy: 'public',
+        tenant_schema: @internal ? @tenant_schema : nil
       )
 
       platform.save!
@@ -143,6 +122,12 @@ module BetterTogether
 
     def community_governance_role
       ::BetterTogether::Role.find_by(identifier: 'community_governance_council')
+    end
+
+    def resolved_internal_flag(platform_options)
+      return ActiveModel::Type::Boolean.new.cast(platform_options.fetch(:internal, true)) unless platform_options.key?(:external)
+
+      !ActiveModel::Type::Boolean.new.cast(platform_options[:external])
     end
   end
 end

--- a/app/tools/better_together/mcp/get_metrics_summary_tool.rb
+++ b/app/tools/better_together/mcp/get_metrics_summary_tool.rb
@@ -22,6 +22,7 @@ module BetterTogether
       # @param to_date [String, nil] Optional end date filter
       # @return [String] JSON metrics summary
       def call(from_date: nil, to_date: nil)
+        return platform_context_required_response unless metrics_platform.present?
         return auth_required_response unless current_user&.person&.permitted_to?('manage_platform', metrics_platform)
 
         with_timezone_scope do
@@ -37,6 +38,10 @@ module BetterTogether
 
       def auth_required_response
         JSON.generate({ error: 'Platform manager access required' })
+      end
+
+      def platform_context_required_response
+        JSON.generate({ error: 'Internal platform context required' })
       end
 
       def build_scope(from_date, to_date)
@@ -83,7 +88,7 @@ module BetterTogether
       end
 
       def metrics_platform
-        Current.platform || BetterTogether::Platform.find_by(host: true)
+        Current.platform if Current.platform&.internal?
       end
     end
   end

--- a/docs/implementation/multi_tenancy/federated_seed_and_sync_handoff_2026-03-12.md
+++ b/docs/implementation/multi_tenancy/federated_seed_and_sync_handoff_2026-03-12.md
@@ -22,6 +22,7 @@ The current planning baseline is spread across these documents:
 
 - `docs/implementation/multi_tenancy/tenant_data_ownership_matrix.md`
 - `docs/implementation/multi_tenancy/tenant_runtime_contract.md`
+- `docs/implementation/multi_tenancy/federation_registry_and_tenant_boundary.md`
 - `docs/implementation/multi_tenancy/schema_per_tenant_implementation_plan.md`
 - `docs/implementation/multi_tenancy/governance_bodies_and_mandates.md`
 - `docs/implementation/multi_tenancy/federated_rbac_reassessment_and_coverage_plan.md`

--- a/docs/implementation/multi_tenancy/federation_registry_and_tenant_boundary.md
+++ b/docs/implementation/multi_tenancy/federation_registry_and_tenant_boundary.md
@@ -1,0 +1,385 @@
+# Federation Registry And Tenant Boundary
+
+**Date:** April 5, 2026  
+**Status:** Architecture reconciliation baseline  
+**Purpose:** Define how federation, mirrored content, linked accounts, and private sharing interact with the public platform registry and per-platform tenant schemas
+
+---
+
+## Why this document exists
+
+Community Engine's intended platform model now has two strong requirements that must both remain true:
+
+1. **platform-owned private/local data belongs in each platform schema**
+2. **platform-to-platform federation must still work across those schemas**
+
+Without a clear boundary, federation features can quietly become a reason to keep private data in shared tables. This document defines the opposite rule:
+
+- federation is a **network layer between platforms**
+- federation is **not** a license to collapse platform-local ownership
+
+It complements:
+
+- `infrastructure_app_platform_topology.md`
+- `platform_registry_and_schema_boundary.md`
+- `platform_runtime_execution_contract.md`
+- `platform_schema_migration_map.md`
+- `tenant_data_ownership_matrix.md`
+- `federated_seed_and_sync_handoff_2026-03-12.md`
+
+---
+
+## Executive summary
+
+### The core rule
+
+Federation should pass **through** the public platform registry/gateway layer, while leaving platform-private working data inside each platform schema.
+
+### What belongs to the public/network layer
+
+- platform registry records
+- platform connections
+- federation access tokens
+- connection/bootstrap/trust metadata
+- cross-platform agreement and sync contracts that identify participating platforms
+
+### What belongs to platform schemas
+
+- local users and people
+- local communities and memberships
+- local content and moderation state
+- local messaging and private spaces
+- local safety records
+- local mirrored-content projections used for local feed/search/display
+
+### What needs careful hybrid handling
+
+- `PersonLink`
+- `PersonAccessGrant`
+- `PersonLinkedSeed`
+- mirrored content provenance and refresh state
+- agreement-backed publish-back and linked-content access
+
+These are cross-platform by meaning, but they still depend on tenant-local people, content, and permissions.
+
+---
+
+## Federation lanes
+
+The current architecture is easiest to reason about when split into distinct lanes:
+
+### Lane 1 — platform-to-platform network governance
+
+This lane is about whether two platforms are connected and what they allow each other to do.
+
+Current implementation examples:
+
+- `PlatformConnection`
+- `FederationAccessToken`
+- `FederationScopeAuthorizer`
+- `FederatedContentAuthorizer`
+
+This lane belongs at the public/network boundary because it identifies platforms and their negotiated trust/configuration.
+
+### Lane 2 — mirrored network content
+
+This lane is about importing authorized content from another platform into a local platform's own search/feed/display context.
+
+Current implementation examples:
+
+- `FederatedPostMirrorService`
+- `FederatedPageMirrorService`
+- `FederatedEventMirrorService`
+- provenance columns such as:
+  - `platform_id`
+  - `source_id`
+  - `source_updated_at`
+  - `last_synced_at`
+
+This lane must **not** turn remote canonical ownership into shared local ownership. The local platform should keep:
+
+- a local mirror/projection for local use
+- explicit source attribution
+- explicit sync state
+
+Canonical ownership stays with the source platform.
+
+### Lane 3 — person-linked private sharing
+
+This lane is narrower and more sensitive than general platform federation.
+
+Current implementation examples:
+
+- `PersonLink`
+- `PersonAccessGrant`
+- `PersonLinkedSeed`
+
+This lane is about explicit person-to-person sharing, not general network-feed visibility.
+
+Private linked content:
+
+- must stay recipient-scoped
+- must stay encrypted at rest where implemented
+- must not surface in general feed/search/community listings
+- must not be treated as if a platform connection alone authorizes broad private-data exposure
+
+---
+
+## Current implementation evidence
+
+### Platform-governance layer
+
+`PlatformConnection` already behaves like a network-governance record:
+
+- connects a `source_platform` and `target_platform`
+- stores content-sharing policy and federation-auth policy
+- controls content-type sharing toggles
+- tracks sync state
+- owns `FederationAccessToken` records
+
+That is strong evidence that platform-to-platform trust belongs at the registry/network layer, not inside local content tables.
+
+### Scope authorization layer
+
+`FederationScopeAuthorizer` currently grants scopes by inspecting the active directed `PlatformConnection`.
+
+That means:
+
+- scopes are already treated as connection-based capabilities
+- this should remain true under schema tenancy
+- local tenant data should be accessed only after both:
+  - network scope authorization passes
+  - tenant-local authorization passes
+
+### Mirrored content layer
+
+`FederatedContentAuthorizer` already checks:
+
+- active connection
+- mirroring vs publish-back mode
+- content type allowlist
+
+That is a good network-layer guard, but it is not a substitute for tenant-local policy and provenance-aware moderation once content exists locally.
+
+### Person-linked sharing lane
+
+`PersonLink` and `PersonAccessGrant` already show the right conceptual split:
+
+- link the two people through a platform connection
+- enforce that source/target people belong to the respective source/target platforms
+- keep grants recipient-scoped and explicit
+- keep linked payloads out of general search/feed
+
+That lane should remain explicit and narrow.
+
+---
+
+## Boundary rules
+
+### Rule 1 — platform connections do not equal tenant access
+
+An active `PlatformConnection` means:
+
+- the two platforms have a network relationship
+- some scopes or content-sharing options may be available
+
+It does **not** mean:
+
+- any local user from one platform can read arbitrary data in the other
+- local tenant policies can be bypassed
+- private community or safety data becomes shared by default
+
+### Rule 2 — network authorization and tenant authorization are separate gates
+
+Every federated action should pass two gates:
+
+1. **network gate**
+   - is there an active platform connection?
+   - is the requested scope/content type allowed?
+   - is the agreement/consent state sufficient?
+
+2. **tenant-local gate**
+   - inside the target platform schema, does local RBAC/privacy/community membership allow this action?
+
+Passing the first gate must never silently imply the second.
+
+### Rule 3 — mirrored content is local projection, not ownership transfer
+
+Mirrored content should remain:
+
+- local copy/projection
+- source-attributed
+- refreshable/revocable
+- subject to local moderation/visibility rules
+- stored inside the tenant schema of the internal platform that accepted the mirror
+
+But:
+
+- the source platform remains canonical owner
+- publish-back requires separate explicit permission
+- mirror presence must not erase source/target platform boundaries
+
+### Rule 4 — external platforms stay registry-only inside CE
+
+External peer platforms may have rich trust, routing, and connection metadata in `public`, but they do **not** get private working schemas inside CE.
+
+If CE accepts remote data from an external peer through:
+
+- federation mirroring
+- OAuth/account linking
+- seeded relationship sync
+- another approved inbound data flow
+
+that data must be stored as tenant-local data inside the schema of the internal platform that accepted it, with explicit provenance.
+
+### Rule 5 — person-linked private sharing is not general federation
+
+Person-linked private sharing should require:
+
+- a durable person link
+- explicit access grant(s)
+- recipient-scoped visibility
+- tenant-local policy checks on both ends where applicable
+
+It must not broaden into:
+
+- general network-feed eligibility
+- general search eligibility
+- implicit visibility for platform staff
+
+### Rule 6 — safety and private spaces remain local by default
+
+Unless a later ADR explicitly defines a federation lane for them, these remain local:
+
+- direct/private messaging
+- safety reports/cases/notes
+- private communities and community-private participation
+- locally protected/private content outside explicit sharing lanes
+
+### Rule 7 — public registry records must not become shadow copies of private state
+
+The public platform registry should store enough to:
+
+- identify platforms
+- route requests
+- manage trust/connection policy
+- expose manifest-level management metadata
+
+It should not become a place to keep shadow copies of:
+
+- local people
+- local memberships
+- local safety state
+- local private content
+
+---
+
+## Placement guidance by model family
+
+| Model / Family | Boundary | Why |
+|----------------|----------|-----|
+| `Platform` | `public` | Registry/gateway identity, routing, management metadata |
+| `PlatformConnection` | public/network | Directed trust/connection contract between platforms |
+| `FederationAccessToken` | public/network | Scoped token for an active platform connection |
+| `FederationScopeAuthorizer` | public/network | Connection-based scope gate |
+| `FederatedContentAuthorizer` | public/network + local policy follow-up | Connection/type gate only; not the final tenant-local authorization |
+| `PersonLink` | hybrid: network edge referencing tenant-local people | Cross-platform relationship edge depends on tenant-local people |
+| `PersonAccessGrant` | hybrid: network consent referencing tenant-local people | Explicit private-share consent should stay narrow and auditable |
+| `PersonLinkedSeed` | target tenant schema, recipient-scoped | Private cached projection for one recipient, not general public/network state |
+| mirrored content projection | target tenant schema | Local feed/search/display needs tenant-local projection with provenance |
+| mirrored content provenance/sync contract | network + target tenant coordination | Needs both source identity and local projection state |
+
+---
+
+## Runtime implications
+
+Federated execution under schema tenancy requires:
+
+1. resolve the local target platform through the public registry
+2. switch into the target platform schema
+3. evaluate local tenant policy there
+4. apply network/connection/consent gates in parallel as required
+
+This means:
+
+- federation endpoints cannot stop at `Current.platform`
+- job-based sync cannot rely on shared-schema fallbacks
+- local mirror ingest must carry both:
+  - source-platform identity
+  - target tenant-schema identity
+
+Those runtime choices also sit inside a larger topology: infrastructure hosts, app instances, internal managed platforms, and external peers are distinct layers. See `infrastructure_app_platform_topology.md`.
+
+---
+
+## Current mismatches to resolve
+
+### 1. Shared-schema runtime shortcuts still exist
+
+Current code still leans on host-platform fallback and shared-schema access patterns. That makes it too easy for federation work to appear valid before tenant isolation is real.
+
+### 2. Mirrored content currently uses platform-aware provenance, not full tenant-local mirror contract
+
+The current provenance fields are useful groundwork, but they are not yet the complete schema-tenancy answer.
+
+### 3. Person-linked lane still needs explicit boundary choices
+
+`PersonLink`, `PersonAccessGrant`, and `PersonLinkedSeed` are conceptually right, but the final placement rules under tenant schemas need to remain explicit so private sharing does not drift into generalized network visibility.
+
+### 4. RBAC cleanup remains mandatory
+
+Federation actions still need distinct capability families. Generic `manage_platform` should not become the de facto authorization path for connection approval, OAuth trust, mirroring, or publish-back.
+
+---
+
+## Recommended implementation order
+
+### Phase 1 — local isolation first
+
+- establish tenant schema runtime
+- remove host/shared fallbacks from tenant-local execution
+- make local `User` / `Person` / `Community` ownership trustworthy
+
+### Phase 2 — platform-governance lane
+
+- stabilize `PlatformConnection`
+- stabilize token/scope/connection policy
+- clearly separate public registry metadata from tenant-local private data
+
+### Phase 3 — mirrored-content lane
+
+- make local mirror projections explicitly tenant-local
+- preserve source attribution and sync state
+- enforce tenant-local moderation and visibility after network authorization
+
+### Phase 4 — person-linked private lane
+
+- keep link + grant + linked-seed flow narrow
+- ensure recipient-scoped storage and visibility
+- explicitly prevent spillover into general feed/search/community surfaces
+
+### Phase 5 — publish-back / advanced federation
+
+- only after local isolation, mirror projections, and RBAC are trustworthy
+
+---
+
+## Success criteria
+
+This boundary is satisfied when:
+
+1. federation records identify and connect platforms without becoming homes for platform-private working data
+2. mirrored content is locally projected without erasing source ownership
+3. person-linked sharing remains explicit, narrow, and recipient-scoped
+4. network authorization never replaces tenant-local authorization
+5. federation features can expand without pressuring the app back toward shared private-state shortcuts
+
+---
+
+## Values and principles guidance
+
+- **Care:** private sharing, safety, and community-private participation must not be widened by federation convenience
+- **Accountability:** every cross-platform access path should show which network contract and which local authorization permitted it
+- **Stewardship:** keep federation additive to local autonomy, not destructive of it
+- **Solidarity:** connected platforms should cooperate through explicit agreements and trust edges, not through hidden centralization of private data
+- **Resilience:** if federation is unavailable or revoked, local platform operation and local private boundaries must remain intact

--- a/docs/implementation/multi_tenancy/infrastructure_app_platform_topology.md
+++ b/docs/implementation/multi_tenancy/infrastructure_app_platform_topology.md
@@ -1,0 +1,346 @@
+# Infrastructure, App Instance, And Platform Topology
+
+**Date:** April 5, 2026  
+**Status:** Architecture reconciliation baseline  
+**Purpose:** Define the relationship between infrastructure hosts, CE app instances, internal managed platforms, external peer platforms, and community governance
+
+---
+
+## Why this document exists
+
+The tenancy work uncovered a persistent vocabulary problem:
+
+- `host` can mean infrastructure host, app-level default platform, or governance steward
+- `platform` can mean a managed internal tenant, an external peer, or a public registry record
+- a routed app instance can be operated by one steward while supporting multiple communities and connected platforms
+
+If these layers stay blurred, schema tenancy, federation, routing, bot protection, and stewardship/accountability work all land on the wrong abstraction.
+
+This document separates those layers and defines how they relate.
+
+It complements:
+
+- `platform_registry_and_schema_boundary.md`
+- `platform_runtime_execution_contract.md`
+- `federation_registry_and_tenant_boundary.md`
+- `../../production/platform_provisioning_and_routing_runbook.md`
+
+---
+
+## Executive summary
+
+Community Engine needs four distinct layers:
+
+| Layer | What it is | What it is not |
+|------|-------------|----------------|
+| Infrastructure host / steward | The server, operator, network links, secrets, uptime, observability, and operational accountability layer | Not a tenant schema |
+| App instance node | One CE deployment plus its local DB/runtime boundary, edge routing, TLS, bot protection, and app-local support context | Not automatically a managed platform |
+| Managed platform | A `better_together_platforms` registry record representing either an internal managed platform or an external peer | Not the same thing as the physical host or app instance |
+| Community | The row-level organizing and permission boundary inside an internal platform schema | Not the replacement for platform or infrastructure stewardship |
+
+### Core rule
+
+Only **internal managed platforms** get tenant schemas in CE.
+
+External peer platforms:
+
+- remain public registry records
+- participate in federation/trust/routing contracts
+- do **not** get their own CE tenant schemas
+- have their accepted remote data stored inside the internal platform schema that ingested it, with explicit provenance
+
+---
+
+## The four-layer model
+
+## 1. Infrastructure host / steward layer
+
+This layer covers:
+
+- physical or virtual servers
+- host-level networking and overlays
+- secrets, service accounts, bot identities, tokens, and API keys at the infrastructure boundary
+- observability, backups, incident response, and capacity stewardship
+- who is accountable for keeping the system healthy
+
+Examples in BTS operations can include servers such as:
+
+- `bts-0`
+- `bts-4`
+- `bts-5`
+
+and network paths such as:
+
+- LAN
+- Headscale
+- Pangolin
+
+### What belongs here
+
+- server federation and private-network relationships
+- uptime and maintenance accountability
+- fleet-level service inventory
+- infra-scoped bot/service identities
+- host-level security controls and ingress protections
+
+### What does not belong here
+
+- tenant-local people, communities, posts, memberships, or safety data
+- the assumption that one server equals one platform
+- the assumption that the "host platform" for governance is the same as the internal schema-bearing platform
+
+---
+
+## 2. App instance node layer
+
+An app instance node is one deployed CE runtime plus its local database boundary.
+
+This layer covers:
+
+- the running Rails app
+- the connected database/runtime boundary
+- DNS, TLS, ingress, and host allowlisting
+- bot protection and abuse prevention at public ingest points
+- local support and operational workflows
+- instance-level auth/integration configuration
+
+### Key rule
+
+An app instance node may:
+
+- manage one or more **internal** platforms
+- maintain registry records for **external** peer platforms
+- federate with other app instances
+- be operated by a steward/platform that is not identical to every internal platform it hosts
+
+### Important consequence
+
+The app instance is the place where:
+
+- request routing becomes runtime context
+- public ingest protections apply
+- tenant schema switching eventually occurs
+- operational support needs to remain auditable and accountable
+
+But the app instance itself is still not the same thing as a managed platform.
+
+---
+
+## 3. Managed platform layer
+
+This layer lives in `better_together_platforms` and has two modes:
+
+### Internal managed platforms
+
+These are platforms whose private/local data is managed by this CE app instance.
+
+They:
+
+- are represented in the public registry
+- carry tenant schema identity
+- own tenant-local people, content, safety state, invitations, and communities
+- participate in federation as local schema-bearing platforms
+
+### External peer platforms
+
+These are remote platforms known to this app instance for trust, federation, mirroring, OAuth, or other cross-platform relationships.
+
+They:
+
+- are represented in the public registry
+- may carry rich trust and routing metadata
+- do **not** carry tenant schema identity in CE
+- do **not** own local tenant tables inside this CE instance
+
+---
+
+## 4. Community layer
+
+Communities remain the row-level organizing boundary inside an internal platform schema.
+
+They are where:
+
+- membership and participation rules are enforced
+- community-private visibility is gated
+- local democratic/governance workflows can happen
+- people can contribute, ask questions, and help guide platform operation
+
+### Important consequence
+
+Community governance should remain visible and meaningful without requiring community members to have infrastructure-host privileges or app-instance operator access.
+
+---
+
+## Relationship model
+
+The intended relationship chain is:
+
+1. **Infrastructure host/steward** operates
+2. **App instance node** which manages
+3. **Internal managed platform(s)** which contain
+4. **Community rows and local people/content**
+
+In parallel, the app instance also knows about:
+
+- **external peer platforms**
+- **server/network relationships**
+- **app-instance-to-app-instance relationships**
+
+Those connected surfaces interact, but they are not the same record type and should not be forced into one overloaded `Platform` meaning.
+
+---
+
+## Federation lanes across the topology
+
+## 1. Server federation
+
+This is infrastructure-to-infrastructure connectivity:
+
+- private overlays
+- routable links
+- machine identities
+- observability and operational reachability
+
+This belongs primarily to the infrastructure/steward layer.
+
+## 2. App-instance federation
+
+This is deployment-to-deployment relationship handling:
+
+- webhook/API reachability
+- TLS/routing trust
+- instance-level public ingress and egress decisions
+- delivery reliability and operational coordination
+
+This belongs primarily to the app instance layer.
+
+## 3. Platform federation
+
+This is managed-platform-to-managed-platform relationship handling:
+
+- platform registry/trust
+- content mirroring
+- OAuth/account linking
+- explicit agreements and publish-back choices
+
+This belongs primarily to the public registry and tenant-local policy layers.
+
+### Key rule
+
+Server federation, app-instance federation, and platform federation are related, but they must not be collapsed into one boolean "connected" state.
+
+---
+
+## Stewardship and accountability model
+
+The architecture should preserve all of these at once:
+
+### Infrastructure stewardship
+
+- who keeps the server healthy
+- who manages secrets, backups, and uptime
+- who is responsible for security posture and bot protection at the edge
+
+### Platform stewardship
+
+- who manages platform defaults, public routing identity, invitation policy, and community support commitments
+- who is accountable for the stability of the platform's community infrastructure
+
+### Community participation and contribution
+
+Hosted communities need meaningful and auditable ways to:
+
+- ask questions
+- report issues
+- understand operational/support boundaries
+- contribute to the effective running of the platform
+- see how stewardship decisions affect their lived experience
+
+That participation layer must not require collapsing community governance into infrastructure-admin privilege.
+
+---
+
+## BTS reference implications
+
+For BTS-operated client infrastructure, this architecture can support a pattern like:
+
+- BTS-operated servers provide the infrastructure host/steward layer
+- a CE app instance runs on that infrastructure
+- the local app instance may have a host/default platform for support and accountability
+- the same app instance may also manage one or more internal client/community platforms
+- those managed platforms can federate with external peers and with other BTS- or client-operated instances
+
+In this pattern:
+
+- the app instance's support/steward platform is not automatically identical to every internal managed platform
+- hardware stewardship is not the same thing as tenant ownership
+- client/community autonomy still depends on preserving internal platform and community boundaries
+
+---
+
+## Implementation implications
+
+### 1. `Platform.host` must stay narrow
+
+`Platform.host` can remain a local app/default-host convenience, but it must not be treated as:
+
+- proof that a platform is internal
+- proof that a platform owns a tenant schema
+- proof that the platform represents the infrastructure steward
+
+### 2. `Platform.internal?` is the schema-tenancy decision
+
+For schema tenancy, the decisive question is:
+
+> Does this CE app instance manage private local data for this platform in a tenant schema?
+
+That is what `internal?` should answer.
+
+### 3. Topology metadata needs its own home
+
+The system will eventually need an explicit representation for:
+
+- infrastructure hosts
+- app instances
+- instance-to-host relationships
+- instance-to-platform stewardship/support relationships
+
+That should not be improvised through overloaded platform flags.
+
+### 4. Provisioning must branch early
+
+Provisioning should first determine whether a new registry record is:
+
+- an internal managed platform
+- an external peer platform
+
+Then it should follow different flows.
+
+### 5. Runtime fail-closed behavior must respect the topology
+
+Tenant-local routes must fail closed when they resolve to:
+
+- an external-only platform record
+- an ambiguous host-default path
+- a platform with no valid tenant schema
+
+---
+
+## Recommended implementation order
+
+1. Keep internal/external platform semantics explicit in code and docs.
+2. Add a canonical topology reference for infrastructure hosts, app instances, and stewardship/support relationships.
+3. Narrow host-platform fallbacks so they are used only for explicitly public/app-default surfaces.
+4. Add explicit app-instance/infrastructure models or inventories rather than overloading `Platform`.
+5. Extend operator runbooks so community members and platform stewards can see where to ask questions and how support/accountability flows work.
+
+---
+
+## Design guardrails
+
+- **Care:** do not mislead communities about who controls infrastructure versus who governs their local platform space
+- **Accountability:** make steward, operator, and platform-support responsibilities legible and auditable
+- **Solidarity:** preserve meaningful autonomy for hosted communities instead of collapsing all power into host-wide defaults
+- **Empowerment:** give people real ways to ask questions and contribute to platform health without needing full operator privileges
+- **Stewardship:** avoid overloading one model with infrastructure, runtime, and community-governance meanings
+

--- a/docs/implementation/multi_tenancy/platform_registry_and_schema_boundary.md
+++ b/docs/implementation/multi_tenancy/platform_registry_and_schema_boundary.md
@@ -1,0 +1,301 @@
+# Platform Registry And Schema Boundary
+
+**Date:** April 5, 2026  
+**Status:** Architecture reconciliation baseline  
+**Purpose:** Canonical boundary for what remains in `public` versus what belongs in each internally hosted platform schema
+
+---
+
+## Why this document exists
+
+Community Engine's intended architecture is:
+
+- platform multi-tenancy at the **schema** level
+- community multi-tenancy at the **row** level inside each platform schema
+- explicit federation between local hosted platforms and external peer platforms
+
+The topology around that platform model also needs to stay explicit:
+
+- infrastructure host/steward is not the same thing as an app instance node
+- app instance node is not the same thing as a managed platform
+- host-platform defaults must not be treated as proof that the routed platform is an internal schema-bearing tenant
+
+The current codebase contains real platform-aware groundwork, but it does **not** yet implement schema switching or full platform-private data isolation. This document clarifies the intended boundary so release notes, upgrade docs, and future implementation work do not overclaim the shipped state.
+
+It complements:
+
+- `infrastructure_app_platform_topology.md`
+- `tenant_runtime_contract.md`
+- `tenant_data_ownership_matrix.md`
+- `platform_schema_migration_map.md`
+- `federation_registry_and_tenant_boundary.md`
+- `schema_per_tenant_implementation_plan.md`
+- `../../assessments/multi_tenancy_gap_assessment_2026-03-11.md`
+
+---
+
+## Executive summary
+
+### Target model
+
+- `public` holds the **platform registry/gateway layer**
+- each internally hosted platform owns its **private/local working data** inside its own tenant schema
+- communities remain the primary organizing and permission boundary inside that tenant schema
+- federation records remain explicit cross-platform relationships and must not collapse tenant isolation
+
+### Important public-schema exception
+
+The `better_together_platforms` table remains in `public`, including the direct platform attributes required for:
+
+- platform management
+- platform manifest participation
+- routing
+- localized domain selection
+- connected-platform governance
+
+This does **not** mean platform-private records should remain in `public`.
+
+It also does **not** mean every platform record represents an internal tenant schema. Internal managed platforms and external peer platforms both live in the public registry, but only internal managed platforms own tenant schemas in CE.
+
+### Current implementation reality
+
+Today CE still runs as a shared-schema app with:
+
+- `Current.platform` host resolution
+- `PlatformDomain` hostname lookup
+- selected `platform_id`-scoped records
+- community-scoped records in the shared schema
+- host-platform and host-community fallbacks in several code paths
+
+The current runtime is therefore **platform-aware groundwork**, not completed schema-isolated hosted-platform tenancy.
+
+---
+
+## Public schema contract
+
+`public` is the shared registry and gateway layer. It should hold only what is necessary to route, identify, govern, and connect platforms.
+
+### Public data that belongs in `public`
+
+1. **Platform registry records**
+   - one record per internally hosted platform
+   - one record per known external peer platform
+   - provisioning state, external/local flags, privacy/network defaults, and lifecycle metadata
+   - tenant schema identity only for internally hosted platforms
+
+2. **Direct platform-management metadata**
+   - direct platform attributes used to manage the platform as a registered platform
+   - translated/localized platform attributes only when those attributes are required for:
+     - platform management
+     - manifest publication
+     - routing/domain presentation
+
+3. **Routing manifest**
+   - primary platform-domain metadata
+   - localized primary-domain metadata across supported/configured locales
+   - permitted alternate domains
+   - permitted campaign/vanity domains when the platform has explicit authorization to use them
+
+4. **Cross-platform registry and trust data**
+   - external peer platform metadata
+   - platform connections
+   - trust/bootstrap state
+   - agreement/bootstrap metadata that spans platforms
+
+5. **Cross-tenant operational metadata**
+   - fleet inventory
+   - tenant schema lifecycle records
+   - migration fan-out status
+   - cross-tenant observability and diagnostics
+
+### Public data that should *not* stay in `public`
+
+Unless a later ADR explicitly carves out an exception, `public` should **not** remain the home of:
+
+- local `User` accounts
+- local `Person` profiles
+- local communities and memberships
+- platform-private invitations and onboarding state
+- direct messaging/conversations
+- reports, safety cases, and safety notes
+- local pages, posts, events, blocks, and navigation
+- platform-private analytics, notifications, and search state
+
+Those belong to the tenant schema of the internally hosted platform that owns them.
+
+---
+
+## Tenant schema contract
+
+Each tenant schema is the home of one **internally hosted** platform's local/private operating data.
+
+### Data families that belong in each internally hosted platform schema
+
+- local `User` accounts and authentication state
+- local `Person` profiles and identifications
+- platform memberships and community memberships
+- host community, personal communities, and additional communities
+- invitations, onboarding, and agreement-participation state that is local to that platform
+- conversations, messages, and notifications
+- safety reports, safety cases, safety notes, and moderation artifacts
+- pages, posts, events, blocks, navigation, search indexes, and other platform content
+- local analytics/metrics unless a deliberate cross-tenant exception is approved
+
+External peer platforms do **not** receive their own local tenant schemas in this app. Their metadata stays in `public`, and any remote data that CE chooses to ingest is stored as tenant-local data inside the schema of the internally hosted platform that accepted or mirrored it.
+
+### Community scope inside a tenant schema
+
+Inside a platform schema:
+
+- communities remain the row-level organizing boundary
+- community-private visibility remains membership-gated
+- personal communities remain tenant-local
+- host community convenience must not become a silent fallback for unrelated records
+
+---
+
+## Routing and domain contract
+
+Routing is resolved from the public registry layer and then activates the tenant schema **only for internally hosted platforms**.
+
+### Target routing flow
+
+1. Receive request host.
+2. Resolve the host through the public platform registry/domain manifest.
+3. Match a permitted domain for the platform:
+   - primary domain
+   - localized primary-domain variant
+   - authorized campaign/vanity domain
+4. Load the platform registry record from `public`.
+5. If the platform is internally hosted, resolve its tenant schema.
+6. Switch into that tenant schema before controller logic.
+7. Fail closed if the host is unknown, inactive, unauthorized, mismatched, or points at an external-only platform record for a local-app route.
+
+### Current code limitation
+
+Current `PlatformDomain` behavior only models:
+
+- `hostname`
+- `primary`
+- `active`
+
+It does **not yet** encode:
+
+- locale
+- domain class/type
+- campaign/vanity authorization
+- primary-domain selection per locale
+
+That capability remains part of the intended routing contract, not proven released behavior.
+
+---
+
+## Federation boundary
+
+Federation must not weaken local platform autonomy.
+
+### Required boundary
+
+- the public platform registry identifies and connects platforms
+- tenant schemas own local private data for internally hosted platforms only
+- external peers remain registry records, not local tenant schemas
+- remote data ingested from external peers becomes tenant-local data inside the schema of the internal platform that accepted it, with explicit provenance
+- mirrored content, linked accounts, OAuth trust, and agreements remain explicit cross-platform relationships
+- direct/private tenant-local spaces stay local unless a separate approved design expands them
+
+### Design consequence
+
+Federation should connect platforms **through** the public registry/gateway layer, not by moving platform-private data back into shared tables.
+
+## Topology note
+
+For BTS-operated infrastructure and client-hosted app instances, the architecture needs three distinct accountability layers:
+
+1. **infrastructure hosts / stewards**
+   - servers such as `bts-0`, `bts-4`, `bts-5`
+   - hardware, secrets, network, observability, and uptime stewardship
+2. **app instance nodes**
+   - one CE deployment plus its local database/runtime boundary
+   - edge routing, TLS, bot protection, operational support, and local app health
+3. **managed platforms**
+   - public registry records representing either:
+     - internal schema-bearing platforms managed by that app instance
+     - external peer platforms used for federation/trust only
+
+That distinction matters because a host platform in governance or operational language may not be the same thing as an internal tenant platform in schema-tenancy language.
+
+See `infrastructure_app_platform_topology.md` for the fuller four-layer contract covering infrastructure hosts, app instances, managed platforms, and communities.
+
+---
+
+## Current mismatch to address
+
+The current code/documentation mismatch is now clear:
+
+1. **Planning docs** describe schema-per-platform tenancy.
+2. **Release notes** currently overstate the shipped result.
+3. **Runtime code** currently resolves `Current.platform` but does not switch schemas.
+4. **Data ownership** still mixes:
+   - shared-schema platform records
+   - shared-schema community-owned records
+   - selected `platform_id` slices
+   - host fallbacks
+
+This is why `0.11.0` should be described as **platform-aware groundwork plus federation primitives**, not completed schema isolation.
+
+---
+
+## Implementation phases
+
+### Phase 0 — truth alignment
+
+- correct release notes and upgrade docs
+- make the public-vs-tenant boundary explicit
+- stop claiming universal per-model tenant scoping
+
+### Phase 1 — public registry hardening
+
+- define exactly which `Platform` attributes stay in `public`
+- add explicit routing/manifest semantics for localized primary domains and permitted vanity/campaign domains
+- document or implement the permission model for campaign/vanity routing
+
+### Phase 2 — tenant runtime
+
+- add tenant schema identity to local platforms
+- resolve host -> platform registry record -> tenant schema
+- set `Current.platform` and `Current.tenant_schema`
+- switch schemas before normal controller execution
+- make jobs, mailers, and background processes tenant-aware
+
+### Phase 3 — data-family migration
+
+- move platform-private records into tenant schemas
+- preserve only direct platform registry/gateway records in `public`
+- remove host-platform/host-community fallback assumptions where tenant context should be required
+
+### Phase 4 — federation reconciliation
+
+- ensure platform connections, agreements, mirrored content, and linked accounts remain explicit cross-platform contracts
+- prevent federation features from reintroducing shared private-data shortcuts
+
+### Phase 5 — operator lifecycle
+
+- document provisioning, routing, DNS, host allowlists, migration fan-out, backup, restore, and rollback for platform schemas
+
+Operator baseline:
+
+- `../production/platform_provisioning_and_routing_runbook.md`
+
+### Phase 6 — validation
+
+- prove host resolution, schema switching, unknown-host fail-closed behavior, tenant isolation, and correct release/operator documentation
+
+---
+
+## Values and principles guidance
+
+- **Care:** do not overstate privacy or isolation guarantees that the code does not yet provide
+- **Accountability:** keep intended and implemented boundaries visible and auditable
+- **Stewardship:** move in reversible phases with explicit rollback points
+- **Solidarity:** preserve platform autonomy and avoid collapsing private community data into a host-global control plane
+- **Resilience:** remove silent shared-schema fallbacks that weaken isolation and make failures harder to reason about

--- a/docs/implementation/multi_tenancy/platform_runtime_execution_contract.md
+++ b/docs/implementation/multi_tenancy/platform_runtime_execution_contract.md
@@ -1,0 +1,372 @@
+# Platform Runtime Execution Contract
+
+**Date:** April 5, 2026  
+**Status:** Architecture-to-implementation contract  
+**Purpose:** Define the concrete runtime behavior for requests, jobs, mailers, and rendering under platform-schema tenancy
+
+---
+
+## Why this document exists
+
+The existing tenancy docs already describe the intended high-level model:
+
+- platform routing resolves through the public registry
+- each internal managed platform owns private/local data in its own schema
+- communities remain row-level organizing boundaries inside that schema
+
+What was still missing was the **execution contract** for the runtime surfaces that must actually honor that boundary:
+
+- Rack requests
+- controllers and URL generation
+- background jobs
+- mailers
+- renderer / cache / ActiveStorage context
+
+This document defines that contract and names the failure modes in the current implementation that must be removed.
+
+It complements:
+
+- `infrastructure_app_platform_topology.md`
+- `tenant_runtime_contract.md`
+- `platform_registry_and_schema_boundary.md`
+- `platform_schema_migration_map.md`
+- `../../production/platform_provisioning_and_routing_runbook.md`
+
+---
+
+## Executive summary
+
+### Intended runtime rule
+
+Every execution path that touches platform-owned data must have:
+
+1. a resolved **public platform registry record**
+2. for internal platforms, a resolved **tenant schema identity**
+3. a fail-closed rule when either is missing or unauthorized
+
+Runtime context should also avoid confusing:
+
+- the infrastructure host/steward
+- the app instance default/host platform
+- the routed internal managed platform
+
+Those are related but distinct topology layers. See `infrastructure_app_platform_topology.md`.
+
+### Required `Current` contract
+
+For tenant-aware execution, the runtime should carry at least:
+
+| Field | Meaning |
+|-------|---------|
+| `Current.platform` | Public platform registry record resolved from host or explicit job/mailer context |
+| `Current.platform_domain` | Resolved domain-manifest record, when execution started from a routed host |
+| `Current.tenant_schema` | Active tenant schema for internal platform-owned private/local data |
+| `Current.person` | Current tenant-local person |
+| `Current.governed_agent` | Current actor for policy/governance checks |
+
+Today CE only carries a subset of this contract.
+
+---
+
+## Current implementation baseline
+
+### Requests today
+
+Current request execution does this:
+
+- `PlatformContextMiddleware` resolves `PlatformDomain.resolve(request.host)`
+- `Current.platform` is set from the resolved domain or falls back to `host: true`
+- `BetterTogether::ApplicationController` repeats that context setup and configures `ActiveStorage::Current.url_options`
+
+That fallback only identifies a default platform record. It does **not** prove the resolved platform is an internal tenant with a schema.
+
+### Jobs today
+
+Current jobs are mixed:
+
+- some jobs accept `platform_id`
+- some jobs set `Current.platform` manually
+- no job contract carries `tenant_schema`
+- no job wrapper performs schema switching before data access
+
+### Mailers today
+
+`BetterTogether::ApplicationMailer` currently resolves mail context from:
+
+1. explicit `@platform`
+2. `Current.platform`
+3. host-platform fallback or `BetterTogether.base_url`
+
+This is enough for platform-aware URL generation in a shared schema, but not enough for tenant-schema execution.
+
+### Shared failure pattern
+
+Across requests, jobs, mailers, helpers, and policies, the current runtime still relies heavily on:
+
+- `Current.platform || Platform.find_by(host: true)`
+- `Community.find_by(host: true)`
+
+Those fallbacks are incompatible with trustworthy schema tenancy.
+
+---
+
+## Request execution contract
+
+### Target flow
+
+For every routed request:
+
+1. read the inbound host
+2. resolve that host against the public platform registry/domain manifest
+3. verify the matched domain is:
+   - active
+   - authorized for the platform
+   - valid for the requested routing mode
+4. load the platform registry record from `public`
+5. verify whether the resolved platform is internal or external
+6. if internal, resolve the platform's `tenant_schema`
+7. switch into that tenant schema **before** application/controller logic reads platform-owned data
+8. set:
+    - `Current.platform`
+    - `Current.platform_domain`
+    - `Current.tenant_schema`
+9. configure tenant-aware URL/rendering helpers
+10. on request end, reset all runtime context
+
+### Fail-closed rules
+
+Requests must fail closed when:
+
+- host is unknown
+- domain record is inactive
+- domain is not authorized for the platform
+- an internal platform has no valid tenant schema
+- schema switch fails
+- a tenant-local route resolves to an external-only platform record
+
+Fail closed means:
+
+- return unavailable / not found / explicit platform-routing failure
+- do **not** silently route to the host platform
+- do **not** silently keep executing in `public`
+
+### Current code changes required
+
+The current request stack must be changed in at least these places:
+
+- `PlatformContextMiddleware`
+- `BetterTogether::ApplicationController#set_current_platform_context`
+- any helper or policy that falls back to `host: true`
+
+The host-platform fallback can remain only for explicitly host-global/public-registry surfaces that are designed to run in `public`.
+
+---
+
+## Controller and rendering contract
+
+Once request routing has selected a tenant schema:
+
+- controller queries for platform-owned private data must execute inside that schema
+- `default_url_options` must reflect the resolved routed domain/platform
+- `ActiveStorage::Current.url_options` must use the resolved platform/domain host
+- helpers must not discover platform context by falling back to host-platform globals
+
+### Explicit exception rule
+
+Some controllers may still be intentionally public/global, for example:
+
+- provisioning before tenant creation
+- fleet support/admin surfaces
+- peer platform discovery/bootstrap
+
+Those surfaces must declare themselves as public-registry execution, not reach that mode accidentally via missing tenant context.
+
+---
+
+## Job execution contract
+
+### Target flow
+
+Every background job that touches internal platform-owned data must carry:
+
+- `platform_id`
+- `tenant_schema`
+- optional `platform_domain_id` if routed-host semantics matter
+- optional `community_id` when the job is community-specific
+
+Job execution must:
+
+1. load the public platform record
+2. verify the tenant schema matches the registry record
+3. switch into that tenant schema
+4. set `Current.platform`
+5. set `Current.tenant_schema`
+6. set any community/person context explicitly if required
+7. perform work
+8. reset context at the end
+
+### Fail-closed rules
+
+Jobs must fail closed when:
+
+- `platform_id` is missing for platform-owned work
+- `tenant_schema` is missing or mismatched
+- schema switch fails
+- a supposedly tenant-local job is invoked from ambiguous host-global assumptions
+
+Federation ingest and remote sync jobs still run inside the internal tenant schema that accepted the data. External peer platforms do not become job-local schemas of their own inside CE.
+
+### Current code changes required
+
+At minimum:
+
+- define a tenant-aware `ApplicationJob` helper or concern
+- update jobs like `NotificationCacheWarmingJob` to carry `tenant_schema`, not just `platform_id`
+- remove implicit shared-schema assumptions from cache warming, metrics, sync, and renderer-backed jobs
+
+---
+
+## Mailer execution contract
+
+### Target flow
+
+Every mailer that renders platform-owned content must have an explicit platform runtime context:
+
+- `platform_id`
+- `tenant_schema`
+- optional `platform_domain_id` or resolved host URL if email must use a specific routed domain
+
+Mailer execution must:
+
+1. load the public platform record
+2. verify and switch to the tenant schema before loading tenant-local records
+3. set `Current.platform`
+4. set `Current.tenant_schema`
+5. compute `default_url_options` from the intended routed platform domain
+6. set `ActiveStorage::Current.url_options` consistently
+7. reset context after rendering
+
+### Fail-closed rules
+
+Mailers must not:
+
+- silently fall back to `Platform.find_by(host: true)` for tenant-local emails
+- render a tenant-local email from the wrong schema
+- default to a global/base URL when a tenant-local routed host is required
+
+### Current code changes required
+
+`BetterTogether::ApplicationMailer` needs a tenant-aware replacement for:
+
+- `@platform ||= Current.platform || BetterTogether::Platform.find_by(host: true)`
+
+Host fallback should remain only for truly host-global mail surfaces, and those should be explicit.
+
+---
+
+## Helper / policy / model fallback contract
+
+### Rule
+
+Any code path that accesses platform-owned private/local data must prefer:
+
+1. explicit context
+2. verified `Current.platform` + `Current.tenant_schema`
+
+It must not silently substitute:
+
+- host platform
+- host community
+- first platform in the database
+
+### Current known hotspots
+
+Examples already present in the codebase:
+
+- `ApplicationController#set_current_platform_context`
+- `PlatformContextMiddleware#call`
+- `ApplicationMailer#set_locale_and_time_zone`
+- `NotificationCacheWarmingJob#with_platform_context`
+- content models that auto-assign `platform_id` from `Current.platform || host platform || first platform`
+- helper/policy code using `Platform.find_by(host: true)` and `Community.find_by(host: true)`
+
+### Migration rule
+
+For tenant-schema work:
+
+- host fallbacks must be removed from tenant-local execution paths
+- true host-global/public-registry execution paths must be explicitly labeled and isolated
+
+---
+
+## Cache, URL, and ActiveStorage contract
+
+Schema tenancy affects rendering, fragment keys, and asset URLs.
+
+### Required behavior
+
+- fragment cache keys for platform-owned data must be schema/platform aware
+- renderer-backed jobs must set the same tenant/runtime context as web requests
+- URL helpers must point at the resolved routed domain for that platform
+- `ActiveStorage::Current.url_options` must be set from the intended platform domain, not a host fallback
+
+### Current limitation
+
+The current platform-aware rendering work uses `Current.platform` plus host fallback. That is useful groundwork, but not sufficient once schemas diverge.
+
+---
+
+## Runtime rollout sequence
+
+### Phase 1 — add runtime identity
+
+- extend `Current` with `tenant_schema`
+- add schema identity to public platform registry records
+- define a single runtime resolver service for host -> platform -> tenant schema
+
+### Phase 2 — request path
+
+- update middleware and controller context setup
+- remove silent host-platform fallback from tenant-local request flow
+- add fail-closed error path for unknown/misconfigured hosts
+
+### Phase 3 — jobs and mailers
+
+- add tenant-aware job helper
+- add tenant-aware mailer helper
+- migrate existing jobs/mailers that currently carry only `platform_id` or rely on host fallback
+
+### Phase 4 — helper/model/policy cleanup
+
+- remove shared-schema host fallbacks from tenant-local helpers, models, and policies
+- isolate true public-registry/host-global surfaces explicitly
+
+### Phase 5 — validation
+
+- request host resolution tests
+- unknown-host fail-closed tests
+- schema-switch tests
+- job and mailer tenant-context tests
+- cache/URL/ActiveStorage tests under multiple platform domains
+
+---
+
+## Success criteria
+
+This contract is satisfied when:
+
+1. every tenant-local request resolves a platform and schema before app logic
+2. every tenant-local job and mailer carries explicit schema identity
+3. unknown or invalid hosts fail closed
+4. tenant-local surfaces no longer rely on host-platform fallback
+5. URL generation, rendering, and cache behavior stay correct under multiple routed platform domains
+
+---
+
+## Values and principles guidance
+
+- **Care:** do not let runtime ambiguity leak one platform's private data into another platform's execution path
+- **Accountability:** runtime context must be explicit enough to audit why a request, job, or mailer ran in a given platform/schema
+- **Stewardship:** remove shared-schema shortcuts deliberately and in waves, not by silently preserving them under a new name
+- **Solidarity:** platform autonomy depends on explicit runtime boundaries, not just model-level intent
+- **Resilience:** routing or schema errors must fail closed rather than silently collapsing back to the host platform

--- a/docs/implementation/multi_tenancy/platform_schema_migration_map.md
+++ b/docs/implementation/multi_tenancy/platform_schema_migration_map.md
@@ -1,0 +1,182 @@
+# Platform Schema Migration Map
+
+**Date:** April 5, 2026  
+**Status:** Planning baseline  
+**Purpose:** Map CE model families from the current shared-schema implementation to the intended public-registry + per-platform-schema architecture
+
+---
+
+## Why this document exists
+
+The architecture docs now distinguish clearly between:
+
+- the **public platform registry/gateway layer**
+- each platform's **tenant schema**
+- **community-scoped** data inside each tenant schema
+- **network-shared** federation records
+
+What was still missing was a practical migration map: which model families move, which stay in `public`, which need redesign instead of a simple move, and which blockers must be cleared before code migration begins.
+
+This document is that map.
+
+It complements:
+
+- `platform_registry_and_schema_boundary.md`
+- `federation_registry_and_tenant_boundary.md`
+- `tenant_data_ownership_matrix.md`
+- `tenant_runtime_contract.md`
+- `schema_per_tenant_implementation_plan.md`
+- `../../assessments/multi_tenancy_gap_assessment_2026-03-11.md`
+
+---
+
+## Migration classes
+
+| Class | Meaning |
+|-------|---------|
+| `stay-public` | Remains in `public` because it is registry/gateway/cross-tenant data |
+| `move-tenant-global` | Moves into each platform schema and is visible platform-wide there |
+| `move-community-scoped` | Moves into each platform schema and remains row-scoped by community |
+| `move-personal-community` | Moves into each platform schema and remains anchored to a person's personal community |
+| `network-redesign` | Needs explicit federation/network modeling instead of a simple move |
+| `ops-redesign` | Needs tenant-aware operational lifecycle work before or during the move |
+
+---
+
+## Canonical migration map
+
+| Domain / Model Family | Current Shape | Target Boundary | Migration Class | Migration Approach | Main Blockers / Notes |
+|-----------------------|---------------|-----------------|-----------------|-------------------|-----------------------|
+| `Platform` registry records | Shared-schema table with mixed responsibilities | `public` | `stay-public` | Keep only direct platform-management, manifest, routing, schema identity, and connected-platform metadata in `public` | Need explicit column-level contract for what stays public |
+| Platform translated attrs used for management/manifest/routing | Mixed into platform records today | `public` | `stay-public` | Keep only translated attrs required for management, manifest publication, and routing | Need explicit translation-field allowlist |
+| `PlatformDomain` / routing manifest | Shared-schema hostname table | `public` | `stay-public` | Expand into full routing manifest for localized primary domains and permission-gated vanity/campaign domains | Current model only has `hostname`, `primary`, `active` |
+| Platform provisioning lifecycle | Not implemented | `public` + ops layer | `ops-redesign` | Add schema identity, provisioning state, migration fan-out status, health, and rollback markers | No tenant lifecycle yet |
+| `User` / auth state | Shared-schema local accounts | tenant schema | `move-tenant-global` | Move per-platform accounts into each platform schema; keep only cross-platform linkage metadata outside | Requires real schema switching, auth/session strategy, and tenant-aware Devise/Doorkeeper contract |
+| `Person` / `Identification` | Shared-schema identity with community/platform links | tenant schema | `move-tenant-global` | Move local person/profile state into tenant schemas; preserve per-platform autonomy | Current model mixes community and platform assumptions; personal-community implications must be preserved |
+| `PersonPlatformMembership` | Shared-schema platform membership | tenant schema | `move-tenant-global` | Recreate as tenant-local platform membership inside each platform schema | Depends on platform-local accounts/people |
+| `Community` | Shared-schema organizing boundary | tenant schema | `move-community-scoped` | Move communities into each platform schema; keep row-level scoping there | Need host-community and primary-community creation contract to become tenant-aware |
+| `PersonCommunityMembership` | Shared-schema community memberships | tenant schema | `move-community-scoped` | Keep same conceptual model inside platform schema | Depends on tenant-local people and communities |
+| Personal communities | Emergent via concerns | tenant schema | `move-personal-community` | Preserve per-person personal communities inside each tenant schema | Must avoid host-community silent fallback |
+| Roles / permissions | Effectively shared/global definitions today | tenant schema | `move-tenant-global` | Seed role catalog and resource permissions per tenant schema | Requires RBAC cleanup and federation permission-family redesign |
+| Invitations / onboarding | Mixed platform/community behavior in shared schema | tenant schema | `move-tenant-global` + `move-community-scoped` | Split platform-local admission state from community-local participation state | Must preserve invitation-only, onboarding, and agreement gates under tenant-local auth |
+| Pages / posts / events | Mixed community/platform behavior; some `platform_id` backfills | tenant schema | `move-community-scoped` | Stop treating `platform_id` backfill as final tenancy; make canonical local records tenant-local, community-scoped | Current `platform_id` usage is groundwork, not final isolation |
+| Blocks / reusable templates / branding | Mixed/shared today | tenant schema | `move-community-scoped` and `move-tenant-global` | Split community-owned blocks from tenant-wide reusable assets | Need explicit ownership rules per block family |
+| Navigation areas/items | Mixed/shared today | tenant schema | `move-tenant-global` and `move-community-scoped` | Separate tenant-wide organizer/account nav from community-local nav | Current ownership is not cleanly encoded |
+| Calendars / geography / places / infrastructure | Shared-schema community-owned records | tenant schema | `move-community-scoped` | Preserve existing community-centric design inside tenant schema | Mostly straightforward once community boundary exists |
+| Conversations / messages | Mixed/shared today | tenant schema | `move-tenant-global` | Keep messaging local to one platform schema; no table-sharing across platforms | Needs tenant-aware messaging context and explicit non-federation rule for private spaces |
+| Notifications | Shared/infrastructure today | tenant schema | `move-tenant-global` | Keep product notifications local to a platform schema | Existing notification plumbing may reference shared records with nullable `platform_id` |
+| Reports / safety cases / safety notes / moderation | Mixed safety records | tenant schema | `move-tenant-global` | Keep safety handling platform-local unless a later ADR creates a separate federation safety lane | Must align with least-privilege privacy model and explicit disclosure rules |
+| Webhook endpoints | Community-scoped today | tenant schema | `move-community-scoped` | Keep endpoints local to community/platform schema | Need tenant-aware delivery context and secret storage assumptions |
+| OAuth applications / local auth config | Mixed/shared today | tenant schema | `move-tenant-global` | Each platform should have local OAuth provider/client config in its own schema | Must distinguish local auth config from cross-platform trust metadata |
+| Platform connections / agreements / shared auth/sync consent | Shared registry/federation layer | `public` + network layer | `network-redesign` | Keep cross-platform connection/trust records outside tenant-local content tables, but reference tenant-local actors/data explicitly | Need stable source/target platform identity without collapsing tenant-local ownership |
+| Linked accounts / person links / access grants | Partially approximated today | network layer + tenant schemas | `network-redesign` | Use explicit cross-platform linkage records plus tenant-local account/person records | Needs clear placement for encrypted private-share artifacts and local projections |
+| Mirrored content / sync state | Partial provenance on local content | network layer + tenant schemas | `network-redesign` | Keep canonical remote identity/network state explicit while storing local mirror projections in tenant-local search/feed context | Needs explicit source attribution and refresh contract |
+| Search indexes / feed aggregation | Shared today | tenant schema + network layer | `network-redesign` | Build local per-platform search/feed state that can include authorized mirrored content | Needs tenant-aware indexing and mirror eligibility logic |
+| Metrics / analytics | Shared today | tenant schema by default | `move-tenant-global` | Default platform analytics to tenant-local storage; treat fleet reporting as separate cross-tenant export/reporting lane | Need explicit exceptions for cross-tenant observability |
+| Background jobs | No tenant support today | ops/runtime layer + tenant schemas | `ops-redesign` | Carry platform/schema identity in every job payload and switch schema before work | No tenant-aware job contract yet |
+| Mailers | No tenant support today | ops/runtime layer + tenant schemas | `ops-redesign` | Resolve platform/schema context before rendering and delivery | No tenant-aware mailer context yet |
+| Fleet observability / backup / restore / migration fan-out | Shared ops concern | cross-tenant ops | `stay-public` + `ops-redesign` | Keep fleet oversight outside tenant schemas while making per-tenant operations explicit and auditable | Needs operator runbook and lifecycle tooling |
+
+---
+
+## Recommended migration waves
+
+### Wave 0 — truth, contracts, and registry cleanup
+
+- finalize the public-vs-tenant boundary
+- define the public `Platform` column/translation allowlist
+- define routing-manifest semantics:
+  - primary domains
+  - localized primary-domain variants
+  - vanity/campaign domains
+- correct release notes and upgrade docs
+
+### Wave 1 — tenant runtime foundation
+
+- add `tenant_schema` identity to local platforms
+- implement host -> public platform record -> tenant schema resolution
+- switch schemas before controller logic
+- propagate tenant context to jobs, mailers, and URL helpers
+
+### Wave 2 — identity and governance core
+
+- tenant-local `User`
+- tenant-local `Person`
+- tenant-local platform/community memberships
+- tenant-local communities and personal communities
+- tenant-local role and permission seeding
+
+These are the minimum foundation for trustworthy private-data isolation.
+
+### Wave 3 — local product data
+
+- invitations/onboarding
+- content, blocks, navigation
+- conversations/messages
+- notifications
+- reports/safety records
+- webhooks
+- metrics and search
+
+### Wave 4 — federation reconciliation
+
+- platform connections
+- agreements and consent
+- linked accounts
+- mirrored content
+- search/feed inclusion of authorized mirrors
+
+This wave must be done **after** local tenant ownership is trustworthy.
+
+### Wave 5 — fleet operations
+
+- schema provisioning
+- migration fan-out
+- backup/restore per tenant
+- tenant inventory and health
+- routing/public-edge operational runbook
+
+---
+
+## Highest-risk blockers
+
+### 1. Auth/session assumptions
+
+If `User` becomes truly tenant-local, sign-in, password reset, OAuth provider/client behavior, and invitation/onboarding flows all need a tenant-aware contract.
+
+### 2. Host fallback shortcuts
+
+Current host-platform/host-community fallbacks are convenient in a shared schema, but they become dangerous once tenant context is mandatory.
+
+### 3. Shared infrastructure tables with mixed ownership
+
+Notifications, metrics, search, and some block/navigation surfaces currently mix platform/global assumptions. These must be classified before migration.
+
+### 4. Federation pressure
+
+Federation features can easily tempt the design back toward shared private-state shortcuts. Cross-platform features must be explicit network contracts, not exceptions that erode local schema ownership.
+
+### 5. Routing manifest incompleteness
+
+The intended locale-aware and vanity/campaign-aware domain routing contract is not yet encoded in the current `PlatformDomain` model.
+
+---
+
+## Success criteria for the migration map
+
+This map is successful when it lets implementation teams answer, for every affected model family:
+
+1. Does it stay in `public`, move into the tenant schema, or need a federation/ops redesign?
+2. If it moves, is it tenant-global, community-scoped, or personal-community-scoped?
+3. What prerequisite runtime or RBAC work must land first?
+4. What current shared-schema shortcuts must be removed to make the move trustworthy?
+
+---
+
+## Values and principles guidance
+
+- **Care:** migration order must prioritize the data families that matter most for privacy and safety
+- **Accountability:** every exception to tenant-local ownership should be documented explicitly, not left as an implicit legacy shortcut
+- **Stewardship:** prefer migration waves with clear rollback boundaries over one-shot tenant rewrites
+- **Solidarity:** preserve meaningful autonomy for each platform instead of drifting back toward host-global private data
+- **Resilience:** tenant runtime, routing, and operations must fail closed rather than silently routing data to the wrong platform or fallback host context

--- a/docs/implementation/multi_tenancy/schema_per_tenant_implementation_plan.md
+++ b/docs/implementation/multi_tenancy/schema_per_tenant_implementation_plan.md
@@ -302,5 +302,7 @@ Acceptance criteria:
 ## Related Documents
 
 - `docs/assessments/multi_tenancy_gap_assessment_2026-03-11.md`
+- `docs/implementation/multi_tenancy/platform_registry_and_schema_boundary.md`
+- `docs/implementation/multi_tenancy/platform_schema_migration_map.md`
 - `docs/implementation/multi_tenancy/tenant_data_ownership_matrix.md`
 - `docs/implementation/multi_tenancy/tenant_runtime_contract.md`

--- a/docs/implementation/multi_tenancy/tenant_data_ownership_matrix.md
+++ b/docs/implementation/multi_tenancy/tenant_data_ownership_matrix.md
@@ -11,6 +11,7 @@
 This document defines target ownership for major CE domains under the new architecture:
 
 - each hosted CE platform on this server keeps its own tenant schema
+- `public` keeps the platform registry/gateway layer and only the platform metadata required for management, manifest participation, and routing
 - remote CE and non-CE platforms can exist as external platform records
 - each platform keeps its own local `User`, `Person`, memberships, onboarding, and private spaces
 - cross-platform sign-in and API access use OAuth between platforms
@@ -31,7 +32,7 @@ This matrix is the source of truth for:
 
 | Class | Meaning |
 |-------|---------|
-| `public-global` | Lives in `public`; shared across the host CE instance for routing, peer platform metadata, or fleet administration |
+| `public-global` | Lives in `public`; shared across the host CE instance for routing, platform registry/gateway metadata, peer platform metadata, or fleet administration |
 | `tenant-global` | Lives in one local tenant schema and is visible across that platform |
 | `community-scoped` | Lives in one local tenant schema and resolves to a community |
 | `personal-community-scoped` | Lives in one local tenant schema and is anchored to a person’s personal community |
@@ -44,8 +45,10 @@ This matrix is the source of truth for:
 
 | Domain / Model Family | Current Shape | Target Ownership | Notes |
 |-----------------------|---------------|------------------|-------|
-| Local hosted `Platform` | Shared-schema platform table | `public-global` | Source of routing, schema name, provisioning state, privacy defaults, peer metadata |
+| Local hosted `Platform` | Shared-schema platform table | `public-global` | Source of routing, schema name, provisioning state, privacy defaults, platform-management metadata, and peer metadata |
 | External peer `Platform` | `external` flag already exists | `public-global` | Represents remote CE or non-CE platforms known to the host app |
+| Platform translated attributes required for management / routing / manifest | Mixed with platform record today | `public-global` | Keep only the translated fields needed to manage the platform and route domains; do not treat this as a home for platform-private content |
+| Platform localized domain manifest | Partially modeled by `PlatformDomain` today | `public-global` | Must cover primary domains, localized primary-domain variants, and permitted vanity/campaign domains |
 | Platform provisioning state | Not implemented | `public-global` | Tracks schema lifecycle for locally hosted platforms only |
 | Platform network trust / visibility settings | Not implemented | `public-global` | Controls default privacy, sharing opt-in, peer/member platform relationships |
 | Host CE platform default connection request | Not implemented | `public-global` | Pre-seeded outbound request from the BTS/CE host platform to new private platforms |
@@ -115,6 +118,11 @@ This draft chooses:
 - agreement-backed consent for shared authentication, sync, and publishing
 
 Any implementation that diverges from these defaults should introduce an ADR first.
+
+Current implementation note:
+
+- the released code does not yet provide tenant-schema switching
+- `PlatformDomain` currently models active hostname routing only; locale-aware primary-domain routing and vanity/campaign domain classes remain future work
 
 ---
 

--- a/docs/implementation/multi_tenancy/tenant_runtime_contract.md
+++ b/docs/implementation/multi_tenancy/tenant_runtime_contract.md
@@ -11,12 +11,16 @@
 This document defines how CE should behave at runtime under the revised architecture:
 
 - locally hosted platforms still use schema-per-platform tenancy
+- `public` retains the platform registry/gateway layer, including direct platform-management and routing metadata
 - each platform keeps its own local accounts, people, memberships, and onboarding
 - CE-powered platforms can authenticate against one another via OAuth
 - linked accounts and configured platform connections form a network graph
 - authorized remote content can be mirrored locally for feed/search/display and refreshed regularly
 
 It assumes the ownership rules in `tenant_data_ownership_matrix.md` and the authorization cleanup in `federated_rbac_reassessment_and_coverage_plan.md`.
+
+See also: `platform_registry_and_schema_boundary.md`.
+See also: `platform_runtime_execution_contract.md`.
 
 ---
 
@@ -32,12 +36,26 @@ Each request is resolved from:
 
 ### Resolution Rules For Locally Hosted Platforms
 
-1. Look up the request host in `public.better_together_platforms`.
-2. Match exact custom domain first.
-3. Match known subdomain + base domain second.
-4. Load the local hosted platform metadata from `public`.
-5. Resolve the tenant schema name.
-6. Switch to that schema before controller logic runs.
+1. Look up the request host through the public platform registry and domain manifest.
+2. Match an active permitted domain for the platform:
+   - primary domain
+   - localized primary-domain variant
+   - authorized campaign/vanity domain
+3. Load the local hosted platform metadata from `public`.
+4. Resolve the tenant schema name from the platform registry record.
+5. Switch to that schema before controller logic runs.
+
+### What stays in `public`
+
+`public` remains the shared registry and routing layer. It may contain:
+
+- direct platform metadata required for platform management
+- translated platform attributes required for manifest/routing
+- domain-manifest records
+- platform registry and connection records
+- cross-tenant operational metadata
+
+`public` is **not** the intended home for a platform's local/private working data.
 
 ### External Platform Records
 
@@ -55,6 +73,12 @@ The following flows run in `public` without switching to a local tenant schema:
 - provisioning flows before a tenant exists
 - fleet-admin and support routes spanning local tenants
 - peer platform discovery, trust bootstrap, and local routing fallbacks
+
+Current implementation note:
+
+- the released code currently resolves `Current.platform` from hostname
+- it does **not yet** switch into tenant schemas
+- locale-aware primary-domain routing and vanity/campaign-domain policy remain planned, not fully implemented
 
 Unknown hosts must fail closed.
 
@@ -78,6 +102,11 @@ Unknown hosts must fail closed.
 - `Current.user` and `Current.person` are local to the active platform.
 - Cross-platform OAuth does not replace local accounts; it is an authentication and authorization bridge into local account creation, login, and sync flows.
 - If a federated sign-in succeeds but the local platform requires invitation or onboarding, the request must enter a join/onboarding gate before the user can participate in private spaces.
+
+Execution note:
+
+- requests, jobs, and mailers that touch tenant-local data must all carry this same platform/schema contract
+- host-platform fallback is incompatible with final tenant-local execution except for explicitly public-registry/host-global surfaces
 
 ---
 

--- a/docs/production/platform_provisioning_and_routing_runbook.md
+++ b/docs/production/platform_provisioning_and_routing_runbook.md
@@ -1,0 +1,367 @@
+# Platform Provisioning And Routing Runbook
+
+**Date:** April 5, 2026  
+**Status:** Operator runbook baseline  
+**Audience:** platform operators, deployment maintainers, release stewards  
+**Purpose:** End-to-end runbook for provisioning internal managed platforms, routing domains, and aligning public registry data with tenant-schema intent
+
+---
+
+## Why this runbook exists
+
+Community Engine now has enough platform-registry and domain-routing groundwork that operators can create platform records and host/domain mappings. But the intended architecture is stricter than the current implementation:
+
+- `public` should hold the **platform registry/gateway layer**
+- each internal managed platform should own its **private/local data** in its own schema
+- communities should remain the row-level organizing boundary inside that platform schema
+- routing should resolve the request host through the public registry/domain manifest and then activate the correct platform schema
+
+This does **not** mean:
+
+- every platform record is internal
+- the host platform for an app instance is always the internal schema-bearing platform
+- infrastructure host/steward metadata should be collapsed into the platform record itself
+
+Today, CE does **not yet** complete the tenant-schema lifecycle. This runbook therefore distinguishes:
+
+1. what operators can do with the current code
+2. what the intended end-state operator workflow must be
+3. what steps remain manual, external, or not-yet-implemented
+
+See also:
+
+- `../implementation/multi_tenancy/infrastructure_app_platform_topology.md`
+- `../implementation/multi_tenancy/platform_registry_and_schema_boundary.md`
+- `../implementation/multi_tenancy/platform_schema_migration_map.md`
+- `../implementation/multi_tenancy/tenant_runtime_contract.md`
+- `../implementation/multi_tenancy/platform_runtime_execution_contract.md`
+- `../upgrade/multi-tenancy-upgrade.md`
+- `external-services-to-configure.md`
+
+---
+
+## Support status matrix
+
+| Capability | Status today | Notes |
+|------------|--------------|-------|
+| Create/update public `Platform` record | **Supported** | `TenantPlatformProvisioningService` can create a platform record by `host_url` |
+| Auto-create one primary `PlatformDomain` from `host_url` | **Supported** | Via `sync_primary_platform_domain!` callback |
+| Create primary community and optional steward/admin | **Supported, transitional** | Current implementation creates local records in the shared schema; this is not final tenant-schema provisioning |
+| Resolve request hostname to `Current.platform` | **Supported** | `PlatformContextMiddleware` + `PlatformDomain.resolve` |
+| Localized primary domains | **Planned, not implemented** | Current `PlatformDomain` does not encode locale |
+| Campaign/vanity-domain permissioning | **Planned, not implemented** | No domain class/policy in current model |
+| Per-internal-platform tenant schema creation | **Not implemented** | No schema lifecycle/tooling yet |
+| Request-time schema switching | **Not implemented** | No `Current.tenant_schema` runtime yet |
+| Tenant-aware jobs/mailers | **Not implemented** | Must be added before true schema isolation |
+| End-to-end platform provisioning run command | **Not implemented** | Current service is transitional and insufficient for the target architecture |
+
+---
+
+## Canonical operator intent
+
+When an operator says "provision a new internal managed platform," that should eventually mean:
+
+1. create or update the platform's **public registry record**
+2. define its **routing/domain manifest**
+3. create and migrate its **tenant schema**
+4. seed tenant-local defaults and governance primitives
+5. wire external DNS / ingress / host allowlists
+6. validate host resolution and fail-closed behavior
+
+Today, only parts of that flow are implemented inside CE.
+
+For external peer platforms, the intended operator flow is narrower:
+
+1. create/update the public registry record
+2. define trust, federation, and routing metadata as needed
+3. **do not** create a CE tenant schema for that peer
+4. store any accepted remote data inside the internal platform schema that ingests it
+
+---
+
+## Step 1 — Define the platform boundary before touching runtime
+
+Before creating a platform, decide and record:
+
+### Required topology classification
+
+- which infrastructure host/steward operates the app instance
+- which app instance is responsible for the platform record
+- whether the platform is:
+  - an internal managed platform
+  - an external peer platform
+- what support/stewardship relationship exists between the app instance default/host platform and the managed platform
+- where community members should ask operational/support questions and how those questions are audited/responded to
+
+### Required public-registry data
+
+- platform name
+- canonical host URL
+- software variant
+- privacy / network visibility defaults
+- connection bootstrap state
+- federation protocol / issuer URL if relevant
+- translated platform metadata required for:
+  - platform management
+  - platform manifest participation
+  - routing presentation
+
+### Required routing data
+
+- canonical primary domain
+- additional active domains
+- intended localized primary-domain variants per supported locale
+- whether campaign/vanity domains are requested
+- whether campaign/vanity-domain permission has been granted
+
+### Required tenant-local expectations for internal managed platforms
+
+- tenant schema identifier
+- steward/admin seed intent
+- primary community and governance assumptions
+- whether invitation-only onboarding is required
+
+If these are not explicit, the operator is likely to create a registry record that cannot be safely routed or isolated later.
+
+---
+
+## Step 2 — Create or update the public platform registry record
+
+### Current code path
+
+Today the app-side primitive is:
+
+```ruby
+BetterTogether::TenantPlatformProvisioningService.call(
+  name: 'My Tenant',
+  host_url: 'https://tenant.example.com',
+  time_zone: 'America/Toronto',
+  admin: { email: 'admin@example.com', password: 'SecurePass1!', name: 'Admin User' }
+)
+```
+
+### What it does today
+
+- finds or initializes a `Platform` by `host_url`
+- writes direct platform fields such as:
+  - `name`
+  - `host_url`
+  - `time_zone`
+  - `external`
+  - `host`
+  - `privacy`
+- triggers callback-based primary-domain sync from `host_url`
+- creates a primary community
+- optionally creates an admin user/person and assigns platform/community roles
+
+### Important operator warning
+
+This service is **transitional**:
+
+- it is useful for the current shared-schema implementation
+- it is **not** a full tenant-schema provisioning workflow
+- it currently creates local records in the shared schema, which is incompatible with the final platform-private-data boundary
+
+Use it only with that limitation in mind.
+
+### Future required behavior
+
+The eventual provisioning primitive must:
+
+- create/update the public `Platform` registry record
+- attach schema identity and provisioning state
+- avoid silently treating shared-schema record creation as final tenant provisioning
+- orchestrate tenant schema creation/migration/seed separately and explicitly
+
+---
+
+## Step 3 — Configure the routing/domain manifest
+
+### Current model
+
+Today `PlatformDomain` supports:
+
+- `hostname`
+- `primary`
+- `active`
+
+One primary domain is synced automatically from `Platform.host_url`.
+
+### Current operator implications
+
+Operators can currently:
+
+- set the canonical host URL on the platform
+- let the primary `PlatformDomain` be created from that URL
+- manually add additional `PlatformDomain` records if needed
+
+Operators cannot yet model, inside CE:
+
+- locale for a domain
+- primary-domain selection per locale
+- domain class/type
+- explicit campaign/vanity-domain permission state
+
+### Intended routing contract
+
+The public registry/domain manifest should eventually distinguish:
+
+1. **canonical primary domain**
+2. **localized primary-domain variants**
+3. **alternate managed domains**
+4. **campaign/vanity domains** that require explicit platform permission
+
+### Operator rule until the model is expanded
+
+Until the domain manifest grows those concepts:
+
+- treat `PlatformDomain` as **hostname activation only**
+- keep a separate operator record for:
+  - intended locale/domain mapping
+  - vanity/campaign-domain approval state
+- do not assume CE can currently enforce locale-aware or vanity-domain routing policy by itself
+
+---
+
+## Step 4 — Provision the tenant schema
+
+### Target operator flow
+
+For the intended architecture, provisioning an internal managed platform must include:
+
+1. create tenant schema
+2. run tenant migrations
+3. seed tenant-local roles and defaults
+4. create tenant-local primary community
+5. create tenant-local steward/admin bootstrap data
+
+### Current reality
+
+This lifecycle is **not yet implemented** in CE:
+
+- no schema provisioning service
+- no tenant-migration fan-out tool
+- no request-time schema switching
+- no tenant-aware seed runner
+
+### Operator rule
+
+Do **not** represent a platform as fully provisioned for schema isolation until:
+
+- schema creation exists
+- migration execution exists
+- runtime schema switching exists
+- validation proves the platform's private data is not sharing the host schema
+
+External peer platforms skip this step entirely.
+
+Until then, the platform is only provisioned at the public-registry/shared-schema-groundwork layer.
+
+---
+
+## Step 5 — Wire public routing outside the app
+
+Creating a platform record inside CE is not enough to make the platform reachable.
+
+Operators must also update the external edge:
+
+1. **DNS**
+   - create the public hostname(s)
+   - confirm TTL and ownership assumptions
+
+2. **Ingress / reverse proxy**
+   - route the hostname(s) to the CE deployment
+   - preserve the request `Host` header
+   - preserve real client IP for Rack::Attack and auditability
+
+3. **TLS / certificate coverage**
+   - ensure the hostname is covered by certificate issuance and renewal
+
+4. **Rails host allowlist**
+   - add hostname(s) to `ALLOWED_HOSTS`
+   - ensure `APP_HOST` / URL-generation settings align with the intended canonical host
+
+If any of these are missing, CE may have a correct platform record that still cannot be reached safely or correctly.
+
+---
+
+## Step 6 — Validation checklist
+
+### Current validation that operators can do today
+
+1. Confirm the `Platform` record exists and has the intended public metadata.
+2. Confirm the primary `PlatformDomain` exists and is active.
+3. Confirm `PlatformDomain.resolve(host)` returns the intended platform.
+4. Confirm `Current.platform` is resolved correctly on requests for that host.
+5. Confirm the hostname is accepted by Rails host authorization.
+6. Confirm ingress preserves the `Host` header and real client IP.
+
+### Future validation required for true schema tenancy
+
+1. Confirm the platform has a tenant schema.
+2. Confirm request-time schema switching selects that schema.
+3. Confirm tenant-local `User` / `Person` / `Community` data is isolated from other platforms.
+4. Confirm jobs and mailers execute in the correct tenant context.
+5. Confirm unknown, inactive, or unauthorized hosts fail closed.
+6. Confirm localized primary domains route to the same platform correctly.
+7. Confirm vanity/campaign domains work only when explicitly authorized.
+
+---
+
+## Rollback guidance
+
+### Public-registry rollback
+
+If the platform should not remain visible:
+
+- disable or remove the active `PlatformDomain`
+- remove the hostname from external ingress and `ALLOWED_HOSTS`
+- revert the platform registry record if appropriate
+
+### Tenant-runtime rollback
+
+Once tenant schemas exist, rollback must become explicit and auditable:
+
+- stop routing traffic to the tenant
+- disable provisioning state in the public registry
+- restore from per-tenant backup if data migration failed
+- do not silently remap the hostname to a host fallback platform
+
+The fail-safe behavior should be **closed/unavailable**, not "route somewhere else."
+
+---
+
+## Current gaps operators should track explicitly
+
+The following are still open implementation tasks, not solved operator problems:
+
+- tenant schema provisioning lifecycle
+- request-time schema switching
+- tenant-aware jobs and mailers
+- locale-aware primary-domain routing
+- campaign/vanity-domain classification and permission policy
+- end-to-end per-platform migration fan-out
+- automated validation of platform-to-schema isolation
+
+These should stay visible in release planning until completed.
+
+---
+
+## Recommended near-term operator policy
+
+Until full schema tenancy lands:
+
+1. Treat new platform records as **registry/routing groundwork**, not as proof of private isolation.
+2. Keep manual operator records for localized domain intent and vanity/campaign approvals.
+3. Do not publish release or onboarding language that implies completed per-platform schema isolation.
+4. Prefer explicit validation and fail-closed behavior over host-platform fallbacks.
+
+---
+
+## Values and principles guidance
+
+- **Care:** never imply platform-private isolation where the current runtime cannot yet prove it
+- **Accountability:** make every routing decision, domain approval, and platform activation auditable
+- **Stewardship:** separate reversible public-registry changes from harder-to-reverse tenant data migrations
+- **Solidarity:** preserve real platform autonomy rather than treating one shared host schema as "good enough"
+- **Resilience:** unknown or misconfigured hosts must fail closed rather than silently landing on a fallback platform

--- a/docs/releases/0.11.0.md
+++ b/docs/releases/0.11.0.md
@@ -18,14 +18,20 @@ For the canonical release ledger, see the root [changelog](../../CHANGELOG.md). 
 
 ### 1. Multi-tenant platform architecture and federation
 
-`0.11.0` expands Community Engine from a single-host application model into a platform-aware engine with tenant context, platform memberships, platform connections, and mirrored-content flows.
+`0.11.0` expands Community Engine from a single-host application model into a platform-aware engine with registry/routing groundwork, platform memberships, platform connections, and mirrored-content flows.
 
 Key release surfaces:
 
-- host-platform and tenant-aware request context
+- host-platform and platform-aware request context
 - federation connections and OAuth-backed trust flows
 - mirrored pages, posts, and events with identifier disambiguation
 - authorship opt-in for federated bylines
+
+Important boundary note:
+
+- this release lays groundwork for the intended schema-per-platform design
+- it does **not yet** complete tenant-schema switching or universal per-model platform isolation
+- current routing resolves a platform from the request host, but locale-aware primary domains and vanity/campaign domain classes remain future work
 
 Related docs:
 
@@ -53,19 +59,22 @@ Related docs:
 
 ### 3. Privacy, safety, and personal-data stewardship
 
-`0.11.0` continues the privacy-hardening direction by improving data export flows, federation authorship consent, invitation/policy handling, and safety reporting.
+`0.11.0` continues the privacy-hardening direction by improving data export flows, federation authorship consent, invitation/policy handling, safety reporting, and membership-gated intake/discoverability.
 
 Key release surfaces:
 
 - personal seed exports and scoped access policies
 - accessible safety reporting workflow with linked safety cases, reviewer lanes, and closure summaries
 - stronger policy and scope behavior for invitation and membership contexts
+- invitation-required registration now has an optional membership-request interstitial when the platform/community allows requests
+- least-privilege privacy hardening and reviewer-facing membership-request workflow documentation landed late in the release lane
 - merged `ApplicationPolicy::Scope` fix so scope subclasses can safely consume keyword context
 
 Related docs:
 
 - [Privacy and safety preferences](../end_users/privacy_and_safety_preferences.md)
 - [Safety reporting](../end_users/safety_reporting.md)
+- [Membership request workflow](../developers/systems/membership_request_workflow.md)
 - [Roles and permissions](../shared/roles_and_permissions.md)
 
 ### 4. End-to-end encrypted conversations remain beta-gated

--- a/docs/upgrade/multi-tenancy-upgrade.md
+++ b/docs/upgrade/multi-tenancy-upgrade.md
@@ -8,7 +8,23 @@
 
 ## Overview
 
-This branch adds a multi-tenant platform architecture, federation MVP, and BCrypt-digested OAuth secrets. Deploying it to an existing CE instance requires the migration sequence below. All steps must be executed in order.
+This branch adds platform-aware groundwork for multi-tenancy, federation MVP, and BCrypt-digested OAuth secrets. It does **not** yet deliver the full intended schema-per-platform runtime described in the implementation architecture docs.
+
+Today this branch provides:
+
+- public platform-registry groundwork
+- hostname-to-platform resolution
+- selected `platform_id` backfills and platform-scoped records
+- federation connection and mirrored-content primitives
+
+It does **not yet** provide:
+
+- request-time tenant schema switching
+- tenant schema provisioning/lifecycle
+- tenant-aware job or mailer execution
+- localized primary-domain routing or permission-gated vanity/campaign domain handling
+
+Treat the migration sequence below as preparation for the current platform-aware/federation slice, not as proof that full hosted-platform schema isolation is already complete.
 
 **What changes at the database level:**
 
@@ -151,3 +167,11 @@ The following features require a federation peer to be registered and approved b
 - Federation OAuth token exchange — requires a configured `PlatformConnection`
 
 These are expected for a fresh deployment with no federation peers.
+
+## Architecture note
+
+For the current intended boundary between the public platform registry and tenant schemas, see:
+
+- `../implementation/multi_tenancy/platform_registry_and_schema_boundary.md`
+- `../implementation/multi_tenancy/tenant_runtime_contract.md`
+- `../production/platform_provisioning_and_routing_runbook.md`

--- a/spec/factories/better_together/events.rb
+++ b/spec/factories/better_together/events.rb
@@ -15,24 +15,16 @@ FactoryBot.define do
     timezone { 'America/New_York' }
 
     association :creator, factory: :person
+    platform do
+      Current.platform&.internal? ? Current.platform : create(:better_together_platform)
+    end
 
     # Assign platform after build so Shoulda matchers (which call save(validate: false)
     # and skip before_validation callbacks) don't hit the NOT NULL DB constraint.
     # Note: before(:build) fires with nil as the object in factory_bot 6.5+;
     # after(:build) fires with the actual built instance.
     after(:build) do |event|
-      unless event.platform_id.present?
-        event.platform = Current.platform ||
-                         BetterTogether::Platform.find_by(host: true)
-      end
-    end
-
-    before(:create) do |event|
-      unless event.platform_id.present?
-        event.platform = Current.platform ||
-                         BetterTogether::Platform.find_by(host: true) ||
-                         create(:better_together_platform)
-      end
+      event.platform ||= (Current.platform&.internal? ? Current.platform : create(:better_together_platform))
     end
 
     trait :with_simple_location do

--- a/spec/factories/better_together/pages.rb
+++ b/spec/factories/better_together/pages.rb
@@ -15,27 +15,13 @@ FactoryBot.define do
     privacy { 'public' } # Default to public so tests work for non-managers
     protected { Faker::Boolean.boolean }
     show_title { true }
-
-    # Use after(:create) to set community after the page is saved
-    # This ensures the host community exists and the association is persisted
-    before(:create) do |page|
-      unless page.platform_id.present?
-        page.platform = Current.platform ||
-                        BetterTogether::Platform.find_by(host: true) ||
-                        create(:better_together_platform)
-      end
+    platform do
+      Current.platform&.internal? ? Current.platform : create(:better_together_platform)
     end
-
-    after(:create) do |page|
-      if page.community_id.blank?
-        host_community = BetterTogether::Community.find_by(host: true)
-        page.update_column(:community_id, host_community&.id) if host_community
-      end
-    end
+    community { platform.primary_community }
 
     trait :with_community do
-      # This trait is now a no-op since the model auto-assigns the host community
-      # Kept for backward compatibility with existing tests
+      community { platform.primary_community }
     end
 
     trait :published_public do

--- a/spec/factories/better_together/posts.rb
+++ b/spec/factories/better_together/posts.rb
@@ -11,6 +11,9 @@ module BetterTogether # :nodoc:
       title { generate(:post_title) }
       identifier { generate(:post_identifier) }
       content { 'Post content' }
+      platform do
+        Current.platform&.internal? ? Current.platform : create(:better_together_platform)
+      end
 
       transient do
         author { create(:better_together_person) }
@@ -19,14 +22,6 @@ module BetterTogether # :nodoc:
       after(:build) do |post, evaluator|
         post.authorships.build(author: evaluator.author)
         post.slug = post.identifier
-      end
-
-      before(:create) do |post|
-        unless post.platform_id.present?
-          post.platform = Current.platform ||
-                          BetterTogether::Platform.find_by(host: true) ||
-                          create(:better_together_platform)
-        end
       end
     end
   end

--- a/spec/jobs/better_together/notification_cache_warming_job_spec.rb
+++ b/spec/jobs/better_together/notification_cache_warming_job_spec.rb
@@ -47,6 +47,19 @@ RSpec.describe BetterTogether::NotificationCacheWarmingJob do
     it 'handles missing notifications gracefully' do
       expect { described_class.new.perform([999_999]) }.not_to raise_error
     end
+
+    it 'sets Current.tenant_schema from the platform runtime context when provided' do
+      platform = create(:better_together_platform, tenant_schema: 'tenant_notifications')
+      job = described_class.new
+
+      allow(job).to receive(:should_warm_cache?).with(notification) do
+        expect(Current.platform).to eq(platform)
+        expect(Current.tenant_schema).to eq('tenant_notifications')
+        false
+      end
+
+      job.perform(notification_ids, platform_id: platform.id, tenant_schema: 'tenant_notifications')
+    end
   end
 
   describe '#warm_notification_fragments' do
@@ -182,6 +195,16 @@ RSpec.describe BetterTogether::NotificationCacheWarmingJob do
       expect do
         described_class.perform_later([1, 2, 3])
       end.to have_enqueued_job(described_class).with([1, 2, 3])
+    end
+
+    it 'can be enqueued with platform runtime metadata' do
+      expect do
+        described_class.perform_later([1, 2, 3], platform_id: 'platform-1', tenant_schema: 'tenant_platform_1')
+      end.to have_enqueued_job(described_class).with(
+        [1, 2, 3],
+        platform_id: 'platform-1',
+        tenant_schema: 'tenant_platform_1'
+      )
     end
   end
 end

--- a/spec/mailers/better_together/application_mailer_spec.rb
+++ b/spec/mailers/better_together/application_mailer_spec.rb
@@ -77,9 +77,20 @@ RSpec.describe BetterTogether::ApplicationMailer do
 
     context 'when no platform exists at all' do
       it 'raises an error when the template accesses @platform.name' do
-        # Stub both resolution paths so this test is DB-state-independent.
-        # better_together_platforms is ESSENTIAL_TABLES and persists across workers.
-        allow(BetterTogether::Platform).to receive(:find_by).with(host: true).and_return(nil)
+        # Stub the runtime resolver so this test is DB-state-independent even
+        # though the mailer now resolves host fallback through the shared
+        # runtime context service instead of calling Platform.find_by(host: true)
+        # directly.
+        allow(BetterTogether::PlatformRuntimeContextResolver).to receive(:for_platform)
+          .with(nil, fallback_to_host: true)
+          .and_return(
+            BetterTogether::PlatformRuntimeContextResolver::Result.new(
+              platform: nil,
+              platform_domain: nil,
+              tenant_schema: nil,
+              source: :none
+            )
+          )
         allow(Current).to receive(:platform).and_return(nil)
         # This is the correct fail-loud behaviour: a misconfigured deployment
         # (no host platform seeded) must not silently send broken emails.

--- a/spec/middleware/better_together/platform_context_middleware_spec.rb
+++ b/spec/middleware/better_together/platform_context_middleware_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe BetterTogether::PlatformContextMiddleware do
     app = lambda do |_env|
       captured[:platform]        = Current.platform
       captured[:platform_domain] = Current.platform_domain
+      captured[:tenant_schema]   = Current.tenant_schema
       [200, { 'Content-Type' => 'text/plain' }, ['ok']]
     end
     [described_class.new(app), captured]
@@ -22,7 +23,7 @@ RSpec.describe BetterTogether::PlatformContextMiddleware do
 
   describe '#call' do
     context 'when the request host matches a registered PlatformDomain' do
-      let!(:platform) { create(:better_together_platform) }
+      let!(:platform) { create(:better_together_platform, tenant_schema: 'tenant_bt_test') }
       let!(:domain) do
         create(:better_together_platform_domain, hostname: 'bt-test.example', platform:)
       end
@@ -36,11 +37,17 @@ RSpec.describe BetterTogether::PlatformContextMiddleware do
         _response, captured = call_with_host('bt-test.example')
         expect(captured[:platform_domain]).to eq(domain)
       end
+
+      it 'sets Current.tenant_schema from the matched platform' do
+        _response, captured = call_with_host('bt-test.example')
+        expect(captured[:tenant_schema]).to eq('tenant_bt_test')
+      end
     end
 
     context 'when the request host does not match any PlatformDomain' do
       it 'falls back to the host platform' do
         host_platform = configure_host_platform
+        host_platform.update!(tenant_schema: 'host_platform_schema')
         _response, captured = call_with_host('unknown-host.test')
         expect(captured[:platform]).to eq(host_platform)
       end
@@ -49,6 +56,13 @@ RSpec.describe BetterTogether::PlatformContextMiddleware do
         configure_host_platform
         _response, captured = call_with_host('unknown-host.test')
         expect(captured[:platform_domain]).to be_nil
+      end
+
+      it 'sets Current.tenant_schema from the host platform fallback' do
+        host_platform = configure_host_platform
+        host_platform.update!(tenant_schema: 'host_platform_schema')
+        _response, captured = call_with_host('unknown-host.test')
+        expect(captured[:tenant_schema]).to eq('host_platform_schema')
       end
     end
 
@@ -63,6 +77,42 @@ RSpec.describe BetterTogether::PlatformContextMiddleware do
         _response, captured = call_with_host('unknown-host.test')
         expect(captured[:platform]).to be_nil
       end
+
+      it 'sets Current.tenant_schema to nil' do
+        allow(BetterTogether::PlatformDomain).to receive(:resolve).and_return(nil)
+        allow(Rails.cache).to receive(:fetch)
+          .with('better_together/host_platform_id', expires_in: 5.minutes)
+          .and_return(nil)
+        _response, captured = call_with_host('unknown-host.test')
+        expect(captured[:tenant_schema]).to be_nil
+      end
+    end
+
+    context 'when the request host matches an external platform domain' do
+      let!(:platform) { create(:better_together_platform, :external) }
+      let!(:domain) do
+        create(:better_together_platform_domain, hostname: 'external-peer.example', platform:)
+      end
+
+      it 'fails closed with not found' do
+        middleware, = capturing_app
+        status, _headers, body = middleware.call(Rack::MockRequest.env_for('http://external-peer.example/'))
+
+        expect(status).to eq(404)
+        expect(body.each.to_a.join).to eq('Not Found')
+      end
+
+      it 'does not invoke the downstream app' do
+        called = false
+        middleware = described_class.new(lambda { |_env|
+          called = true
+          [200, { 'Content-Type' => 'text/plain' }, ['ok']]
+        })
+
+        middleware.call(Rack::MockRequest.env_for('http://external-peer.example/'))
+
+        expect(called).to be(false)
+      end
     end
 
     it 'resets Current after the response' do
@@ -71,6 +121,7 @@ RSpec.describe BetterTogether::PlatformContextMiddleware do
       middleware.call(Rack::MockRequest.env_for('http://www.example.com/'))
       expect(Current.platform).to be_nil
       expect(Current.platform_domain).to be_nil
+      expect(Current.tenant_schema).to be_nil
     end
 
     it 'resets Current even when the inner app raises' do

--- a/spec/models/better_together/event_spec.rb
+++ b/spec/models/better_together/event_spec.rb
@@ -449,6 +449,28 @@ module BetterTogether # :nodoc:
         expect(event.platform).to eq(local_platform)
       end
 
+      it 'does not silently fall back to the host platform when Current.platform is missing' do
+        previous_platform = Current.platform
+        Current.platform = nil
+        BetterTogether::Platform.find_by(host: true) || create(:better_together_platform, :host)
+        event = described_class.new(
+          name: 'No Context Event',
+          identifier: SecureRandom.uuid,
+          starts_at: 1.day.from_now,
+          ends_at: 1.day.from_now + 1.hour,
+          privacy: 'public',
+          timezone: 'America/New_York',
+          creator: create(:person)
+        )
+
+        event.valid?
+
+        expect(event.platform).to be_nil
+        expect(event.errors[:platform_id]).to be_present
+      ensure
+        Current.platform = previous_platform
+      end
+
       it 'treats a current-platform event as local' do
         event.valid?
 

--- a/spec/models/better_together/metrics/page_view_spec.rb
+++ b/spec/models/better_together/metrics/page_view_spec.rb
@@ -6,6 +6,13 @@ RSpec.describe BetterTogether::Metrics::PageView do
   let(:viewed_at) { Time.zone.now }
   let(:locale) { 'en' }
 
+  around do |example|
+    previous_platform = Current.platform
+    Current.reset
+    example.run
+    Current.platform = previous_platform
+  end
+
   # rubocop:todo RSpec/MultipleExpectations
   it 'normalizes page_url to exclude query strings' do # rubocop:todo RSpec/MultipleExpectations
     # rubocop:enable RSpec/MultipleExpectations
@@ -30,5 +37,34 @@ RSpec.describe BetterTogether::Metrics::PageView do
 
     expect(page_view).not_to be_valid
     expect(page_view.errors[:page_url]).to include('contains sensitive parameters')
+  end
+
+  it 'assigns platform from explicit internal current platform context' do
+    platform = create(:better_together_platform)
+    Current.platform = platform
+
+    page_view = described_class.create!(
+      page_url: 'http://127.0.0.1:3000/path',
+      viewed_at: viewed_at,
+      locale: locale,
+      logged_in: false
+    )
+
+    expect(page_view.platform).to eq(platform)
+  end
+
+  it 'does not borrow platform from external current platform context' do
+    Current.platform = create(:better_together_platform, external: true)
+
+    page_view = described_class.new(
+      page_url: 'http://127.0.0.1:3000/path',
+      viewed_at: viewed_at,
+      locale: locale,
+      logged_in: false
+    )
+
+    page_view.valid?
+
+    expect(page_view.platform).to be_nil
   end
 end

--- a/spec/models/better_together/page_spec.rb
+++ b/spec/models/better_together/page_spec.rb
@@ -140,6 +140,7 @@ module BetterTogether # :nodoc:
           page.valid?
 
           expect(page.platform).to eq(local_platform)
+          expect(page.community).to eq(local_platform.primary_community)
         end
 
         it 'treats a current-platform page as local' do
@@ -172,6 +173,21 @@ module BetterTogether # :nodoc:
           expect(mirrored_page).to be_mirrored
           expect(mirrored_page).to be_preserved_remote_uuid
           expect(mirrored_page.source_identifier).to eq(mirrored_page.id)
+        end
+
+        it 'does not silently fall back to the host platform when Current.platform is missing' do
+          previous_platform = Current.platform
+          Current.platform = nil
+          BetterTogether::Platform.find_by(host: true) || create(:better_together_platform, :host)
+          page = described_class.new(title: 'No Context', content: 'Body', privacy: 'public')
+
+          page.valid?
+
+          expect(page.platform).to be_nil
+          expect(page.community).to be_nil
+          expect(page.errors[:platform_id]).to be_present
+        ensure
+          Current.platform = previous_platform
         end
       end
 

--- a/spec/models/better_together/platform_spec.rb
+++ b/spec/models/better_together/platform_spec.rb
@@ -60,6 +60,31 @@ RSpec.describe BetterTogether::Platform, :skip_host_setup do
     end
   end
 
+  describe 'internal/external semantics' do
+    it 'treats the default platform factory as internal' do
+      platform = build(:better_together_platform)
+
+      expect(platform).to be_internal
+      expect(platform.external).to be(false)
+    end
+
+    it 'allows internal assignment as the canonical inverse of external' do
+      platform = build(:better_together_platform, :external)
+
+      platform.internal = true
+
+      expect(platform).to be_internal
+      expect(platform.external).to be(false)
+    end
+
+    it 'rejects tenant_schema on external peer platforms' do
+      platform = build(:better_together_platform, :external, tenant_schema: 'peer_schema')
+
+      expect(platform).not_to be_valid
+      expect(platform.errors[:tenant_schema]).to include('must be blank for external platforms')
+    end
+  end
+
   describe 'validations' do
     subject(:platform) { build(:better_together_platform, host_url:) }
 

--- a/spec/models/better_together/post_spec.rb
+++ b/spec/models/better_together/post_spec.rb
@@ -112,6 +112,17 @@ RSpec.describe BetterTogether::Post do
       Current.reset
     end
 
+    it 'does not silently fall back to the host platform when Current.platform is missing' do
+      host_platform = BetterTogether::Platform.find_by(host: true) || create(:better_together_platform, :host)
+      post = described_class.new(title: 'No Context', identifier: 'no-context', content: 'Body', privacy: 'public')
+
+      post.valid?
+
+      expect(post.platform).to be_nil
+      expect(host_platform).to be_present
+      expect(post.errors[:platform_id]).to be_present
+    end
+
     it 'distinguishes local and remote mirrored origin' do
       local_platform = create(:better_together_platform)
       remote_platform = create(:better_together_platform)

--- a/spec/policies/better_together/conversation_policy_spec.rb
+++ b/spec/policies/better_together/conversation_policy_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe BetterTogether::ConversationPolicy, type: :policy do
     create(:better_together_person, preferences: { receive_messages_from_members: true })
   end
 
+  around do |example|
+    previous_platform = Current.platform
+    Current.platform = host_platform
+    example.run
+    Current.platform = previous_platform
+  end
+
   before do
     manage_platform_permission = BetterTogether::ResourcePermission.find_by(identifier: 'manage_platform')
     steward_role = create(:better_together_role, :platform_role)
@@ -42,6 +49,19 @@ RSpec.describe BetterTogether::ConversationPolicy, type: :policy do
     create(:better_together_person_platform_membership, member: non_opted_person, joinable: host_platform)
     create(:better_together_person_platform_membership, member: other_platform_opted_in_person, joinable: other_platform)
     create(:better_together_person_community_membership, member: host_only_opted_in_person, joinable: host_platform.community)
+  end
+
+  describe 'without explicit current platform context' do
+    it 'returns no permitted participants' do
+      previous_platform = Current.platform
+      Current.platform = nil
+
+      policy = described_class.new(steward_user, BetterTogether::Conversation.new)
+
+      expect(policy.permitted_participants).to be_empty
+    ensure
+      Current.platform = previous_platform
+    end
   end
 
   describe '#permitted_participants' do

--- a/spec/policies/better_together/metrics/link_checker_report_policy_spec.rb
+++ b/spec/policies/better_together/metrics/link_checker_report_policy_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe BetterTogether::Metrics::LinkCheckerReportPolicy, type: :policy d
     BetterTogether::AccessControlBuilder.seed_data
   end
 
+  around do |example|
+    previous_platform = Current.platform
+    Current.platform = platform
+    example.run
+    Current.platform = previous_platform
+  end
+
   describe '#index?' do
     context 'when user is analytics viewer' do
       before do
@@ -131,5 +138,14 @@ RSpec.describe BetterTogether::Metrics::LinkCheckerReportPolicy, type: :policy d
         expect(policy.destroy?).to be false
       end
     end
+  end
+
+  it 'denies access without explicit current platform context' do
+    previous_platform = Current.platform
+    Current.platform = nil
+
+    expect(policy.index?).to be false
+  ensure
+    Current.platform = previous_platform
   end
 end

--- a/spec/policies/better_together/metrics/link_click_report_policy_spec.rb
+++ b/spec/policies/better_together/metrics/link_click_report_policy_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe BetterTogether::Metrics::LinkClickReportPolicy, type: :policy do
     BetterTogether::AccessControlBuilder.seed_data
   end
 
+  around do |example|
+    previous_platform = Current.platform
+    Current.platform = platform
+    example.run
+    Current.platform = previous_platform
+  end
+
   describe '#index?' do
     context 'when user is analytics viewer' do
       before do
@@ -131,5 +138,14 @@ RSpec.describe BetterTogether::Metrics::LinkClickReportPolicy, type: :policy do
         expect(policy.destroy?).to be false
       end
     end
+  end
+
+  it 'denies access without explicit current platform context' do
+    previous_platform = Current.platform
+    Current.platform = nil
+
+    expect(policy.index?).to be false
+  ensure
+    Current.platform = previous_platform
   end
 end

--- a/spec/policies/better_together/metrics/page_view_report_policy_spec.rb
+++ b/spec/policies/better_together/metrics/page_view_report_policy_spec.rb
@@ -13,6 +13,13 @@ RSpec.describe BetterTogether::Metrics::PageViewReportPolicy, type: :policy do
     BetterTogether::AccessControlBuilder.seed_data
   end
 
+  around do |example|
+    previous_platform = Current.platform
+    Current.platform = platform
+    example.run
+    Current.platform = previous_platform
+  end
+
   describe '#index?' do
     context 'when user is analytics viewer' do
       before do
@@ -131,5 +138,14 @@ RSpec.describe BetterTogether::Metrics::PageViewReportPolicy, type: :policy do
         expect(policy.destroy?).to be false
       end
     end
+  end
+
+  it 'denies access without explicit current platform context' do
+    previous_platform = Current.platform
+    Current.platform = nil
+
+    expect(policy.index?).to be false
+  ensure
+    Current.platform = previous_platform
   end
 end

--- a/spec/policies/better_together/metrics/report_policy_spec.rb
+++ b/spec/policies/better_together/metrics/report_policy_spec.rb
@@ -19,12 +19,20 @@ RSpec.describe BetterTogether::Metrics::ReportPolicy, type: :policy do
   let(:report_creator) { create(:user) }
   let(:report_downloader) { create(:user) }
   let(:manage_only_user) { create(:user) }
+  let(:platform) { BetterTogether::Platform.find_by(host: true) || configure_host_platform }
 
   before do
     grant_platform_permission(metrics_viewer, 'view_metrics_dashboard')
     grant_platform_permission(report_creator, 'create_metrics_reports')
     grant_platform_permission(report_downloader, 'download_metrics_reports')
     grant_platform_permission(manage_only_user, 'manage_platform')
+  end
+
+  around do |example|
+    previous_platform = Current.platform
+    Current.platform = platform
+    example.run
+    Current.platform = previous_platform
   end
 
   it 'requires explicit dashboard permission to view metrics' do

--- a/spec/requests/better_together/metrics/search_queries_controller_spec.rb
+++ b/spec/requests/better_together/metrics/search_queries_controller_spec.rb
@@ -66,4 +66,16 @@ RSpec.describe 'BetterTogether::Metrics::SearchQueriesController' do
     post better_together.metrics_search_queries_path(locale:), params: { query: '', results_count: '' }
     expect(response).to have_http_status(:unprocessable_content)
   end
+
+  it 'gracefully skips tracking without internal metrics platform context' do
+    allow(capture_service).to receive(:call).with('test').and_return('test')
+    allow(Current).to receive(:platform).and_return(nil)
+
+    expect do
+      post better_together.metrics_search_queries_path(locale:), params: {
+        query: 'test',
+        results_count: 3
+      }
+    end.not_to have_enqueued_job(BetterTogether::Metrics::TrackSearchQueryJob)
+  end
 end

--- a/spec/requests/better_together/search_controller_spec.rb
+++ b/spec/requests/better_together/search_controller_spec.rb
@@ -84,6 +84,14 @@ RSpec.describe 'BetterTogether::SearchController', :as_user do
         end.not_to have_enqueued_job(BetterTogether::Metrics::TrackSearchQueryJob)
       end
 
+      it 'gracefully skips search analytics without internal metrics platform context' do
+        allow(Current).to receive(:platform).and_return(nil)
+
+        expect do
+          get better_together.search_path(locale:), params: { q: 'test query' }
+        end.not_to have_enqueued_job(BetterTogether::Metrics::TrackSearchQueryJob)
+      end
+
       it 'filters private linked seed models out of the global search set' do
         # PersonLinkedSeed.global_searchable? returns false so Registry excludes it from
         # global_search_models. The registry_spec covers this at unit level; here we confirm

--- a/spec/services/better_together/metrics/search_query_capture_service_spec.rb
+++ b/spec/services/better_together/metrics/search_query_capture_service_spec.rb
@@ -7,6 +7,13 @@ RSpec.describe BetterTogether::Metrics::SearchQueryCaptureService do
     let(:platform) { create(:better_together_platform, settings: settings) }
     let(:settings) { {} }
 
+    around do |example|
+      previous_platform = Current.platform
+      Current.reset
+      example.run
+      Current.platform = previous_platform
+    end
+
     it 'keeps normalized queries in full mode' do
       result = described_class.new(platform: platform).call("  Housing  Support \n")
 
@@ -32,6 +39,18 @@ RSpec.describe BetterTogether::Metrics::SearchQueryCaptureService do
         expect(result).to start_with('sha256:')
         expect(result).to eq("sha256:#{Digest::SHA256.hexdigest('housing support')}")
       end
+    end
+
+    it 'returns nil without explicit internal platform context' do
+      result = described_class.new.call('housing support')
+
+      expect(result).to be_nil
+    end
+
+    it 'returns nil for external platform context' do
+      result = described_class.new(platform: create(:better_together_platform, external: true)).call('housing support')
+
+      expect(result).to be_nil
     end
   end
 end

--- a/spec/services/better_together/platform_runtime_context_resolver_spec.rb
+++ b/spec/services/better_together/platform_runtime_context_resolver_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BetterTogether::PlatformRuntimeContextResolver do
+  describe '.for_host' do
+    it 'resolves platform, domain, and tenant schema from a matching domain' do
+      platform = create(:better_together_platform, tenant_schema: 'tenant_alpha')
+      domain = create(:better_together_platform_domain, platform:, hostname: 'tenant-alpha.test')
+
+      result = described_class.for_host('tenant-alpha.test')
+
+      expect(result.platform).to eq(platform)
+      expect(result.platform_domain).to eq(domain)
+      expect(result.tenant_schema).to eq('tenant_alpha')
+      expect(result.source).to eq(:platform_domain)
+    end
+
+    it 'falls back to the host platform when configured to do so' do
+      host_platform = configure_host_platform
+      host_platform.update!(tenant_schema: 'host_platform_schema')
+
+      result = described_class.for_host('unknown-host.test')
+
+      expect(result.platform).to eq(host_platform)
+      expect(result.platform_domain).to be_nil
+      expect(result.tenant_schema).to eq('host_platform_schema')
+      expect(result.source).to eq(:host_platform)
+    end
+
+    it 'returns no platform when no match exists and fallback is disabled' do
+      result = described_class.for_host('unknown-host.test', fallback_to_host: false)
+
+      expect(result.platform).to be_nil
+      expect(result.platform_domain).to be_nil
+      expect(result.tenant_schema).to be_nil
+      expect(result.source).to eq(:none)
+    end
+  end
+
+  describe '.for_platform' do
+    it 'resolves tenant schema from an explicit platform record' do
+      platform = create(:better_together_platform, tenant_schema: 'tenant_explicit')
+
+      result = described_class.for_platform(platform)
+
+      expect(result.platform).to eq(platform)
+      expect(result.tenant_schema).to eq('tenant_explicit')
+      expect(result.source).to eq(:explicit_platform)
+    end
+
+    it 'does not surface tenant schema metadata for external peer platforms' do
+      platform = create(:better_together_platform, :external)
+
+      result = described_class.for_platform(platform)
+
+      expect(result.platform).to eq(platform)
+      expect(result.tenant_schema).to be_nil
+      expect(result.source).to eq(:explicit_platform)
+    end
+  end
+end

--- a/spec/services/better_together/tenant_platform_provisioning_service_spec.rb
+++ b/spec/services/better_together/tenant_platform_provisioning_service_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe BetterTogether::TenantPlatformProvisioningService do
         expect(result.errors).to be_blank
         expect(result.platform).to be_persisted
         expect(result.platform.name).to eq('Test Tenant')
+        expect(result.platform).to be_internal
         expect(result.platform.host).to be(false)
         expect(result.community).to be_present
         expect(result.admin_user).to be_nil
@@ -67,6 +68,26 @@ RSpec.describe BetterTogether::TenantPlatformProvisioningService do
 
         expect(second).to be_success
         expect(second.platform.id).to eq(first.platform.id)
+      end
+    end
+
+    context 'with tenant schema metadata' do
+      it 'persists tenant_schema on the platform registry record' do
+        result = described_class.call(**base_params, tenant_schema: 'tenant_test_tenant')
+
+        expect(result).to be_success
+        expect(result.platform.tenant_schema).to eq('tenant_test_tenant')
+      end
+    end
+
+    context 'with external compatibility params' do
+      it 'treats external: true as a non-internal registry record and clears tenant_schema' do
+        result = described_class.call(**base_params, external: true, tenant_schema: 'tenant_should_not_persist')
+
+        expect(result).to be_success
+        expect(result.platform).not_to be_internal
+        expect(result.platform.external).to be(true)
+        expect(result.platform.tenant_schema).to be_nil
       end
     end
 


### PR DESCRIPTION
## ⚠️ Needs Triage — Do Not Merge Without Review

Salvage branch from April 18, 2026 remediation (session 7eb000bc). The local `feat/community-privacy` worktree was **1,166 commits ahead of remote** when salvaged — this branch captures the tip as a single salvage commit.

**Scope (58 files, +2657/-161):**
- Metrics policy specs (link_checker, link_click, page_view, report, search_queries)
- Platform runtime context resolver spec
- Tenant platform provisioning service spec
- Search controller spec
- And more (see diff)

**Why this is a draft / not ready:**
- Cherry-pick attempts from the original worktree caused massive conflicts
- The branch diverged 607 commits behind `release/0.11.0-notes` at time of salvage
- Conflict-resolution integration strategy needs deliberate design before this can be merged

**Next step:** Extract individual commits or file-level patches from this salvage snapshot into targeted PRs once the conflict scope is understood.