### PR TITLE
fix(dev): harden release 0.11.0 local setup

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -16,6 +16,14 @@ SEARCH_BACKEND='pg_search'
 # ES_HOST='http://elasticsearch'
 # ELASTICSEARCH_URL='http://elasticsearch:9201'
 
+# Optional Active Record encryption overrides for local development.
+# The dev and test environments fall back to fixed local-only defaults when
+# these are unset, which keeps fresh worktrees bootstrappable without
+# `spec/dummy/config/master.key`.
+# ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY='4f7f0d8d0e2b7c8f9a1b2c3d4e5f60714f7f0d8d0e2b7c8f9a1b2c3d4e5f6071'
+# ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY='6a8b0c1d2e3f40516a8b0c1d2e3f40516a8b0c1d2e3f40516a8b0c1d2e3f4051'
+# ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT='8c9d0e1f2a3b4c5d8c9d0e1f2a3b4c5d8c9d0e1f2a3b4c5d8c9d0e1f2a3b4c5d'
+
 BASE_URL='http://localhost:3000'
 
 REDIS_URL='redis://community-engine-redis:6379'

--- a/README.md
+++ b/README.md
@@ -102,20 +102,26 @@ bin/dc build
 Bundle the gems:
 
 ```bash
-bin/dc-run app bundle
+bin/dc-run bundle
 ```
 
 Setup the database:
 
 ```bash
-bin/dc-run app rails db:setup
+bin/dc-run rails db:setup
 ```
 
 Run the RSpec tests:
 
 ```bash
-bin/dc-run app rspec
+bin/dc-run rspec
 ```
+
+Troubleshooting:
+
+- `bin/dc-run rails db:create` only creates the databases. It does not load schema or run migrations.
+- If you have already run `db:create`, run `bin/dc-run rails db:migrate` or `bin/dc-run rails db:setup` before `bin/dc-run rails db:seed`.
+- Fresh worktrees may not include ignored files such as `spec/dummy/config/master.key`, so local setup must not depend on that file being present.
 
 ## Contributing
 

--- a/app/builders/better_together/navigation_builder.rb
+++ b/app/builders/better_together/navigation_builder.rb
@@ -21,563 +21,569 @@ module BetterTogether
       end
 
       # rubocop:todo Metrics/AbcSize
-      def build_better_together # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
-        I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
-          # Create Better Together Nav Area
-          better_together_pages = ::BetterTogether::Page.create!(
-            [
-              {
-                title_en: 'What is Better Together?',
-                slug_en: 'better-together',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/better_together',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+      def build_better_together # rubocop:todo Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
+        # rubocop:todo Metrics/BlockLength
+        with_navigation_touch_suppressed do
+          I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
+            # Create Better Together Nav Area
+            better_together_pages = ::BetterTogether::Page.create!(
+              [
+                {
+                  title_en: 'What is Better Together?',
+                  slug_en: 'better-together',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/better_together',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                title_en: 'About the Community Engine',
-                slug_en: 'better-together/community-engine',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                layout: 'layouts/better_together/full_width_page',
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/community_engine',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+                  ]
+                },
+                {
+                  title_en: 'About the Community Engine',
+                  slug_en: 'better-together/community-engine',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  layout: 'layouts/better_together/full_width_page',
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/community_engine',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              }
-            ]
-          )
+                  ]
+                }
+              ]
+            )
 
-          area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'better-together') do |area|
-            area.name = 'Better Together'
-            area.slug = 'better-together'
-            area.visible = true
-            area.protected = true
+            area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'better-together') do |area|
+              area.name = 'Better Together'
+              area.slug = 'better-together'
+              area.visible = true
+              area.protected = true
+            end
+
+            # Clear existing navigation items if area already existed
+            area.reload.navigation_items.delete_all
+
+            # Create Host Navigation Item
+            better_together_nav_item = area.navigation_items.create!(
+              identifier: 'better-together-nav',
+              title_en: 'Powered with <3 by Better Together',
+              slug_en: 'better-together-nav',
+              position: 0,
+              visible: true,
+              protected: true,
+              item_type: 'dropdown',
+              url: '#',
+              privacy: 'public'
+            )
+
+            # Add children to Better Together Navigation Item
+            better_together_nav_item.create_children(better_together_pages, area)
+
+            area.reload.save!
           end
-
-          # Clear existing navigation items if area already existed
-          area.reload.navigation_items.delete_all
-
-          # Create Host Navigation Item
-          better_together_nav_item = area.navigation_items.create!(
-            identifier: 'better-together-nav',
-            title_en: 'Powered with <3 by Better Together',
-            slug_en: 'better-together-nav',
-            position: 0,
-            visible: true,
-            protected: true,
-            item_type: 'dropdown',
-            url: '#',
-            privacy: 'public'
-          )
-
-          # Add children to Better Together Navigation Item
-          better_together_nav_item.create_children(better_together_pages, area)
-
-          area.reload.save!
         end
+        # rubocop:enable Metrics/BlockLength
       end
       # rubocop:enable Metrics/AbcSize
 
-      def build_footer # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
-        previous_skip_navigation_touches = BetterTogether.skip_navigation_touches
-        BetterTogether.skip_navigation_touches = true
-
-        I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
-          # Create Platform Footer Pages
-          footer_pages = ::BetterTogether::Page.create!(
-            [
-              {
-                title_en: 'FAQ',
-                slug_en: 'faq',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/faq',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+      def build_footer # rubocop:todo Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
+        # rubocop:todo Metrics/BlockLength
+        with_navigation_touch_suppressed do
+          I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
+            # Create Platform Footer Pages
+            footer_pages = ::BetterTogether::Page.create!(
+              [
+                {
+                  title_en: 'FAQ',
+                  slug_en: 'faq',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/faq',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                title_en: 'Privacy Policy',
-                slug_en: 'privacy-policy',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/privacy',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+                  ]
+                },
+                {
+                  title_en: 'Privacy Policy',
+                  slug_en: 'privacy-policy',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/privacy',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                title_en: 'Terms of Service',
-                slug_en: 'terms-of-service',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/terms_of_service',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+                  ]
+                },
+                {
+                  title_en: 'Terms of Service',
+                  slug_en: 'terms-of-service',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/terms_of_service',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                title_en: 'Code of Conduct',
-                slug_en: 'code-of-conduct',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/code_of_conduct',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+                  ]
+                },
+                {
+                  title_en: 'Code of Conduct',
+                  slug_en: 'code-of-conduct',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/code_of_conduct',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                title_en: 'Accessibility',
-                slug_en: 'accessibility',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/accessibility',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+                  ]
+                },
+                {
+                  title_en: 'Accessibility',
+                  slug_en: 'accessibility',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/accessibility',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                title_en: 'Cookie Policy',
-                slug_en: 'cookie-policy',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                show_title: false,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/static_pages/cookie_consent',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
+                  ]
+                },
+                {
+                  title_en: 'Cookie Policy',
+                  slug_en: 'cookie-policy',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  show_title: false,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/static_pages/cookie_consent',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  }
-                ]
-              },
-              {
-                title_en: 'Contact Us',
-                slug_en: 'contact',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::RichText',
-                      # rubocop:todo Lint/CopDirectiveSyntax
-                      content_en: <<-HTML
-                        <p>This is a default contact page for your platform. Be sure to write a real one!</p>
-                      HTML
-                      # rubocop:enable Lint/CopDirectiveSyntax
+                  ]
+                },
+                {
+                  title_en: 'Contact Us',
+                  slug_en: 'contact',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::RichText',
+                        # rubocop:todo Lint/CopDirectiveSyntax
+                        content_en: <<-HTML
+                          <p>This is a default contact page for your platform. Be sure to write a real one!</p>
+                        HTML
+                        # rubocop:enable Lint/CopDirectiveSyntax
+                      }
+                    },
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::Template',
+                        template_path: 'better_together/content/blocks/template/host_community_contact_details',
+                        css_settings: { container_class: '', css_classes: 'my-4' }
+                      }
                     }
-                  },
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::Template',
-                      template_path: 'better_together/content/blocks/template/host_community_contact_details',
-                      css_settings: { container_class: '', css_classes: 'my-4' }
-                    }
-                  }
-                ]
-              }
-            ]
-          )
-
-          # Create contributor agreement pages separately for nested navigation
-          contributor_agreement_pages = [
-            ensure_static_page!(
-              identifier: 'code_contributor_agreement',
-              title: 'Code Contributor Agreement',
-              slug: 'code-contributor-agreement',
-              template_path: 'better_together/static_pages/code_contributor_agreement'
-            ),
-            ensure_static_page!(
-              identifier: 'content_contributor_agreement',
-              title: 'Content Contributor Agreement',
-              slug: 'content-contributor-agreement',
-              template_path: 'better_together/static_pages/content_contributor_agreement'
+                  ]
+                }
+              ]
             )
-          ]
 
-          # Create Platform Footer Navigation Area and its Navigation Items
-          area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'platform-footer') do |area|
-            area.name = 'Platform Footer'
-            area.slug = 'platform-footer'
-            area.visible = true
-            area.protected = true
-          end
+            # Create contributor agreement pages separately for nested navigation
+            contributor_agreement_pages = [
+              ensure_static_page!(
+                identifier: 'code_contributor_agreement',
+                title: 'Code Contributor Agreement',
+                slug: 'code-contributor-agreement',
+                template_path: 'better_together/static_pages/code_contributor_agreement'
+              ),
+              ensure_static_page!(
+                identifier: 'content_contributor_agreement',
+                title: 'Content Contributor Agreement',
+                slug: 'content-contributor-agreement',
+                template_path: 'better_together/static_pages/content_contributor_agreement'
+              )
+            ]
 
-          # Clear existing navigation items if area already existed
-          area.reload.navigation_items.delete_all
+            # Create Platform Footer Navigation Area and its Navigation Items
+            area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'platform-footer') do |area|
+              area.name = 'Platform Footer'
+              area.slug = 'platform-footer'
+              area.visible = true
+              area.protected = true
+            end
 
-          # Build navigation items for main footer pages
-          area.reload.build_page_navigation_items(footer_pages)
+            # Clear existing navigation items if area already existed
+            area.reload.navigation_items.delete_all
 
-          # Create parent "Contributor Agreements" dropdown navigation item
-          # Position it after the existing footer items
-          next_position = area.navigation_items.maximum(:position).to_i + 1
-          contributor_agreements_parent = area.navigation_items.create!(
-            title_en: 'Contributor Agreements',
-            item_type: 'dropdown',
-            position: next_position,
-            visible: true,
-            protected: true
-          )
+            # Build navigation items for main footer pages
+            area.reload.build_page_navigation_items(footer_pages)
 
-          # Build child navigation items for contributor agreements
-          contributor_agreement_pages.each_with_index do |page, index|
-            area.navigation_items.create!(
-              title_en: page.title,
-              linkable: page,
-              parent: contributor_agreements_parent,
-              position: index,
-              item_type: 'link',
+            # Create parent "Contributor Agreements" dropdown navigation item
+            # Position it after the existing footer items
+            next_position = area.navigation_items.maximum(:position).to_i + 1
+            contributor_agreements_parent = area.navigation_items.create!(
+              title_en: 'Contributor Agreements',
+              item_type: 'dropdown',
+              position: next_position,
               visible: true,
               protected: true
             )
-          end
 
-          area.save!
+            # Build child navigation items for contributor agreements
+            contributor_agreement_pages.each_with_index do |page, index|
+              area.navigation_items.create!(
+                title_en: page.title,
+                linkable: page,
+                parent: contributor_agreements_parent,
+                position: index,
+                item_type: 'link',
+                visible: true,
+                protected: true
+              )
+            end
+
+            area.save!
+          end
         end
-      ensure
-        BetterTogether.skip_navigation_touches = previous_skip_navigation_touches
+        # rubocop:enable Metrics/BlockLength
       end
 
-      def build_header # rubocop:todo Metrics/MethodLength, Metrics/AbcSize
-        previous_skip_navigation_touches = BetterTogether.skip_navigation_touches
-        BetterTogether.skip_navigation_touches = true
-
-        I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
-          # Create platform header pages
-          header_pages = ::BetterTogether::Page.create(
-            [
-              {
-                title_en: 'About',
-                slug_en: 'about',
-                published_at: Time.zone.now,
-                privacy: 'public',
-                protected: true,
-                page_blocks_attributes: [
-                  {
-                    block_attributes: {
-                      type: 'BetterTogether::Content::RichText',
-                      content_en: <<-HTML
-                        <p>This is a default about page. Be sure to write a real one!</p>
-                      HTML
+      def build_header # rubocop:todo Metrics/MethodLength, Metrics/AbcSize, Metrics/BlockLength
+        # rubocop:todo Metrics/BlockLength
+        with_navigation_touch_suppressed do
+          I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
+            # Create platform header pages
+            header_pages = ::BetterTogether::Page.create(
+              [
+                {
+                  title_en: 'About',
+                  slug_en: 'about',
+                  published_at: Time.zone.now,
+                  privacy: 'public',
+                  protected: true,
+                  page_blocks_attributes: [
+                    {
+                      block_attributes: {
+                        type: 'BetterTogether::Content::RichText',
+                        content_en: <<-HTML
+                          <p>This is a default about page. Be sure to write a real one!</p>
+                        HTML
+                      }
                     }
-                  }
-                ]
+                  ]
+                }
+              ]
+            )
+
+            # Create Platform Header Navigation Area
+            area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'platform-header') do |area|
+              area.name = 'Platform Header'
+              area.slug = 'platform-header'
+              area.visible = true
+              area.protected = true
+            end
+
+            # Clear existing navigation items if area already existed
+            area.reload.navigation_items.delete_all
+
+            area.build_page_navigation_items(header_pages)
+
+            # Add non-page navigation items using route_name for URL
+            non_page_nav_items = [
+              {
+                identifier: 'posts',
+                title_en: I18n.t('navigation.header.posts', default: 'Posts'),
+                slug_en: 'posts',
+                position: 1,
+                item_type: 'link',
+                route_name: 'posts_url',
+                visible: true,
+                privacy: 'public',
+                navigation_area: area
+              },
+              {
+                identifier: 'events',
+                title_en: I18n.t('navigation.header.events', default: 'Events'),
+                slug_en: 'events',
+                position: 2,
+                item_type: 'link',
+                route_name: 'events_url',
+                visible: true,
+                navigation_area: area,
+                privacy: 'public'
+              },
+              {
+                identifier: 'community-hub',
+                title_en: I18n.t('navigation.header.community_hub', default: 'Community Hub'),
+                slug_en: 'community-hub',
+                position: 2,
+                item_type: 'link',
+                route_name: 'hub_url',
+                visible: true,
+                navigation_area: area,
+                privacy: 'private',
+                visibility_strategy: 'authenticated'
+              },
+              {
+                identifier: 'exchange-hub',
+                title_en: I18n.t('navigation.header.exchange_hub', default: 'Exchange Hub'),
+                slug_en: 'exchange-hub',
+                position: 3,
+                item_type: 'link',
+                route_name: 'joatu_hub_url',
+                visible: true,
+                navigation_area: area,
+                privacy: 'private',
+                visibility_strategy: 'authenticated'
               }
             ]
-          )
 
-          # Create Platform Header Navigation Area
-          area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'platform-header') do |area|
-            area.name = 'Platform Header'
-            area.slug = 'platform-header'
-            area.visible = true
-            area.protected = true
-          end
-
-          # Clear existing navigation items if area already existed
-          area.reload.navigation_items.delete_all
-
-          area.build_page_navigation_items(header_pages)
-
-          # Add non-page navigation items using route_name for URL
-          non_page_nav_items = [
-            {
-              identifier: 'posts',
-              title_en: I18n.t('navigation.header.posts', default: 'Posts'),
-              slug_en: 'posts',
-              position: 1,
-              item_type: 'link',
-              route_name: 'posts_url',
-              visible: true,
-              privacy: 'public',
-              navigation_area: area
-            },
-            {
-              identifier: 'events',
-              title_en: I18n.t('navigation.header.events', default: 'Events'),
-              slug_en: 'events',
-              position: 2,
-              item_type: 'link',
-              route_name: 'events_url',
-              visible: true,
-              navigation_area: area,
-              privacy: 'public'
-            },
-            {
-              identifier: 'community-hub',
-              title_en: I18n.t('navigation.header.community_hub', default: 'Community Hub'),
-              slug_en: 'community-hub',
-              position: 2,
-              item_type: 'link',
-              route_name: 'hub_url',
-              visible: true,
-              navigation_area: area,
-              privacy: 'private',
-              visibility_strategy: 'authenticated'
-            },
-            {
-              identifier: 'exchange-hub',
-              title_en: I18n.t('navigation.header.exchange_hub', default: 'Exchange Hub'),
-              slug_en: 'exchange-hub',
-              position: 3,
-              item_type: 'link',
-              route_name: 'joatu_hub_url',
-              visible: true,
-              navigation_area: area,
-              privacy: 'private',
-              visibility_strategy: 'authenticated'
-            }
-          ]
-
-          non_page_nav_items.each do |attrs|
-            area.navigation_items.create!(attrs)
-          end
-
-          unless area.valid?
-            puts "\n=== Navigation Area Validation Errors ==="
-            area.errors.full_messages.each { |msg| puts "  Area error: #{msg}" }
-            area.navigation_items.each_with_index do |item, idx|
-              next if item.valid?
-
-              puts "  Item #{idx} (#{item.identifier}) errors: #{item.errors.full_messages.join(', ')}"
+            non_page_nav_items.each do |attrs|
+              area.navigation_items.create!(attrs)
             end
-            puts "===\n"
-          end
 
-          area.save!
+            unless area.valid?
+              puts "\n=== Navigation Area Validation Errors ==="
+              area.errors.full_messages.each { |msg| puts "  Area error: #{msg}" }
+              area.navigation_items.each_with_index do |item, idx|
+                next if item.valid?
+
+                puts "  Item #{idx} (#{item.identifier}) errors: #{item.errors.full_messages.join(', ')}"
+              end
+              puts "===\n"
+            end
+
+            area.save!
+          end
         end
-      ensure
-        BetterTogether.skip_navigation_touches = previous_skip_navigation_touches
+        # rubocop:enable Metrics/BlockLength
       end
 
       # rubocop:todo Metrics/MethodLength
-      def build_host # rubocop:todo Metrics/MethodLength, Metrics/AbcSize, Lint/CopDirectiveSyntax, Metrics/AbcSize
-        I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
-          # Create Platform Header Host Navigation Area and its Navigation Items
-          area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'platform-host') do |area|
-            area.name = 'Platform Host'
-            area.slug = 'platform-host'
-            area.visible = true
-            area.protected = true
-          end
+      def build_host # rubocop:todo Metrics/MethodLength, Metrics/AbcSize, Lint/CopDirectiveSyntax, Metrics/BlockLength
+        # rubocop:todo Metrics/BlockLength
+        with_navigation_touch_suppressed do
+          I18n.with_locale(:en) do # rubocop:todo Metrics/BlockLength
+            # Create Platform Header Host Navigation Area and its Navigation Items
+            area = ::BetterTogether::NavigationArea.find_or_create_by!(identifier: 'platform-host') do |area|
+              area.name = 'Platform Host'
+              area.slug = 'platform-host'
+              area.visible = true
+              area.protected = true
+            end
 
-          # Clear existing navigation items if area already existed
-          area.reload.navigation_items.delete_all
+            # Clear existing navigation items if area already existed
+            area.reload.navigation_items.delete_all
 
-          # Create Host Navigation Item
-          host_nav = area.navigation_items.create!(
-            identifier: 'host-nav',
-            title_en: 'Host',
-            slug_en: 'host-nav',
-            position: 0,
-            visible: true,
-            protected: true,
-            item_type: 'dropdown',
-            url: '#',
-            privacy: 'private',
-            visibility_strategy: 'permission',
-            permission_identifier: 'view_metrics_dashboard'
-          )
-
-          # Add children to Host Navigation Item
-          host_nav_children = [
-            {
-              identifier: 'host-dashboard',
-              title_en: 'Dashboard',
-              slug_en: 'host-dashboard',
+            # Create Host Navigation Item
+            host_nav = area.navigation_items.create!(
+              identifier: 'host-nav',
+              title_en: 'Host',
+              slug_en: 'host-nav',
               position: 0,
-              item_type: 'link',
-              route_name: 'host_dashboard_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'analytics',
-              title_en: 'Analytics',
-              slug_en: 'analytics',
-              position: 1,
-              item_type: 'link',
-              route_name: 'metrics_reports_url',
-              icon: 'chart-line',
+              visible: true,
+              protected: true,
+              item_type: 'dropdown',
+              url: '#',
               privacy: 'private',
               visibility_strategy: 'permission',
               permission_identifier: 'view_metrics_dashboard'
-            },
-            {
-              identifier: 'communities',
-              title_en: 'Communities',
-              slug_en: 'communities',
-              position: 2,
-              item_type: 'link',
-              route_name: 'communities_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'navigation-areas',
-              title_en: 'Navigation Areas',
-              slug_en: 'navigation-areas',
-              position: 3,
-              item_type: 'link',
-              route_name: 'navigation_areas_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'pages',
-              title_en: 'Pages',
-              slug_en: 'pages',
-              position: 4,
-              item_type: 'link',
-              route_name: 'pages_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'host-posts',
-              title_en: 'Posts',
-              slug_en: 'host-posts',
-              position: 5,
-              item_type: 'link',
-              route_name: 'posts_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'people',
-              title_en: 'People',
-              slug_en: 'people',
-              position: 6,
-              item_type: 'link',
-              route_name: 'people_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'platforms',
-              title_en: 'Platforms',
-              slug_en: 'platforms',
-              position: 7,
-              item_type: 'link',
-              route_name: 'platforms_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'roles',
-              title_en: 'Roles',
-              slug_en: 'roles',
-              position: 8,
-              item_type: 'link',
-              route_name: 'roles_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'resource_permissions',
-              title_en: 'Resource Permissions',
-              slug_en: 'resource_permissions',
-              position: 9,
-              item_type: 'link',
-              route_name: 'resource_permissions_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'webhook_endpoints',
-              title_en: 'Webhooks',
-              slug_en: 'webhook_endpoints',
-              position: 10,
-              item_type: 'link',
-              route_name: 'webhook_endpoints_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            },
-            {
-              identifier: 'oauth_applications',
-              title_en: 'OAuth Apps',
-              slug_en: 'oauth_applications',
-              position: 11,
-              item_type: 'link',
-              route_name: 'oauth_applications_url',
-              privacy: 'private',
-              visibility_strategy: 'permission',
-              permission_identifier: 'manage_platform'
-            }
-          ]
+            )
 
-          host_nav_children.each do |child_attrs|
-            host_nav.children.create!(child_attrs.merge(visible: true, protected: true, navigation_area: area))
+            # Add children to Host Navigation Item
+            host_nav_children = [
+              {
+                identifier: 'host-dashboard',
+                title_en: 'Dashboard',
+                slug_en: 'host-dashboard',
+                position: 0,
+                item_type: 'link',
+                route_name: 'host_dashboard_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'analytics',
+                title_en: 'Analytics',
+                slug_en: 'analytics',
+                position: 1,
+                item_type: 'link',
+                route_name: 'metrics_reports_url',
+                icon: 'chart-line',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'view_metrics_dashboard'
+              },
+              {
+                identifier: 'communities',
+                title_en: 'Communities',
+                slug_en: 'communities',
+                position: 2,
+                item_type: 'link',
+                route_name: 'communities_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'navigation-areas',
+                title_en: 'Navigation Areas',
+                slug_en: 'navigation-areas',
+                position: 3,
+                item_type: 'link',
+                route_name: 'navigation_areas_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'pages',
+                title_en: 'Pages',
+                slug_en: 'pages',
+                position: 4,
+                item_type: 'link',
+                route_name: 'pages_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'host-posts',
+                title_en: 'Posts',
+                slug_en: 'host-posts',
+                position: 5,
+                item_type: 'link',
+                route_name: 'posts_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'people',
+                title_en: 'People',
+                slug_en: 'people',
+                position: 6,
+                item_type: 'link',
+                route_name: 'people_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'platforms',
+                title_en: 'Platforms',
+                slug_en: 'platforms',
+                position: 7,
+                item_type: 'link',
+                route_name: 'platforms_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'roles',
+                title_en: 'Roles',
+                slug_en: 'roles',
+                position: 8,
+                item_type: 'link',
+                route_name: 'roles_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'resource_permissions',
+                title_en: 'Resource Permissions',
+                slug_en: 'resource_permissions',
+                position: 9,
+                item_type: 'link',
+                route_name: 'resource_permissions_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'webhook_endpoints',
+                title_en: 'Webhooks',
+                slug_en: 'webhook_endpoints',
+                position: 10,
+                item_type: 'link',
+                route_name: 'webhook_endpoints_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              },
+              {
+                identifier: 'oauth_applications',
+                title_en: 'OAuth Apps',
+                slug_en: 'oauth_applications',
+                position: 11,
+                item_type: 'link',
+                route_name: 'oauth_applications_url',
+                privacy: 'private',
+                visibility_strategy: 'permission',
+                permission_identifier: 'manage_platform'
+              }
+            ]
+
+            host_nav_children.each do |child_attrs|
+              host_nav.children.create!(child_attrs.merge(visible: true, protected: true, navigation_area: area))
+            end
+
+            area.reload.save!
           end
-
-          area.reload.save!
         end
+        # rubocop:enable Metrics/BlockLength
       end
       # rubocop:enable Metrics/MethodLength
 
@@ -776,6 +782,19 @@ module BetterTogether
         # Delete children first to satisfy FK constraints, then parents
         ::BetterTogether::NavigationItem.where.not(parent_id: nil).delete_all
         ::BetterTogether::NavigationItem.where(parent_id: nil).delete_all
+      end
+
+      def with_navigation_touch_suppressed(&block)
+        previous_skip_navigation_touches = BetterTogether.skip_navigation_touches
+        BetterTogether.skip_navigation_touches = true
+
+        ::BetterTogether::NavigationItem.no_touching do
+          ::BetterTogether::Page.no_touching do
+            block.call
+          end
+        end
+      ensure
+        BetterTogether.skip_navigation_touches = previous_skip_navigation_touches
       end
     end
   end

--- a/spec/dummy/config/environments/development.rb
+++ b/spec/dummy/config/environments/development.rb
@@ -91,6 +91,21 @@ Rails.application.configure do
 
   BetterErrors::Middleware.allow_ip! '0.0.0.0/0' if defined?(BetterErrors)
 
+  # Local and worktree dev runs need stable encryption keys even when
+  # credentials are not available inside ephemeral containers.
+  config.active_record.encryption.primary_key = ENV.fetch(
+    'ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY',
+    '4f7f0d8d0e2b7c8f9a1b2c3d4e5f60714f7f0d8d0e2b7c8f9a1b2c3d4e5f6071'
+  )
+  config.active_record.encryption.deterministic_key = ENV.fetch(
+    'ACTIVE_RECORD_ENCRYPTION_DETERMINISTIC_KEY',
+    '6a8b0c1d2e3f40516a8b0c1d2e3f40516a8b0c1d2e3f40516a8b0c1d2e3f4051'
+  )
+  config.active_record.encryption.key_derivation_salt = ENV.fetch(
+    'ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT',
+    '8c9d0e1f2a3b4c5d8c9d0e1f2a3b4c5d8c9d0e1f2a3b4c5d8c9d0e1f2a3b4c5d'
+  )
+
   if defined?(FactoryBot)
     config.to_prepare do
       FactoryBot.definition_file_paths << File.join(BetterTogether::Engine.root, 'spec', 'factories')


### PR DESCRIPTION
## Summary
- harden development encryption bootstrap so fresh worktrees do not depend on ignored credential files
- suppress navigation touch cascades during bulk navigation seed rebuilds so `db:setup` no longer fails with `ActiveRecord::StaleObjectError`
- update local setup docs and `.env.dev` comments to reflect the supported wrapper commands and encryption overrides

## Verification
- `./bin/dc-run rails db:drop db:setup`
- `./bin/dc-run bundle exec prspec spec/models/better_together/calendar_spec.rb`
- `./bin/dc-run bundle exec rubocop --parallel`
- `./bin/dc-run bin/i18n check`