### PR TITLE
fix: ensure that event hosts have a host association

### DIFF
--- a/app/models/better_together/event_host.rb
+++ b/app/models/better_together/event_host.rb
@@ -4,7 +4,7 @@ module BetterTogether
   # Join an event to its host
   class EventHost < ApplicationRecord
     belongs_to :event, class_name: 'BetterTogether::Event'
-    belongs_to :host, polymorphic: true
+    belongs_to :host, polymorphic: true, required: true
 
     def self.permitted_attributes(id: false, destroy: false)
       super + %i[

--- a/app/views/better_together/events/_event_host_fields.html.erb
+++ b/app/views/better_together/events/_event_host_fields.html.erb
@@ -44,6 +44,7 @@
                         [], 
                         { include_blank: t('better_together.events.hosts.loading') }, 
                         class: 'form-select',
+                        required: true,
                         data: { 
                           'better-together--event-hosts-target': 'hostSelect',
                           action: 'change->better-together--event-hosts#hostSelectChanged'


### PR DESCRIPTION
## Summary

error in the edit form listing page after saving an event host with an empty host association

## Evidence Tier

Select one:

- [ ] Docs-only
- [x] Backend / behavioral
- [x] UI / workflow

## Evidence Checklist

- [ ] Tests added/updated and passing (`bin/ci`).
- [ ] Lint and security checks (`rubocop`, `brakeman`, `bundler-audit`).
- [ ] Documentation updated under `docs/` describing new/changed functionality.
- [ ] Mermaid diagram source updated under `docs/diagrams/source/` when architecture or workflow changed.
- [ ] Rendered PNGs regenerated with `bin/render_diagrams` and committed.
- [ ] Screenshot spec added or updated under `spec/docs_screenshots/` for UI/workflow changes.
- [ ] Desktop screenshots committed under `docs/screenshots/desktop/` for UI/workflow changes.
- [ ] Mobile screenshots committed under `docs/screenshots/mobile/` for UI/workflow changes.
- [ ] For DB changes, included any needed backfills/dedupes and noted risks.
- [ ] If a normally required evidence type is intentionally omitted, the PR body or a PR comment explains the exemption.

## Screenshots / Diagrams

Link the canonical evidence for this PR:

- Docs:
- Changed files:
- Spec / test coverage:
- Diagram source/export:
- Screenshot spec:
- Desktop/mobile screenshots:

## Stakeholder Packet

For significant PRs, add the private Community Engine stakeholder packet links:

- Private page:
- Private post:
- If intentionally deferred, explain why:

## Notes

Anything reviewers should be aware of (migration order, flags, feature toggles).
