### PR TITLE
docs: interim human-actor exception for PR opening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Project instructions for Claude Code sessions in this repository.
   - Targeted spec: `bin/dc-run bundle exec prspec spec/path/to/file_spec.rb`
   - Full suite (use sparingly, 13–18 min): `bin/dc-ci`
   - After any DB schema change: run `bin/parallel-setup` before running any tests
-- **GitHub comments/PRs**: Use `gh_with_bts_robot.sh` — never bare `gh api graphql`. Posts as `bettertogether-bts-robot`, not `rsmithlal`.
+- **GitHub comments/PRs**: Use `gh_with_bts_robot.sh` — never bare `gh api graphql`. Posts as `bettertogether-bts-robot`, not `rsmithlal`. **Exception — opening a new PR:** `gh pr create` uses `rsmithlal` (human), not `bettertogether-bts-robot`, interim until a second BTS Robot GitHub account exists for authoring — GitHub blocks requesting a review from a PR's own author, so a bts-robot-opened PR could never have bts-robot assigned as an independent reviewer. Comments, reviews, and thread replies on that PR still post as `bettertogether-bts-robot` as normal.
 - **Migrations**: Use `create_bt_table :name`, not `create_table :better_together_name`. Guard all additive migrations with `table_exists?`, `column_exists?`, `index_name_exists?`.
 - **Run `bin/dc-ci` locally before pushing**. Full `bin/dc-ci` before any push that touches CI.
 - **Never reference or ingest Colibri Software code** — proprietary third-party, no BTS relationship.


### PR DESCRIPTION
## Summary
- Carves out an interim exception in `CLAUDE.md`'s GitHub comments/PRs rule: opening a new PR (`gh pr create`) uses the human actor (rsmithlal), not bts-robot, until a second BTS Robot GitHub account exists for authoring.
- Reason: GitHub blocks requesting a review from a PR's own author, so a bts-robot-authored PR can never have bts-robot assigned as an independent reviewer — which defeats the new reviewer-assignment auto-trigger (n8n `github` workflow, added 2026-07-05).
- Scope: only the PR-open action changes. Commits, PR comments, reviews, and thread replies/resolves on the resulting PR are unaffected and continue to use bts-robot identity.
- This PR itself demonstrates the new policy: opened as rsmithlal (this `gh pr create` call), with the underlying commit still signed as BTS Robot.

## Test plan
- N/A — single-line `CLAUDE.md` prose change, no runtime behavior.