### PR TITLE
fix(deps): update websocket-driver to 0.8.2 to resolve bundler-audit vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -940,7 +940,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
## Summary
- `bundler-audit check` flagged `websocket-driver 0.8.0` (transitive dep of `actioncable`) for 4 advisories: GHSA-ghhp-3qvg-889p, GHSA-33ph-fccm-39pj, GHSA-8j3g-f24p-4mpw, GHSA-2x63-gw47-w4mm
- `bundle update websocket-driver --conservative` bumps it to `0.8.2`, the only line in `Gemfile.lock` touched
- `crass` was already patched at `1.0.7` on this branch (no change needed here)

## Test plan
- [x] `bundle exec bundler-audit check --update` → No vulnerabilities found
- [x] `bundle exec rubocop --parallel` → 2521 files inspected, no offenses detected
- [x] `bundle exec brakeman -q -w2` → No warnings found
- [x] `bundle exec rails zeitwerk:check` → all is good
- [ ] Full local CI (`bin/dc-ci`) — running, will confirm here
- [ ] GitHub Actions CI on this PR