### PR TITLE
fix(rubocop): resolve RSpec/MatchWithSimpleRegex offenses from rubocop-rspec 3.10.2

### DIFF
--- a/app/models/better_together/recurrence.rb
+++ b/app/models/better_together/recurrence.rb
@@ -72,7 +72,7 @@ module BetterTogether
     # @param date [Date] Date to exclude
     def add_exception_date(date)
       self.exception_dates ||= []
-      self.exception_dates << date unless exception_dates.include?(date)
+      exception_dates << date unless exception_dates.include?(date)
     end
 
     # Remove an exception date

--- a/spec/lib/better_together/generators/invitation_generator_spec.rb
+++ b/spec/lib/better_together/generators/invitation_generator_spec.rb
@@ -130,8 +130,8 @@ RSpec.describe BetterTogether::Generators::InvitationGenerator, type: :generator
         expect(migration_files.length).to eq(1)
 
         migration_content = File.read(migration_files.first)
-        expect(migration_content).to match(/class CreateBetterTogetherProjectInvitations/)
-        expect(migration_content).to match(/create_bt_table :project_invitations/)
+        expect(migration_content).to include('class CreateBetterTogetherProjectInvitations')
+        expect(migration_content).to include('create_bt_table :project_invitations')
       end
     end
   end

--- a/spec/mailers/better_together/platform_invitation_mailer_spec.rb
+++ b/spec/mailers/better_together/platform_invitation_mailer_spec.rb
@@ -52,7 +52,7 @@ module BetterTogether # :nodoc:
         end
 
         it 'includes greeting text' do
-          expect(mail.body.encoded).to match(/Welcome to our platform/)
+          expect(mail.body.encoded).to include('Welcome to our platform')
         end
       end
 
@@ -145,7 +145,7 @@ module BetterTogether # :nodoc:
         end
 
         it 'includes HTML content' do
-          expect(mail.content_type).to match(/html/)
+          expect(mail.content_type).to include('html')
         end
       end
 
@@ -178,7 +178,7 @@ module BetterTogether # :nodoc:
         end
 
         it 'assigns @invitation_url' do
-          expect(mail.body.encoded).to match(/invitation/)
+          expect(mail.body.encoded).to include('invitation')
         end
       end
     end

--- a/spec/models/better_together/concerns/privacy_spec.rb
+++ b/spec/models/better_together/concerns/privacy_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe BetterTogether::Privacy do # rubocop:todo RSpec/SpecFilePathForma
     it 'has translations for all supported locales' do
       I18n.available_locales.each do |locale|
         I18n.with_locale(locale) do
-          expect(I18n.t('attributes.privacy_list.public')).not_to match(/translation missing/)
-          expect(I18n.t('attributes.privacy_list.community')).not_to match(/translation missing/)
+          expect(I18n.t('attributes.privacy_list.public')).not_to include('translation missing')
+          expect(I18n.t('attributes.privacy_list.community')).not_to include('translation missing')
         end
       end
     end

--- a/spec/notifiers/better_together/person_platform_integration_created_notifier_spec.rb
+++ b/spec/notifiers/better_together/person_platform_integration_created_notifier_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe BetterTogether::PersonPlatformIntegrationCreatedNotifier do
 
     it 'uses locale-aware translation' do
       I18n.with_locale(:en) do
-        expect(notifier.body).to match(/A new Github account integration was connected on/)
+        expect(notifier.body).to include('A new Github account integration was connected on')
       end
     end
   end

--- a/spec/requests/better_together/agreements_status_controller_spec.rb
+++ b/spec/requests/better_together/agreements_status_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe BetterTogether::AgreementsStatusController do
           expect_element_with_text('.card-title', code_of_conduct.title)
           # Privacy Policy should not appear in any card title (already accepted)
           card_titles = parsed_response.css('.card-title').map(&:text)
-          expect(card_titles).not_to include(match(/Privacy Policy/))
+          expect(card_titles).not_to include(include('Privacy Policy'))
           # Verify we have only 2 agreement cards
           expect_element_count('.card.mb-3', 2)
         end

--- a/spec/requests/better_together/content_blocks_preview_markdown_spec.rb
+++ b/spec/requests/better_together/content_blocks_preview_markdown_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Content Blocks Markdown Preview', :as_user do
              as: :json
 
         expect(response).to have_http_status(:ok)
-        expect(response.content_type).to match(%r{application/json})
+        expect(response.content_type).to include('application/json')
 
         json_response = JSON.parse(response.body)
         expect(json_response['html']).to include('<h1 id="hello-world">Hello World</h1>')

--- a/spec/requests/better_together/debug_mode_spec.rb
+++ b/spec/requests/better_together/debug_mode_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe 'Debug Mode Functionality' do
       get test_path, params: { debug: 'true' }
 
       # Verify robots meta tag prevents indexing
-      expect(response.body).to match(/<meta name="robots" content="noindex,nofollow"/)
+      expect(response.body).to include('<meta name="robots" content="noindex,nofollow"')
     end
 
     it 'allows normal caching when debug is disabled' do
@@ -234,7 +234,7 @@ RSpec.describe 'Debug Mode Functionality' do
       get test_path
 
       # Should have normal indexing permission
-      expect(response.body).to match(/<meta name="robots" content="index,follow"/)
+      expect(response.body).to include('<meta name="robots" content="index,follow"')
     end
   end
 end

--- a/spec/requests/better_together/duplicate_invitation_prevention_spec.rb
+++ b/spec/requests/better_together/duplicate_invitation_prevention_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Duplicate Invitation Prevention', :as_platform_manager do # rubo
              params: { invitation: { invitee_email: email } }
 
         expect(response).to redirect_to(community)
-        expect(flash[:alert]).to match(/has already been invited and the invitation is still pending/)
+        expect(flash[:alert]).to include('has already been invited and the invitation is still pending')
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe 'Duplicate Invitation Prevention', :as_platform_manager do # rubo
              params: { invitation: { invitee_email: email } }
 
         expect(response).to redirect_to(community)
-        expect(flash[:alert]).to match(/has already accepted an invitation/)
+        expect(flash[:alert]).to include('has already accepted an invitation')
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe 'Duplicate Invitation Prevention', :as_platform_manager do # rubo
              params: { invitation: { invitee_email: email } }
 
         expect(response).to redirect_to(community)
-        expect(flash[:alert]).to match(/has previously declined an invitation/)
+        expect(flash[:alert]).to include('has previously declined an invitation')
       end
     end
 
@@ -95,7 +95,7 @@ describe 'with existing user', :as_platform_manager do
            params: { invitation: { invitee_id: person.id } }
 
       expect(response).to redirect_to(community)
-      expect(flash[:alert]).to match(/has already been invited and the invitation is still pending/)
+      expect(flash[:alert]).to include('has already been invited and the invitation is still pending')
     end
   end
 

--- a/spec/requests/better_together/notifications_controller_spec.rb
+++ b/spec/requests/better_together/notifications_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe BetterTogether::NotificationsController, :as_user do
 
     it 'returns HTML content' do
       get "/#{I18n.default_locale}/notifications/dropdown"
-      expect(response.content_type).to match(%r{text/html})
+      expect(response.content_type).to include('text/html')
     end
 
     it 'caches the response based on max updated_at' do

--- a/spec/requests/better_together/person_platform_integrations_spec.rb
+++ b/spec/requests/better_together/person_platform_integrations_spec.rb
@@ -276,7 +276,7 @@ RSpec.describe '/better_together/person_platform_integrations', :as_user do
           delete better_together.person_platform_integration_path(last_integration, locale: I18n.default_locale),
                  headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
 
-          expect(response.content_type).to match(/turbo-stream/)
+          expect(response.content_type).to include('turbo-stream')
           expect(response.body).to include('turbo-stream')
           expect(response.body).to include('flash_messages')
         end

--- a/spec/requests/better_together/translations_controller_spec.rb
+++ b/spec/requests/better_together/translations_controller_spec.rb
@@ -44,7 +44,7 @@ module BetterTogether # :nodoc:
         end
 
         it 'returns translated content as JSON' do
-          expect(response.content_type).to match(%r{application/json})
+          expect(response.content_type).to include('application/json')
           json_response = JSON.parse(response.body)
           expect(json_response['translation']).to eq(translated_content)
         end

--- a/spec/services/better_together/ics/generator_spec.rb
+++ b/spec/services/better_together/ics/generator_spec.rb
@@ -101,12 +101,12 @@ module BetterTogether # :nodoc:
 
           it 'includes DTSTART' do
             result = generator.generate
-            expect(result).to match(/DTSTART/)
+            expect(result).to include('DTSTART')
           end
 
           it 'includes DTEND' do
             result = generator.generate
-            expect(result).to match(/DTEND/)
+            expect(result).to include('DTEND')
           end
 
           it 'includes UID' do

--- a/spec/services/better_together/markdown_renderer_service_spec.rb
+++ b/spec/services/better_together/markdown_renderer_service_spec.rb
@@ -288,13 +288,13 @@ RSpec.describe BetterTogether::MarkdownRendererService do
 
       it 'removes HTML tags completely' do
         plain = service.render_plain_text
-        expect(plain).not_to match(/<h1>/)
-        expect(plain).not_to match(/<strong>/)
-        expect(plain).not_to match(/<em>/)
-        expect(plain).not_to match(/<ul>/)
-        expect(plain).not_to match(/<li>/)
+        expect(plain).not_to include('<h1>')
+        expect(plain).not_to include('<strong>')
+        expect(plain).not_to include('<em>')
+        expect(plain).not_to include('<ul>')
+        expect(plain).not_to include('<li>')
         expect(plain).not_to match(/<a[^>]*>/)
-        expect(plain).not_to match(/<code>/)
+        expect(plain).not_to include('<code>')
       end
 
       it 'includes code content as plain text' do
@@ -323,12 +323,12 @@ RSpec.describe BetterTogether::MarkdownRendererService do
 
       it 'removes table HTML tags' do
         plain = service.render_plain_text
-        expect(plain).not_to match(/<table>/)
-        expect(plain).not_to match(/<thead>/)
-        expect(plain).not_to match(/<tbody>/)
-        expect(plain).not_to match(/<tr>/)
-        expect(plain).not_to match(/<th>/)
-        expect(plain).not_to match(/<td>/)
+        expect(plain).not_to include('<table>')
+        expect(plain).not_to include('<thead>')
+        expect(plain).not_to include('<tbody>')
+        expect(plain).not_to include('<tr>')
+        expect(plain).not_to include('<th>')
+        expect(plain).not_to include('<td>')
       end
     end
 

--- a/spec/services/better_together/template_renderer_service_spec.rb
+++ b/spec/services/better_together/template_renderer_service_spec.rb
@@ -115,9 +115,9 @@ RSpec.describe BetterTogether::TemplateRendererService do
     it 'removes HTML tags' do
       result = service.render_for_current_locale
 
-      expect(result).not_to match(/<p>/)
-      expect(result).not_to match(/<div>/)
-      expect(result).not_to match(/<h1>/)
+      expect(result).not_to include('<p>')
+      expect(result).not_to include('<div>')
+      expect(result).not_to include('<h1>')
       expect(result).not_to match(/<a[^>]*>/)
     end
 

--- a/spec/tasks/swagger_spec.rb
+++ b/spec/tasks/swagger_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'swagger rake tasks', type: :task do
             SystemExit
           end
           expect(output).to match(/Expected URL: #{Regexp.escape(current_base_url)}/)
-          expect(output).to match(%r{Found URLs: http://old-server\.example\.com})
+          expect(output).to include('Found URLs: http://old-server.example.com')
         end
 
         it 'suggests running generation task' do


### PR DESCRIPTION
## Summary
- The already-merged `rubocop-rspec` 3.9.0 → 3.10.2 bump (#1628) enabled `RSpec/MatchWithSimpleRegex`, which has been failing `main`'s CI `rubocop` job for everyone since — every open PR (including #1663, #1664) inherits this red check regardless of what it actually touches.
- Ran `bundle exec rubocop -A` to auto-correct all 38 offenses: `match(/literal/)` → `include('literal')` across 15 spec files. Semantically identical assertions, mechanical fix.
- One incidental `Style/RedundantSelf` autocorrect included in `app/models/better_together/recurrence.rb` (`self.exception_dates << date` → `exception_dates << date`) — it was part of the same 38-offense count. Safe: no setter call, no local-variable name shadowing `exception_dates`, purely stylistic.

## Test plan
- [x] `bundle exec bundler-audit check` → No vulnerabilities found (unaffected by this change, checked anyway)
- [x] `bundle exec rubocop --cache false` → 2061 files, no offenses (was 38)
- [x] `bundle exec brakeman -q -w2` → same 8 pre-existing unrelated `ValidationRegex` warnings, nothing new
- [x] `bundle exec rails zeitwerk:check` → all is good
- [ ] Local `rspec` — blocked repo-wide on `main` by a separate pre-existing gap (`spec/support/screenshot_callout_processor.rb` requires `vips`, not declared in Gemfile/Gemfile.lock); not fixed here, flagging separately
- [ ] GitHub Actions CI on this PR