### PR TITLE
fix(migrations): correct platform_id/community_id ownership bugs from the federation campaign

### DIFF
--- a/app/models/better_together/page.rb
+++ b/app/models/better_together/page.rb
@@ -12,6 +12,7 @@ module BetterTogether
     # to stamp newly-created authorships with the acting person.
     include Categorizable
     include Citable
+    include CommunityAssignable
     include Creatable
     include Identifier
     include Metrics::Shareable
@@ -29,7 +30,6 @@ module BetterTogether
     belongs_to :community, class_name: 'BetterTogether::Community', optional: true
 
     before_validation :sync_name_and_title
-    before_validation :assign_host_community
 
     categorizable
 
@@ -197,21 +197,6 @@ module BetterTogether
     def sync_name_and_title
       self.name = title if respond_to?(:name) && name.blank? && title.present?
       self.title = name if title.blank? && name.present?
-    end
-
-    def assign_host_community
-      return unless has_attribute?(:community_id)
-      return if community.present?
-
-      self.community ||= BetterTogether::Community.find_by(host: true)
-      self.community ||= host_platform_community
-    end
-
-    def host_platform_community
-      host_platform_community_id = BetterTogether::Platform.where(host: true).limit(1).pluck(:community_id).first
-      return unless host_platform_community_id
-
-      BetterTogether::Community.find_by(id: host_platform_community_id)
     end
 
     # Touch navigation areas for all navigation items that link to this page

--- a/db/migrate/20260321000003_backfill_content_platform_id.rb
+++ b/db/migrate/20260321000003_backfill_content_platform_id.rb
@@ -13,6 +13,12 @@
 # record (platform_id IS NULL) to the host platform so the federation
 # provenance queries resolve correctly.
 class BackfillContentPlatformId < ActiveRecord::Migration[7.2]
+  TABLES = %w[
+    better_together_posts
+    better_together_pages
+    better_together_events
+  ].freeze
+
   def up
     host_platform_id = execute(
       "SELECT id FROM better_together_platforms WHERE host = TRUE LIMIT 1"
@@ -20,11 +26,21 @@ class BackfillContentPlatformId < ActiveRecord::Migration[7.2]
 
     return unless host_platform_id
 
-    %w[
-      better_together_posts
-      better_together_pages
-      better_together_events
-    ].each do |table|
+    TABLES.each do |table|
+      # Derive platform_id from the record's own creator's platform membership first,
+      # so any cross-tenant content already present at migration time (e.g. an
+      # in-progress federation setup) isn't silently reassigned to the host.
+      execute <<~SQL
+        UPDATE #{table} rec
+        SET    platform_id = ppm.joinable_id
+        FROM   better_together_people p
+        JOIN   better_together_person_platform_memberships ppm
+          ON   p.id = ppm.member_id
+        WHERE  rec.creator_id = p.id
+          AND  rec.platform_id IS NULL
+          AND  ppm.joinable_id IS NOT NULL
+      SQL
+
       execute <<~SQL
         UPDATE #{table}
         SET    platform_id = '#{host_platform_id}'

--- a/db/migrate/20260605002004_backfill_platform_id_for_conversations_messages_agreements.rb
+++ b/db/migrate/20260605002004_backfill_platform_id_for_conversations_messages_agreements.rb
@@ -2,11 +2,11 @@
 
 # Phase 2 — Backfill platform_id for conversations, messages, and agreements.
 #
-# Conversations and agreements are assigned to the host platform (the only
-# platform that existed before this migration series). Messages inherit from
-# their parent conversation. This is a conservative safe default — all existing
-# data is single-platform. New records will pick up Current.platform via the
-# PlatformScoped concern's before_validation callback.
+# Conversations and agreements are derived from their creator's platform
+# membership first, falling back to the host platform only when no membership
+# can be found. Messages inherit from their parent conversation. New records
+# will pick up Current.platform via the PlatformScoped concern's
+# before_validation callback.
 class BackfillPlatformIdForConversationsMessagesAgreements < ActiveRecord::Migration[7.2]
   def up
     host_platform_id = execute(
@@ -15,11 +15,7 @@ class BackfillPlatformIdForConversationsMessagesAgreements < ActiveRecord::Migra
 
     return unless host_platform_id
 
-    execute <<~SQL
-      UPDATE better_together_conversations
-      SET    platform_id = #{quote(host_platform_id)}
-      WHERE  platform_id IS NULL
-    SQL
+    backfill_from_creator('better_together_conversations', host_platform_id)
 
     execute <<~SQL
       UPDATE better_together_messages m
@@ -29,16 +25,33 @@ class BackfillPlatformIdForConversationsMessagesAgreements < ActiveRecord::Migra
         AND  m.platform_id IS NULL
     SQL
 
-    execute <<~SQL
-      UPDATE better_together_agreements
-      SET    platform_id = #{quote(host_platform_id)}
-      WHERE  platform_id IS NULL
-    SQL
+    backfill_from_creator('better_together_agreements', host_platform_id)
   end
 
   def down
     execute "UPDATE better_together_conversations SET platform_id = NULL"
     execute "UPDATE better_together_messages       SET platform_id = NULL"
     execute "UPDATE better_together_agreements     SET platform_id = NULL"
+  end
+
+  private
+
+  def backfill_from_creator(table, host_platform_id)
+    execute <<~SQL
+      UPDATE #{table} rec
+      SET    platform_id = ppm.joinable_id
+      FROM   better_together_people p
+      JOIN   better_together_person_platform_memberships ppm
+        ON   p.id = ppm.member_id
+      WHERE  rec.creator_id = p.id
+        AND  rec.platform_id IS NULL
+        AND  ppm.joinable_id IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE #{table}
+      SET    platform_id = #{quote(host_platform_id)}
+      WHERE  platform_id IS NULL
+    SQL
   end
 end

--- a/db/migrate/20260605003003_backfill_platform_id_for_categories_and_joatu.rb
+++ b/db/migrate/20260605003003_backfill_platform_id_for_categories_and_joatu.rb
@@ -1,15 +1,21 @@
 # frozen_string_literal: true
 
 # Phase 3 — Backfill platform_id for categories, categorizations, and joatu exchanges.
-# All existing records assigned to the host platform (single-platform baseline).
+#
+# Categories have no owning record (shared taxonomy) and are assigned to the
+# host platform directly. Categorizations, joatu offers/requests, and joatu
+# agreements are derived from their real owner first, falling back to the
+# host platform only when no owner can be determined.
 class BackfillPlatformIdForCategoriesAndJoatu < ActiveRecord::Migration[7.2]
-  TABLES = %w[
+  HOST_ONLY_TABLES = %w[
     better_together_categories
-    better_together_categorizations
-    better_together_joatu_requests
-    better_together_joatu_offers
-    better_together_joatu_agreements
   ].freeze
+
+  CATEGORIZABLE_TYPES = {
+    'BetterTogether::Post' => 'better_together_posts',
+    'BetterTogether::Page' => 'better_together_pages',
+    'BetterTogether::Event' => 'better_together_events'
+  }.freeze
 
   def up
     host_platform_id = execute(
@@ -18,22 +24,101 @@ class BackfillPlatformIdForCategoriesAndJoatu < ActiveRecord::Migration[7.2]
 
     return unless host_platform_id
 
-    TABLES.each do |table|
-      next unless table_exists?(table)
+    HOST_ONLY_TABLES.each { |table| backfill_host_only(table, host_platform_id) }
 
-      execute <<~SQL
-        UPDATE #{quote_table_name(table)}
-        SET    platform_id = #{quote(host_platform_id)}
-        WHERE  platform_id IS NULL
-      SQL
-    end
+    backfill_categorizations(host_platform_id)
+    backfill_from_creator('better_together_joatu_offers', host_platform_id)
+    backfill_from_creator('better_together_joatu_requests', host_platform_id)
+    backfill_joatu_agreements(host_platform_id)
   end
 
   def down
-    TABLES.each do |table|
+    (HOST_ONLY_TABLES + %w[
+      better_together_categorizations
+      better_together_joatu_offers
+      better_together_joatu_requests
+      better_together_joatu_agreements
+    ]).each do |table|
       next unless table_exists?(table)
 
       execute "UPDATE #{table} SET platform_id = NULL"
     end
+  end
+
+  private
+
+  def backfill_host_only(table, host_platform_id)
+    return unless table_exists?(table)
+
+    execute <<~SQL
+      UPDATE #{quote_table_name(table)}
+      SET    platform_id = #{quote(host_platform_id)}
+      WHERE  platform_id IS NULL
+    SQL
+  end
+
+  def backfill_categorizations(host_platform_id)
+    return unless table_exists?('better_together_categorizations')
+
+    CATEGORIZABLE_TYPES.each do |type, owner_table|
+      next unless table_exists?(owner_table)
+
+      execute <<~SQL
+        UPDATE better_together_categorizations cz
+        SET    platform_id = owner.platform_id
+        FROM   #{owner_table} owner
+        WHERE  cz.categorizable_type = #{quote(type)}
+          AND  cz.categorizable_id = owner.id
+          AND  cz.platform_id IS NULL
+          AND  owner.platform_id IS NOT NULL
+      SQL
+    end
+
+    execute <<~SQL
+      UPDATE better_together_categorizations
+      SET    platform_id = #{quote(host_platform_id)}
+      WHERE  platform_id IS NULL
+    SQL
+  end
+
+  def backfill_from_creator(table, host_platform_id)
+    return unless table_exists?(table)
+
+    execute <<~SQL
+      UPDATE #{quote_table_name(table)} rec
+      SET    platform_id = ppm.joinable_id
+      FROM   better_together_people p
+      JOIN   better_together_person_platform_memberships ppm
+        ON   p.id = ppm.member_id
+      WHERE  rec.creator_id = p.id
+        AND  rec.platform_id IS NULL
+        AND  ppm.joinable_id IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE #{quote_table_name(table)}
+      SET    platform_id = #{quote(host_platform_id)}
+      WHERE  platform_id IS NULL
+    SQL
+  end
+
+  def backfill_joatu_agreements(host_platform_id)
+    return unless table_exists?('better_together_joatu_agreements')
+
+    # Derive from the offer first (offers are already backfilled above by this point).
+    execute <<~SQL
+      UPDATE better_together_joatu_agreements ja
+      SET    platform_id = o.platform_id
+      FROM   better_together_joatu_offers o
+      WHERE  ja.offer_id = o.id
+        AND  ja.platform_id IS NULL
+        AND  o.platform_id IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE better_together_joatu_agreements
+      SET    platform_id = #{quote(host_platform_id)}
+      WHERE  platform_id IS NULL
+    SQL
   end
 end

--- a/db/migrate/20260605004003_backfill_platform_id_for_reports.rb
+++ b/db/migrate/20260605004003_backfill_platform_id_for_reports.rb
@@ -1,13 +1,37 @@
 # frozen_string_literal: true
 
-# Phase 4 — Backfill platform_id for reports to host platform.
+# Phase 4 — Backfill platform_id for reports.
+#
+# Derived from the reported record's own platform first, falling back to the
+# host platform only when the reportable type isn't one of the known content
+# types or its platform_id isn't yet populated.
 class BackfillPlatformIdForReports < ActiveRecord::Migration[7.2]
+  REPORTABLE_TYPES = {
+    'BetterTogether::Post' => 'better_together_posts',
+    'BetterTogether::Page' => 'better_together_pages',
+    'BetterTogether::Event' => 'better_together_events'
+  }.freeze
+
   def up
     host_platform_id = execute(
       "SELECT id FROM better_together_platforms WHERE host = TRUE LIMIT 1"
     ).first&.fetch('id')
 
     return unless host_platform_id
+
+    REPORTABLE_TYPES.each do |type, owner_table|
+      next unless table_exists?(owner_table)
+
+      execute <<~SQL
+        UPDATE better_together_reports r
+        SET    platform_id = owner.platform_id
+        FROM   #{owner_table} owner
+        WHERE  r.reportable_type = #{quote(type)}
+          AND  r.reportable_id = owner.id
+          AND  r.platform_id IS NULL
+          AND  owner.platform_id IS NOT NULL
+      SQL
+    end
 
     execute <<~SQL
       UPDATE better_together_reports

--- a/db/migrate/20260606002001_backfill_platform_id_phase5.rb
+++ b/db/migrate/20260606002001_backfill_platform_id_phase5.rb
@@ -1,29 +1,58 @@
 # frozen_string_literal: true
 
 # Phase 5 — Backfill platform_id for all newly scoped model families.
-# All existing records are assigned to the host platform (single-platform baseline).
+#
+# Tables with a real derivable owner are backfilled via join first, falling
+# back to the host platform only for records whose owner can't be resolved.
+# `better_together_activities` and `better_together_person_blocks` are
+# intentionally NOT blanket-defaulted here — Phase 9
+# (20260616002001_backfill_platform_id_for_critical_isolation.rb) derives
+# both via join later in the campaign; blanket-setting them here first would
+# leave nothing NULL for Phase 9's correct join-based logic to act on.
 # WebhookDeliveries inherit platform_id from their parent WebhookEndpoint.
-class BackfillPlatformIdPhase5 < ActiveRecord::Migration[7.2]
-  SIMPLE_TABLES = %w[
-    better_together_webhook_endpoints
-    better_together_uploads
+class BackfillPlatformIdPhase5 < ActiveRecord::Migration[7.2] # rubocop:disable Metrics/ClassLength
+  # No derivable owner column — correctly host-default.
+  HOST_ONLY_TABLES = %w[
     better_together_oauth_applications
-    better_together_activities
-    better_together_content_blocks
-    better_together_person_blocks
     better_together_wizards
-    better_together_checklists
-    better_together_calls_for_interest
     better_together_person_data_exports
     better_together_person_deletion_requests
   ].freeze
+
+  # table => owner FK column, joined through better_together_people.
+  CREATOR_OWNED_TABLES = {
+    'better_together_uploads' => 'creator_id',
+    'better_together_content_blocks' => 'creator_id',
+    'better_together_checklists' => 'creator_id',
+    'better_together_webhook_endpoints' => 'person_id'
+  }.freeze
+
+  CALL_FOR_INTEREST_INTERESTABLE_TYPES = {
+    'BetterTogether::Community' => 'better_together_communities',
+    'BetterTogether::Calendar' => 'better_together_calendars',
+    'BetterTogether::Event' => 'better_together_events',
+    'BetterTogether::Page' => 'better_together_pages'
+  }.freeze
 
   def up
     host_platform_id = fetch_host_platform_id
     return unless host_platform_id
 
-    backfill_simple_tables(host_platform_id)
+    backfill_host_only_tables(host_platform_id)
+    CREATOR_OWNED_TABLES.each { |table, fk| backfill_from_creator(table, fk, host_platform_id) }
+    backfill_calls_for_interest(host_platform_id)
     backfill_webhook_deliveries(host_platform_id)
+  end
+
+  def down
+    (HOST_ONLY_TABLES + CREATOR_OWNED_TABLES.keys + %w[
+      better_together_calls_for_interest
+      better_together_webhook_deliveries
+    ]).each do |table|
+      next unless table_exists?(table) && column_exists?(table, :platform_id)
+
+      execute "UPDATE #{table} SET platform_id = NULL"
+    end
   end
 
   private
@@ -34,8 +63,8 @@ class BackfillPlatformIdPhase5 < ActiveRecord::Migration[7.2]
     ).first&.fetch('id')
   end
 
-  def backfill_simple_tables(host_platform_id)
-    SIMPLE_TABLES.each do |table|
+  def backfill_host_only_tables(host_platform_id)
+    HOST_ONLY_TABLES.each do |table|
       next unless table_exists?(table) && column_exists?(table, :platform_id)
 
       execute <<~SQL
@@ -44,6 +73,48 @@ class BackfillPlatformIdPhase5 < ActiveRecord::Migration[7.2]
         WHERE  platform_id IS NULL
       SQL
     end
+  end
+
+  def backfill_from_creator(table, owner_column, host_platform_id)
+    return unless table_exists?(table) && column_exists?(table, :platform_id)
+
+    execute <<~SQL
+      UPDATE #{table} rec
+      SET    platform_id = ppm.joinable_id
+      FROM   better_together_people p
+      JOIN   better_together_person_platform_memberships ppm
+        ON   p.id = ppm.member_id
+      WHERE  rec.#{owner_column} = p.id
+        AND  rec.platform_id IS NULL
+        AND  ppm.joinable_id IS NOT NULL
+    SQL
+
+    execute <<~SQL
+      UPDATE #{table}
+      SET    platform_id = #{quote(host_platform_id)}
+      WHERE  platform_id IS NULL
+    SQL
+  end
+
+  def backfill_calls_for_interest(host_platform_id)
+    table = 'better_together_calls_for_interest'
+    return unless table_exists?(table) && column_exists?(table, :platform_id)
+
+    CALL_FOR_INTEREST_INTERESTABLE_TYPES.each do |type, owner_table|
+      next unless table_exists?(owner_table)
+
+      execute <<~SQL
+        UPDATE #{table} cfi
+        SET    platform_id = owner.platform_id
+        FROM   #{owner_table} owner
+        WHERE  cfi.interestable_type = #{quote(type)}
+          AND  cfi.interestable_id = owner.id
+          AND  cfi.platform_id IS NULL
+          AND  owner.platform_id IS NOT NULL
+      SQL
+    end
+
+    backfill_from_creator(table, 'creator_id', host_platform_id)
   end
 
   def backfill_webhook_deliveries(host_platform_id)
@@ -70,13 +141,5 @@ class BackfillPlatformIdPhase5 < ActiveRecord::Migration[7.2]
       SET    platform_id = #{quote(host_platform_id)}
       WHERE  platform_id IS NULL
     SQL
-  end
-
-  def down
-    (SIMPLE_TABLES + ['better_together_webhook_deliveries']).each do |table|
-      next unless table_exists?(table) && column_exists?(table, :platform_id)
-
-      execute "UPDATE #{table} SET platform_id = NULL"
-    end
   end
 end

--- a/spec/lib/better_together/categories_and_joatu_platform_id_backfill_migration_spec.rb
+++ b/spec/lib/better_together/categories_and_joatu_platform_id_backfill_migration_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require BetterTogether::Engine.root.join('db/migrate/20260605003003_backfill_platform_id_for_categories_and_joatu')
+
+RSpec.describe 'Categories/joatu platform_id backfill migration' do # rubocop:disable RSpec/DescribeClass
+  let(:migration) { BackfillPlatformIdForCategoriesAndJoatu.new }
+
+  it "derives a categorization's platform_id from its categorizable Page" do
+    federated_platform = create(:better_together_platform, :public, host: false)
+    federated_page = create(:better_together_page, platform: federated_platform)
+
+    categorization = create(:categorization, categorizable: federated_page)
+    categorization.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(categorization.reload.platform_id).to eq(federated_platform.id)
+  end
+
+  it "derives a joatu offer's platform_id from its creator's platform membership" do
+    federated_platform = create(:better_together_platform, host: false)
+    federated_person = create(:better_together_person)
+    create(:better_together_person_platform_membership, joinable: federated_platform, member: federated_person)
+
+    offer = create(:better_together_joatu_offer, creator: federated_person)
+    offer.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(offer.reload.platform_id).to eq(federated_platform.id)
+  end
+end

--- a/spec/lib/better_together/content_platform_id_backfill_migration_spec.rb
+++ b/spec/lib/better_together/content_platform_id_backfill_migration_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require BetterTogether::Engine.root.join('db/migrate/20260321000003_backfill_content_platform_id')
+require BetterTogether::Engine.root.join('db/migrate/20260321000004_enforce_platform_id_not_null_on_content_tables')
+
+RSpec.describe 'Content platform_id backfill migration' do # rubocop:disable RSpec/DescribeClass
+  let(:migration) { BackfillContentPlatformId.new }
+  let(:not_null_migration) { EnforcePlatformIdNotNullOnContentTables.new }
+
+  before { not_null_migration.down } # relax NOT NULL so platform_id can be nulled for the test
+  after { not_null_migration.up } # restore the constraint
+
+  it "derives platform_id from the record's creator platform membership before defaulting to host" do
+    federated_platform = create(:better_together_platform, host: false)
+    federated_person = create(:better_together_person)
+    create(:better_together_person_platform_membership, joinable: federated_platform, member: federated_person)
+
+    federated_page = create(:better_together_page, creator: federated_person)
+    federated_page.update_column(:platform_id, nil)
+
+    orphan_page = create(:better_together_page)
+    orphan_page.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(federated_page.reload.platform_id).to eq(federated_platform.id)
+    expect(orphan_page.reload.platform_id).to eq(BetterTogether::Platform.find_by(host: true).id)
+  end
+end

--- a/spec/lib/better_together/conversations_messages_agreements_platform_id_backfill_migration_spec.rb
+++ b/spec/lib/better_together/conversations_messages_agreements_platform_id_backfill_migration_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require BetterTogether::Engine.root.join(
+  'db/migrate/20260605002004_backfill_platform_id_for_conversations_messages_agreements'
+)
+
+RSpec.describe 'Conversations/messages/agreements platform_id backfill migration' do # rubocop:disable RSpec/DescribeClass
+  let(:migration) { BackfillPlatformIdForConversationsMessagesAgreements.new }
+
+  it "derives a conversation's platform_id from its creator's platform membership" do
+    federated_platform = create(:better_together_platform, host: false)
+    federated_person = create(:better_together_person)
+    create(:better_together_person_platform_membership, joinable: federated_platform, member: federated_person)
+
+    conversation = create(:better_together_conversation, creator: federated_person)
+    conversation.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(conversation.reload.platform_id).to eq(federated_platform.id)
+  end
+
+  it 'falls back to the host platform when the creator has no platform membership' do
+    conversation = create(:better_together_conversation)
+    conversation.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(conversation.reload.platform_id).to eq(BetterTogether::Platform.find_by(host: true).id)
+  end
+end

--- a/spec/lib/better_together/platform_id_phase5_backfill_migration_spec.rb
+++ b/spec/lib/better_together/platform_id_phase5_backfill_migration_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require BetterTogether::Engine.root.join('db/migrate/20260606002001_backfill_platform_id_phase5')
+
+RSpec.describe 'Phase 5 platform_id backfill migration' do # rubocop:disable RSpec/DescribeClass
+  let(:migration) { BackfillPlatformIdPhase5.new }
+
+  it "derives a content block's platform_id from its creator's platform membership" do
+    federated_platform = create(:better_together_platform, host: false)
+    federated_person = create(:better_together_person)
+    create(:better_together_person_platform_membership, joinable: federated_platform, member: federated_person)
+
+    block = create(:content_alert_block)
+    block.update_columns(creator_id: federated_person.id, platform_id: nil)
+
+    migration.up
+
+    expect(block.reload.platform_id).to eq(federated_platform.id)
+  end
+
+  it "derives a call_for_interest's platform_id from its interestable Page before falling back to its creator" do
+    federated_platform = create(:better_together_platform, :public, host: false)
+    federated_page = create(:better_together_page, platform: federated_platform)
+
+    call = create(:better_together_call_for_interest, interestable: federated_page)
+    call.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(call.reload.platform_id).to eq(federated_platform.id)
+  end
+end

--- a/spec/lib/better_together/reports_platform_id_backfill_migration_spec.rb
+++ b/spec/lib/better_together/reports_platform_id_backfill_migration_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require BetterTogether::Engine.root.join('db/migrate/20260605004003_backfill_platform_id_for_reports')
+
+RSpec.describe 'Reports platform_id backfill migration' do # rubocop:disable RSpec/DescribeClass
+  let(:migration) { BackfillPlatformIdForReports.new }
+
+  it "derives a report's platform_id from its reportable Page rather than defaulting to host" do
+    federated_platform = create(:better_together_platform, :public, host: false)
+    federated_page = create(:better_together_page, platform: federated_platform)
+
+    report = create(:report, reportable: federated_page)
+    report.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(report.reload.platform_id).to eq(federated_platform.id)
+  end
+
+  it 'falls back to the host platform for reportable types with no platform_id (e.g. Person)' do
+    report = create(:report) # default factory reportable is a Person, which has no platform_id
+    report.update_column(:platform_id, nil)
+
+    migration.up
+
+    expect(report.reload.platform_id).to eq(BetterTogether::Platform.find_by(host: true).id)
+  end
+end

--- a/spec/models/better_together/page_spec.rb
+++ b/spec/models/better_together/page_spec.rb
@@ -242,6 +242,40 @@ module BetterTogether # :nodoc:
         end
       end
 
+      describe 'community assignment (CommunityAssignable)' do
+        let(:local_platform) { Platform.find_by(host: true) || create(:better_together_platform, host: true) }
+        let(:remote_platform) { create(:better_together_platform, :external) }
+
+        it "assigns the platform's own community when community is nil, not the host community" do
+          federated_page = build(:better_together_page, platform: remote_platform, community: nil)
+
+          federated_page.valid?
+
+          expect(federated_page.community).to eq(remote_platform.community)
+          expect(federated_page.community).not_to eq(local_platform.community)
+        end
+
+        it 'falls back to the host community when the platform has no community of its own' do
+          allow(remote_platform).to receive(:community).and_return(nil)
+          page_without_platform_community = build(:better_together_page, platform: remote_platform, community: nil)
+
+          page_without_platform_community.valid?
+
+          expect(page_without_platform_community.community).to eq(BetterTogether::Community.host_community)
+        end
+
+        it 'leaves an explicitly-assigned community untouched' do
+          explicit_community = create(:better_together_community)
+          page_with_explicit_community = build(
+            :better_together_page, platform: remote_platform, community: explicit_community
+          )
+
+          page_with_explicit_community.valid?
+
+          expect(page_with_explicit_community.community).to eq(explicit_community)
+        end
+      end
+
       describe 'evidence selector options' do
         it 'includes media-specific selectors from page content blocks' do
           page = create(:better_together_page)


### PR DESCRIPTION
## Summary

Two related fixes, both stemming from the same production incident on `communityengine.app`:

**1. `Page#assign_host_community` model bug.** `Page` had a hand-rolled callback that defaulted straight to the host community whenever `community_id` was nil, without ever checking `platform&.community` first — unlike the shared `CommunityAssignable` concern `Post` already uses. Replaced with `include CommunityAssignable`.

**2. Five backfill migrations in the multi-tenant/federation campaign** blanket-assigned `platform_id` to the host platform on every NULL row, with no join back to the record's actual owner (creator, reportable, categorizable, etc.):
- `20260321000003_backfill_content_platform_id.rb` (posts/pages/events)
- `20260605002004_..._conversations_messages_agreements.rb` (conversations/agreements)
- `20260605003003_..._categories_and_joatu.rb` (categorizations/joatu offers/requests/agreements)
- `20260605004003_backfill_platform_id_for_reports.rb` (reports)
- `20260606002001_backfill_platform_id_phase5.rb` (uploads, content_blocks, checklists, webhook_endpoints, calls_for_interest)

All five now derive `platform_id` from the record's real owner first, falling back to host only when no owner can be resolved. `activities` and `person_blocks` are no longer touched by Phase 5 at all — Phase 9 (`20260616002001`) already derives both correctly via join, and Phase 5 running first was pre-empting that correct logic.

**Production incident context:** this combination (the model bug plus the blanket-migration pattern) caused real data corruption on `communityengine.app` — 15 pages (including the homepage and about page) and 15 more rows across authorships/events/event_attendances/calendar_entries/event_hosts had their `platform_id` silently reassigned away from their true platform. That production data has already been corrected directly on the live database; this PR fixes the underlying bugs so the same corruption can't recur — including on the next federation sync, and when other CE-family apps (NNL, NLVenues, NLO) adopt this release and run these migrations for the first time against their own data.

## Changes

- `app/models/better_together/page.rb` + `spec/models/better_together/page_spec.rb` (3 new tests)
- 5 migration files rewritten with join-based derivation
- 5 new migration specs under `spec/lib/better_together/`, following the existing `event_host_association_migration_spec.rb` pattern (instantiate the migration class directly, seed pre-migration state, assert `up` derives correctly)

## Test plan

- [x] `bin/dc-run bundle exec prspec spec/models/better_together/page_spec.rb` + all 5 new migration specs — 66 examples, 0 failures
- [x] `bin/dc-run bundle exec rubocop` (targeted + full repo pre-push) — clean
- [x] `bin/dc-run bin/i18n` — clean
