### PR TITLE
fix(content-security): keep blob proxy src same-origin, not CDN-rewritten

### DIFF
--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -8,7 +8,13 @@
                    else
                      BetterTogether::MediaUrlBuilder.proxy_path_for(representation)
                    end %>
-    <%= image_tag image_src %>
+    <%# image_src is always a same-origin, root-relative path (the content-security
+        scan-gated proxy route, or MediaUrlBuilder's same-origin proxy path) — never
+        run it through image_tag, which unconditionally rewrites root-relative srcs
+        through config.action_controller.asset_host. Neither of these dynamic Rails
+        routes exists as an object in the CDN's S3 origin, so an asset-host-rewritten
+        src 404s/403s there instead of hitting the app. %>
+    <%= tag.img src: image_src %>
   <% end %>
 
   <figcaption class="attachment__caption">

--- a/spec/models/better_together/message_rich_text_attachment_rendering_spec.rb
+++ b/spec/models/better_together/message_rich_text_attachment_rendering_spec.rb
@@ -54,6 +54,32 @@ RSpec.describe BetterTogether::Message do
     expect(rendered).to have_css("img[src*='/content-security/active-storage/representations/proxy/']")
   end
 
+  it 'keeps the content-security proxy src same-origin even when an asset host CDN is configured' do
+    # Regression test: config.action_controller.asset_host (e.g. a CDN fronting the
+    # S3 bucket directly) must never be applied to this src. The content-security
+    # proxy route only exists in the Rails app (it checks the scan verdict before
+    # serving), not as an object in the CDN's S3 origin — an asset-host-rewritten src
+    # 403s there instead of reaching the app.
+    original_asset_host = ActionController::Base.asset_host
+    ActionController::Base.asset_host = 'https://cdn-assets.communityengine.app'
+
+    BetterTogether::ContentSecurity::Subject.find_by!(subject: message, attachment_name: "content:embed:#{blob.id}").update!(
+      lifecycle_state: 'approved_public',
+      aggregate_verdict: 'clean',
+      current_visibility_state: 'public',
+      current_ai_ingestion_state: 'eligible',
+      released_at: Time.current
+    )
+
+    rendered = Capybara.string(message.reload.content.to_s)
+    img_src = rendered.find('img')['src']
+
+    expect(img_src).to start_with('/content-security/active-storage/representations/proxy/')
+    expect(img_src).not_to start_with('https://cdn-assets.communityengine.app')
+  ensure
+    ActionController::Base.asset_host = original_asset_host
+  end
+
   it 'renders blocked embedded attachments with a restricted placeholder' do
     BetterTogether::ContentSecurity::Subject.find_by!(subject: message, attachment_name: "content:embed:#{blob.id}").update!(
       lifecycle_state: 'blocked_rejected',


### PR DESCRIPTION
## Summary

Rich-text/embedded image attachments enrolled in the content-security malware
scan gate were rendering as broken images in production (`communityengine.app`)
once an `ASSET_HOST` CDN was configured. Root cause: `app/views/active_storage/blobs/_blob.html.erb`
built the `<img>` src via `image_tag`, which unconditionally rewrites any
root-relative src through `config.action_controller.asset_host`. The
content-security scan-gated proxy route (`/content-security/active-storage/representations/proxy/...`)
only exists as a Rails controller action — it was never uploaded to the CDN's
S3 origin — so once `image_tag` rewrote the src to the CDN host, the CDN
(CloudFront in front of S3 directly) forwarded the request straight to S3 and
403'd instead of ever reaching the Rails app.

## Fix

Switch from `image_tag image_src` to `tag.img src: image_src` — this renders
the src attribute verbatim with no asset-host rewriting, keeping the request
same-origin regardless of `ASSET_HOST`, matching `MediaUrlBuilder`'s own
documented "same-origin proxy URL generation" intent for the non-gated branch.

## Test plan

- [x] Added a regression test in `spec/models/better_together/message_rich_text_attachment_rendering_spec.rb`
      that configures `ActionController::Base.asset_host` to a CDN value and
      asserts the rendered `<img>` src stays root-relative
      (`/content-security/active-storage/representations/proxy/...`), never
      picking up the CDN host.
- [x] Confirmed the new test fails against the pre-fix code, reproducing the
      exact production symptom (`src` rewritten to
      `https://cdn-assets.communityengine.app/content-security/...`).
- [x] Full spec file green (4 examples, 0 failures) with the fix applied.
- [x] Adjacent specs (`rich_text_attachment_filter_spec`, `image_helper_spec`,
      `media_url_builder_spec`) unaffected — 21 examples, 0 failures.
- [x] `rubocop` clean (pre-commit + pre-push, full repo).